### PR TITLE
Build cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,104 +6,138 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: cargo-{{ checksum "Cargo.lock" }}
+          key: rust-cargo-v1-{{ checksum "Cargo.lock" }}
       - run:
-          name: Install Nightly Toolchain
+          name: Install Rust Toolchain
           command: |
-            rustup toolchain install nightly
+            rustup toolchain install "$(cat rust-toolchain)"
+            rustup component add rustfmt
+            rustup component add clippy
             rustc --version --verbose
             cargo --version --verbose
+            rustfmt --version
+            cargo clippy -- --version
       - run:
           # https://github.com/mruby/mruby/blob/master/doc/guides/compile.md#prerequisites
           name: Install mruby Build Dependencies
           command: |
             sudo apt-get install -y binutils bison ruby-full
-            ruby --version
-            rustup component add rustfmt
             rustfmt --version
+            ruby --version
       - run:
           # needed for cc crate in build.rs
           name: Install mruby-sys Build Dependencies
           command: |
             sudo apt-get install -y clang
-            ruby --version
+            clang --version
       - run:
           name: Build Workspace
           command: |
             cargo build
-            cargo build --release
       - save_cache:
-          key: cargo-{{ checksum "Cargo.lock" }}
+          key: rust-cargo-v1-{{ checksum "Cargo.lock" }}
           paths:
             - "~/.cargo"
             - "./target"
       - run:
-          name: Test
+          name: Test Workspace
           command: cargo test --all-features
       - run:
-          name: Check Formatting
+          name: Format Rust Sources
           command: |
-            rustup component add rustfmt
             rustfmt --version
             cargo fmt -- --check --color=auto
       - run:
-          name: Lint With Clippy
+          name: Lint Rust With Clippy
           command: |
-            rustup component add clippy
+            cargo clippy -- --version
             cargo clippy --all-targets --all-features
   c:
-    docker:
-      - image: silkeh/clang:latest
-    steps:
-      - checkout
-      - run:
-          name: clang-format
-          command: |
-            SOURCES="$(find . -type f \( -name '*.h' -or -name '*.c' \) -and -not -path '*vendor*' -and -not -path '*target*')"
-            for SOURCE in $SOURCES
-            do
-              clang-format -output-replacements-xml "$SOURCE" > /tmp/clang-format-replacements
-              if grep -q "offset" /tmp/clang-format-replacements; then
-                echo "Source file '$SOURCE' contains formatting issues."
-                echo "Please use clang-format tool to resolve found issues."
-                exit 1
-              fi
-            done
-  ruby:
-    docker:
-      - image: circleci/ruby:2.6
-    steps:
-      - checkout
-      - run:
-          name: rubocop
-          command: |
-            cd foolsgold/ruby
-            bundle install
-            bundle exec rubocop
-  docs:
     docker:
       - image: circleci/node:lts
     steps:
       - checkout
       - restore_cache:
-          key: yarn-deps-{{ checksum "yarn.lock" }}
+          key: c-yarn-v1-{{ checksum "yarn.lock" }}
       - run:
           name: Yarn Install
           command: yarn install
       - save_cache:
-          key: yarn-deps-{{ checksum "yarn.lock" }}
+          key: c-yarn-v1-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
       - run:
-          name: Format Markdown
+          name: Format C Sources
           command: |
-            yarn run fmt
-            git diff -q
+            yarn run clang-format --version
+
+            _check_clang_format() {
+              if yarn run clang-format -output-replacements-xml "$1" | grep -q "offset"; then
+                echo "KO: $1"
+                echo "    Please run 'yarn fmt-c' to resolve C formatting issues"
+                return 1
+              else
+                echo "OK: $1"
+              fi
+            }
+            export -f _check_clang_format
+
+            find . \
+              -type f \( -name '*.h' -or -name '*.c' \) \
+              -and -not -path '*vendor*' -and -not -path '*target*' \
+              -print0 | xargs -0 -n1 bash -c '_check_clang_format "$@"' _
+  ruby:
+    docker:
+      - image: circleci/ruby:2.6
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - ruby-bundler-v1-{{ checksum "Gemfile.lock" }}
+      - run:
+          name: Bundle Install
+          working_directory: ./foolsgold/ruby
+          command: bundle install --path ~/vendor/bundle
+      - save_cache:
+          key: ruby-bundler-v1-{{ checksum "Gemfile.lock" }}
+          paths:
+            - ~/vendor/bundle
+      - run:
+          name: Lint Ruby With RuboCop
+          working_directory: ./foolsgold/ruby
+          command: |
+            bundle exec rubocop --version
+            bundle exec rubocop
+  text:
+    docker:
+      - image: circleci/node:lts
+    steps:
+      - checkout
+      - restore_cache:
+          key: text-yarn-v1-{{ checksum "yarn.lock" }}
+      - run:
+          name: Yarn Install
+          command: yarn install
+      - save_cache:
+          key: text-yarn-v1-{{ checksum "yarn.lock" }}
+          paths:
+            - ~/.cache/yarn
+      - run:
+          name: Format Text Sources
+          command: |
+            yarn run prettier --version
+            yarn run fmt-text
+            if ! git diff -q; then
+              echo "KO: Text files not formatted"
+              git status --porcelain
+              echo "    Please run 'yarn fmt-text' to resolve text formatting issues"
+              exit 1
+            fi
 workflows:
   version: 2
-  build_test_lint:
+  build:
     jobs:
       - rust
       - c
       - ruby
-      - docs
+      - text

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,13 +93,13 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - ruby-bundler-v1-{{ checksum "Gemfile.lock" }}
+            - ruby-bundler-v1-foolsgold-{{ checksum "./foolsgold/ruby/Gemfile.lock" }}
       - run:
           name: Bundle Install
           working_directory: ./foolsgold/ruby
           command: bundle install --path ~/vendor/bundle
       - save_cache:
-          key: ruby-bundler-v1-{{ checksum "Gemfile.lock" }}
+          key: ruby-bundler-v1-foolsgold-{{ checksum "./foolsgold/ruby/Gemfile.lock" }}
           paths:
             - ~/vendor/bundle
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,10 +126,8 @@ jobs:
           name: Format Text Sources
           command: |
             yarn run prettier --version
-            yarn run fmt-text
-            if ! git diff -q; then
+            if ! yarn run prettier --check --prose-wrap always './*.{css,html,js,json,md}' '{mruby*,foolsgold}/**/*.{css,html,js,json,md}'; then
               echo "KO: Text files not formatted"
-              git status --porcelain
               echo "    Please run 'yarn fmt-text' to resolve text formatting issues"
               exit 1
             fi

--- a/mruby-vfs/Cargo.toml
+++ b/mruby-vfs/Cargo.toml
@@ -5,7 +5,7 @@ description = "Fake implementation of a unix file system for an mruby sandbox"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 license = "MIT"
-repository = "https://github.com/lopopolo/foolsgold"
+repository = "https://github.com/lopopolo/ferrocarril"
 readme = "README.md"
 categories = [
   "development-tools::testing",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "foolsgold",
+  "name": "ferrocarril",
   "version": "0.1.0",
   "description": "Experiments with mruby bindings for Rust",
   "keywords": [
@@ -8,8 +8,8 @@
     "ruby",
     "rust"
   ],
-  "homepage": "https://github.com/lopopolo/foolsgold",
-  "bugs": "https://github.com/lopopolo/foolsgold/issues",
+  "homepage": "https://github.com/lopopolo/ferrocarril",
+  "bugs": "https://github.com/lopopolo/ferrocarril/issues",
   "license": "MIT",
   "author": {
     "name": "Ryan Lopopolo",
@@ -25,7 +25,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/lopopolo/foolsgold.git"
+    "url": "https://github.com/lopopolo/ferrocarril.git"
   },
   "devDependencies": {
     "@babel/core": "^7.2.2",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@babel/core": "^7.2.2",
     "babel-eslint": "^10.0.1",
     "babel-preset-env": "^1.6.1",
+    "clang-format": "^1.2.4",
     "eslint": "^5.11.1",
     "eslint-config-airbnb": "^17.1.0",
     "eslint-config-prettier": "^3.3.0",
@@ -78,9 +79,9 @@
     }
   },
   "scripts": {
-    "clang-fmt": "find . \\( -name '*.h' -or -name '*.c' \\) -and -not -path '*vendor*' -and -not -path '*target*' | xargs clang-format -i",
     "eslint-check": "eslint --print-config . | eslint-config-prettier-check",
-    "fmt": "prettier --write --prose-wrap always './*.{css,html,js,json,md}' '{mruby*,foolsgold}/**/*.{css,html,js,json,md}'",
+    "fmt-c": "find . \\( -name '*.h' -or -name '*.c' \\) -and -not -path '*vendor*' -and -not -path '*target*' | xargs clang-format -i",
+    "fmt-text": "prettier --write --prose-wrap always './*.{css,html,js,json,md}' '{mruby*,foolsgold}/**/*.{css,html,js,json,md}'",
     "lint": "cargo clean -p foolsgold; for crate in mruby*; do cargo clean -p $crate; done && cargo clippy --all-targets && cd foolsgold/ruby && bundle exec rubocop"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -236,6 +236,11 @@ astral-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
   integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
 
+async@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
+  integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
+
 axobject-query@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.0.2.tgz#ea187abe5b9002b377f925d8bf7d1c561adf38f9"
@@ -788,6 +793,15 @@ circular-json@^0.3.1:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
   integrity sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==
+
+clang-format@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/clang-format/-/clang-format-1.2.4.tgz#4bb4b0a98180428deb093cf20982e9fc1af20b6c"
+  integrity sha512-sw+nrGUp3hvmANd1qF8vZPuezSYQAiXgGBiEtkXTtJnnu6b00fCqkkDIsnRKrNgg4nv6NYZE92ejvOMIXZoejw==
+  dependencies:
+    async "^1.5.2"
+    glob "^7.0.0"
+    resolve "^1.1.6"
 
 cli-cursor@^2.1.0:
   version "2.1.0"
@@ -1370,6 +1384,18 @@ get-stdin@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
   integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
+
+glob@^7.0.0:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
+  integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
 
 glob@^7.1.2, glob@^7.1.3:
   version "7.1.3"
@@ -2103,6 +2129,13 @@ resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
+
+resolve@^1.1.6:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.0.tgz#4014870ba296176b86343d50b60f3b50609ce232"
+  integrity sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==
+  dependencies:
+    path-parse "^1.0.6"
 
 resolve@^1.10.0, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.9.0:
   version "1.10.0"


### PR DESCRIPTION
Massively clean up the CircleCI build

## CircleCI config.yml

- Add a version key to all dependency caches
- Rename cache keys '${lang}-${package-manager}-v1-${checksum}'
- Install all Rust toolchain components and up front
- Install the Rust toolchain specified in the rust-toolchain file
- Print clang version after install instead of Ruby version
- Drop Rust release build -- It consumes lots of build time without much value add
- Consistently name Test, Format, and Lint build steps
- Add clang-format node dependency
- Change the 'c' job to use a node base image
- Save yarn dependency cache in 'c' build
- Save bundler dependency cache in 'ruby' build
- use 'working_directory' instead of cd during bundle commands in 'ruby' build
- Rename 'doc' job to 'text' since it covers all text source files, not just markdown
- Make 'c' and 'text' formatting errors easier to parse and directly actionable with suggested yarn commands to remediate
- use prettier --check

## Formatting

- rename yarn run clang-fmt to yarn run fmt-c
- rename yarn run fmt to yarn run fmt-text

## Misc

This PR also gloms on a fix for missing rebrands to _ferrocarril_ in Cargo.toml and package.json.