### PR TITLE
Implement an irb REPL with the mruby crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2rs"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +115,15 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "blake2-rfc"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,6 +179,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "cookie"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,6 +224,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_users 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,6 +251,18 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -363,6 +416,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "mruby-bin"
+version = "0.1.0"
+dependencies = [
+ "mruby 0.1.0",
+ "rustyline 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "mruby-rack"
 version = "0.1.0"
 dependencies = [
@@ -384,6 +445,23 @@ version = "0.5.0-alpha"
 dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "nix"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nodrop"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "nom"
@@ -602,6 +680,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ref_thread_local"
 version = "0.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,6 +800,22 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "rustyline"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8parse 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "safemem"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,6 +827,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "scoped_threadpool"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "scopeguard"
@@ -779,6 +889,17 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -874,6 +995,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,6 +1035,11 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "utf8parse"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "uuid"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,6 +1055,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "version_check"
 version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "void"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -994,6 +1130,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum aho-corasick 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e6f484ae0c99fec2e858eb6134949117399f222608d84cadb3f58c1f97c2364c"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392"
+"checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
 "checksum backtrace 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "f106c02a3604afcdc0df5d36cc47b44b55917dbaf3d808f71c163a0ddba64637"
@@ -1002,6 +1140,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bindgen 0.49.0 (registry+https://github.com/rust-lang/crates.io-index)" = "33e1b67a27bca31fd12a683b2a3618e275311117f48cfcc892e18403ff889026"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
+"checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
 "checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
 "checksum cc 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)" = "a0c56216487bb80eec9c4516337b2588a4f2a2290d72a1416d930e4dcdb0c90d"
 "checksum cexpr 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7fa24eb00d5ffab90eaeaf1092ac85c04c64aaf358ea6f84505b8116d24c6af"
@@ -1009,12 +1148,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum clang-sys 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4227269cec09f5f83ff160be12a1e9b0262dd1aa305302d5ba296c2ebd291055"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
 "checksum cookie 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "99be24cfcf40d56ed37fd11c2123be833959bbc5bddecb46e1c2e442e15fa3e0"
 "checksum devise 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "74e04ba2d03c5fa0d954c061fc8c9c288badadffc272ebb87679a89846de3ed3"
 "checksum devise_codegen 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "066ceb7928ca93a9bedc6d0e612a8a0424048b0ab1f75971b203d01420c055d7"
 "checksum devise_core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cf41c59b22b5e3ec0ea55c7847e5f358d340f3a8d6d53a5cf4f1564967f96487"
+"checksum dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
 "checksum env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b61fa891024a945da30a9581546e8cfaf5602c7b3f4c137a2805cf388f92075a"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
+"checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3bae29b6653b3412c2e71e9d486db9f9df5d701941d86683005efb9f2d28e3da"
@@ -1032,6 +1174,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
+"checksum nix 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46f0f3210768d796e8fa79ec70ee6af172dacbe7147f5e69be5240a47778302b"
+"checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 "checksum num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a23f0ed30a54abaa0c7e83b1d2d87ada7c3c23078d1d87815af3e3b6385fbba"
 "checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
@@ -1058,6 +1202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)" = "12229c14a0f65c4f1cb046a3b52047cdd9da1f4b30f8a39c5063c8bae515e252"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
+"checksum redox_users 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe5204c3a17e97dde73f285d49be585df59ed84b50a872baf416e73b62c3828"
 "checksum ref_thread_local 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d813022b2e00774a48eaf43caaa3c20b45f040ba8cbf398e2e8911a06668dbe6"
 "checksum regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8f0a0bcab2fd7d1d7c54fa9eae6f43eddeb9ce2e7352f8518a814a4f65d60c58"
 "checksum regex-syntax 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "dcfd8681eebe297b81d98498869d4aae052137651ad7b96822f09ceb690d0a96"
@@ -1068,8 +1213,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rust-embed 4.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "da54e434a7cca32d7973157fbbb12480c059e8b2d52b574bd45a6d9986dc8f16"
 "checksum rust-embed-impl 4.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd0e740ca1e1969c2d3310bd2bda2024ed44ce473e527a2585aeaec1de9d81c3"
 "checksum rustc-demangle 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "ccc78bfd5acd7bf3e89cffcf899e5cb1a52d6fafa8dec2739ad70c9577a57288"
+"checksum rustyline 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cf0a3bbb3167469f834da68a6636b93d4f6838f5438dd53ac02668abee8b997a"
 "checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
 "checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
+"checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)" = "a72e9b96fa45ce22a4bc23da3858dfccfd60acd28a25bcd328a98fdd6bea43fd"
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
@@ -1079,6 +1226,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)" = "a1393e4a97a19c01e900df2aec855a29f71cf02c402e2f443b8d2747c25c5dbe"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+"checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
 "checksum termion 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dde0593aeb8d47accea5392b39350015b5eccb12c0d98044d856983d89548dea"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
@@ -1091,15 +1239,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
+"checksum unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1967f4cdfc355b37fd76d2a954fb2ed3871034eb4f26d60537d88795cfc332a9"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "55cd1f4b4e96b46aeb8d4855db4a7a9bd96eeeb5c6a1ab54593328761642ce2f"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
+"checksum utf8parse 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8772a4ccbb4e89959023bc5b7cb8623a795caa7092d99f3aa9501b9484d4557d"
 "checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1"
 "checksum which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"
 "checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   "foolsgold",
   "mruby",
+  "mruby-bin",
   "mruby-rack",
   "mruby-sys",
   "mruby-vfs",

--- a/mruby-bin/Cargo.toml
+++ b/mruby-bin/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "mruby-bin"
+version = "0.1.0"
+authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
+edition = "2018"
+
+[dependencies]
+rustyline = "4.0.0"
+
+[dependencies.mruby]
+path = "../mruby"

--- a/mruby-bin/README.md
+++ b/mruby-bin/README.md
@@ -1,0 +1,44 @@
+# mruby-bin
+
+Crate mruby-bin binaries for interacting with the mruby interpreter in the
+[mruby crate](/mruby).
+
+## rirb
+
+`rirb` is a Rust implementation of `irb` and is an interactive mruby shell or a
+[REPL](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop).
+`rirb` includes all extensions that are implemented as part of the `mruby`
+crate.
+
+`rirb` is a readline enabled shell, although it does not persist history.
+
+To invoke `rirb`, run:
+
+```shell
+cargo run -p mruby-bin rirb
+```
+
+The REPL looks like this:
+
+```console
+[2.0 (v2.0.1)] > 12 +
+[2.0 (v2.0.1)] * 25
+=> 37
+[2.0 (v2.0.1)] > 12.times.map do |i|
+[2.0 (v2.0.1)] * i.to_s
+[2.0 (v2.0.1)] * end
+=> ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"]
+[2.0 (v2.0.1)] > def foo
+[2.0 (v2.0.1)] * 'foo'
+[2.0 (v2.0.1)] * end
+=> :foo
+[2.0 (v2.0.1)] > foo
+=> "foo"
+[2.0 (v2.0.1)] > undefined_method
+mruby exception: (rirb):1: undefined method 'undefined_method' (NoMethodError)
+(rirb):1
+[2.0 (v2.0.1)] > raise 'error'
+mruby exception: (rirb):1: error (RuntimeError)
+(rirb):1
+[2.0 (v2.0.1)] >
+```

--- a/mruby-bin/src/bin/rirb.rs
+++ b/mruby-bin/src/bin/rirb.rs
@@ -1,0 +1,154 @@
+#![deny(clippy::all, clippy::pedantic)]
+
+use mruby::eval::{EvalContext, MrbEval};
+use mruby::gc::GarbageCollection;
+use mruby::interpreter::{Interpreter, Mrb};
+use mruby::sys::{self, DescribeState};
+use mruby::MrbError;
+use rustyline::error::ReadlineError;
+use std::convert::TryFrom;
+use std::ffi::CStr;
+use std::process;
+
+const REPL_FILENAME: &str = "(rirb)";
+
+struct Parser(*mut sys::mrb_parser_state);
+
+impl Parser {
+    fn new(interp: &Mrb) -> Option<Self> {
+        let mrb = interp.borrow().mrb;
+        let parser = unsafe { sys::mrb_parser_new(mrb) };
+        if parser.is_null() {
+            None
+        } else {
+            Some(Self(parser))
+        }
+    }
+}
+
+impl Drop for Parser {
+    fn drop(&mut self) {
+        unsafe {
+            sys::mrb_parser_free(self.0);
+        }
+    }
+}
+
+// Parse the current code buffer to determine if any blocks are open
+fn is_code_block_open(interp: &Mrb, parser: &Parser, code: &str) -> Result<bool, MrbError> {
+    let ctx = interp.borrow().ctx;
+    unsafe {
+        let bytes = code.as_bytes();
+        let len =
+            isize::try_from(bytes.len()).map_err(|_| MrbError::Exec("code too long".to_owned()))?;
+        let ptr = bytes.as_ptr() as *const i8;
+        (*parser.0).s = ptr;
+        (*parser.0).send = ptr.offset(len);
+        (*parser.0).lineno = i32::from((*ctx).lineno);
+        sys::mrb_parser_parse(parser.0, ctx);
+
+        // open heredoc
+        if !(*parser.0).parsing_heredoc.is_null() {
+            return Ok(true);
+        }
+        // unterminated string
+        if !(*parser.0).lex_strterm.is_null() {
+            return Ok(true);
+        }
+        if (*parser.0).nerr > 0 {
+            let errmsg = (*parser.0).error_buffer[0].message;
+            if errmsg.is_null() {
+                return Ok(true);
+            }
+            let cstring = CStr::from_ptr(errmsg);
+            let message = cstring
+                .to_str()
+                .map(ToOwned::to_owned)
+                .map_err(|_| MrbError::Exec("parser error with unparseable message".to_owned()))?;
+            #[allow(clippy::match_same_arms)]
+            return match message.as_str() {
+                "syntax error, unexpected $end" => Ok(true),
+                "syntax error, unexpected keyword_end" => Ok(true),
+                "syntax error, unexpected tREGEXP_BEG" => Ok(false),
+                _ => Ok(true),
+            };
+        }
+        #[allow(clippy::match_same_arms)]
+        let open = match (*parser.0).lstate {
+            // beginning of a statement, that means previous line ended
+            sys::mrb_lex_state_enum::EXPR_BEG => false,
+            // a message dot was the last token, there has to come more
+            sys::mrb_lex_state_enum::EXPR_DOT => true,
+            // class keyword is not enough! we need also a name of the class
+            sys::mrb_lex_state_enum::EXPR_CLASS => true,
+            // a method name is necessary
+            sys::mrb_lex_state_enum::EXPR_FNAME => true,
+            // if, elsif, etc. without condition
+            sys::mrb_lex_state_enum::EXPR_VALUE => true,
+            // an argument is the last token
+            sys::mrb_lex_state_enum::EXPR_ARG => false,
+            // a block/proc/lambda argument is the last token
+            sys::mrb_lex_state_enum::EXPR_CMDARG => false,
+            // an expression was ended
+            sys::mrb_lex_state_enum::EXPR_END => false,
+            // closing parenthesis
+            sys::mrb_lex_state_enum::EXPR_ENDARG => false,
+            // definition end
+            sys::mrb_lex_state_enum::EXPR_ENDFN => false,
+            // jump keyword like break, return, ...
+            sys::mrb_lex_state_enum::EXPR_MID => false,
+            // this token is unreachable and is used to do integer math on the
+            // values of `mrb_lex_state_enum`.
+            sys::mrb_lex_state_enum::EXPR_MAX_STATE => false,
+        };
+        Ok(open)
+    }
+}
+
+fn main() -> Result<(), MrbError> {
+    let interp = Interpreter::create()?;
+    let parser = Parser::new(&interp).ok_or(MrbError::New)?;
+    interp.push_context(EvalContext::new(REPL_FILENAME));
+
+    let mut rl = rustyline::Editor::<()>::new();
+    // If a code block is open, accumulate code from multiple readlines in this
+    // mutable `String` buffer.
+    let mut buf = String::new();
+    let mut code_block_open = false;
+    loop {
+        // Allow shell users to identify that they have an open code block.
+        let prompt = if code_block_open {
+            format!("[{}] * ", interp.borrow().mrb.version())
+        } else {
+            format!("[{}] > ", interp.borrow().mrb.version())
+        };
+
+        let readline = rl.readline(&prompt);
+        let code = match readline {
+            Ok(line) => line,
+            // Gracefully exit on CTRL-D EOF
+            Err(ReadlineError::Eof) => break,
+            Err(_) => process::exit(1),
+        };
+        buf.push_str(&code);
+        if is_code_block_open(&interp, &parser, buf.as_str())? {
+            // Add a newline to the code buffer to mirror the multiple lines
+            // that the shell user is typing into readline.
+            buf.push('\n');
+            code_block_open = true;
+        } else {
+            match interp.eval(buf.as_str()) {
+                Ok(value) => println!("=> {}", value.inspect()),
+                Err(err) => eprintln!("{}", err),
+            };
+            for line in buf.lines() {
+                rl.add_history_entry(line);
+            }
+            // We have successfully evaled some Ruby code. Reset REPL state.
+            interp.incremental_gc();
+            buf.clear();
+            code_block_open = false;
+        }
+    }
+    Ok(())
+}

--- a/mruby-sys/build.rs
+++ b/mruby-sys/build.rs
@@ -112,6 +112,7 @@ fn main() {
         // As of bindgen 0.49.0, `mrb_heap_page` type fails a layout test.
         .layout_tests(false)
         .rustified_enum("mrb_vtype")
+        .rustified_enum("mrb_lex_state_enum")
         .rustfmt_bindings(true)
         .generate()
         .expect("Unable to generate mruby bindings");

--- a/mruby-sys/src/ffi.rs
+++ b/mruby-sys/src/ffi.rs
@@ -2516,19 +2516,22 @@ pub struct mrb_ast_node {
     pub lineno: u16,
     pub filename_index: u16,
 }
-pub const mrb_lex_state_enum_EXPR_BEG: mrb_lex_state_enum = 0;
-pub const mrb_lex_state_enum_EXPR_END: mrb_lex_state_enum = 1;
-pub const mrb_lex_state_enum_EXPR_ENDARG: mrb_lex_state_enum = 2;
-pub const mrb_lex_state_enum_EXPR_ENDFN: mrb_lex_state_enum = 3;
-pub const mrb_lex_state_enum_EXPR_ARG: mrb_lex_state_enum = 4;
-pub const mrb_lex_state_enum_EXPR_CMDARG: mrb_lex_state_enum = 5;
-pub const mrb_lex_state_enum_EXPR_MID: mrb_lex_state_enum = 6;
-pub const mrb_lex_state_enum_EXPR_FNAME: mrb_lex_state_enum = 7;
-pub const mrb_lex_state_enum_EXPR_DOT: mrb_lex_state_enum = 8;
-pub const mrb_lex_state_enum_EXPR_CLASS: mrb_lex_state_enum = 9;
-pub const mrb_lex_state_enum_EXPR_VALUE: mrb_lex_state_enum = 10;
-pub const mrb_lex_state_enum_EXPR_MAX_STATE: mrb_lex_state_enum = 11;
-pub type mrb_lex_state_enum = u32;
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum mrb_lex_state_enum {
+    EXPR_BEG = 0,
+    EXPR_END = 1,
+    EXPR_ENDARG = 2,
+    EXPR_ENDFN = 3,
+    EXPR_ARG = 4,
+    EXPR_CMDARG = 5,
+    EXPR_MID = 6,
+    EXPR_FNAME = 7,
+    EXPR_DOT = 8,
+    EXPR_CLASS = 9,
+    EXPR_VALUE = 10,
+    EXPR_MAX_STATE = 11,
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct mrb_parser_message {

--- a/mruby/src/interpreter.rs
+++ b/mruby/src/interpreter.rs
@@ -120,6 +120,7 @@ extern "C" fn require(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mr
                     // dynamic, Rust-backed require
                     interp.push_context(context);
                     require(Rc::clone(&interp));
+                    interp.pop_context();
                 } else {
                     // source-backed require
                     let contents = {

--- a/mruby/src/value/mod.rs
+++ b/mruby/src/value/mod.rs
@@ -48,13 +48,17 @@ impl Value {
     }
 
     pub fn to_s_debug(&self) -> String {
+        format!("{}<{}>", self.ruby_type().class_name(), self.inspect())
+    }
+
+    pub fn inspect(&self) -> String {
         let arena = self.interp.create_arena_savepoint();
         let mrb = { self.interp.borrow().mrb };
         let debug = unsafe { sys::mrb_sys_value_debug_str(mrb, self.value) };
         let cstr = unsafe { sys::mrb_str_to_cstr(mrb, debug) };
         let string = unsafe { CStr::from_ptr(cstr) }.to_string_lossy();
         arena.restore();
-        format!("{}<{}>", self.ruby_type().class_name(), string)
+        string.into_owned()
     }
 }
 
@@ -88,6 +92,17 @@ mod tests {
     }
 
     #[test]
+    fn inspect_true() {
+        unsafe {
+            let interp = Interpreter::create().expect("mrb init");
+
+            let value = Value::try_from_mrb(&interp, true).expect("convert");
+            let debug = value.inspect();
+            assert_eq!(debug, "true");
+        }
+    }
+
+    #[test]
     fn to_s_false() {
         unsafe {
             let interp = Interpreter::create().expect("mrb init");
@@ -106,6 +121,17 @@ mod tests {
             let value = Value::try_from_mrb(&interp, false).expect("convert");
             let debug = value.to_s_debug();
             assert_eq!(debug, "Boolean<false>");
+        }
+    }
+
+    #[test]
+    fn inspect_false() {
+        unsafe {
+            let interp = Interpreter::create().expect("mrb init");
+
+            let value = Value::try_from_mrb(&interp, false).expect("convert");
+            let debug = value.inspect();
+            assert_eq!(debug, "false");
         }
     }
 
@@ -132,6 +158,17 @@ mod tests {
     }
 
     #[test]
+    fn inspect_nil() {
+        unsafe {
+            let interp = Interpreter::create().expect("mrb init");
+
+            let value = Value::try_from_mrb(&interp, None::<Value>).expect("convert");
+            let debug = value.inspect();
+            assert_eq!(debug, "nil");
+        }
+    }
+
+    #[test]
     fn to_s_fixnum() {
         unsafe {
             let interp = Interpreter::create().expect("mrb init");
@@ -150,6 +187,17 @@ mod tests {
             let value = Value::try_from_mrb(&interp, 255).expect("convert");
             let debug = value.to_s_debug();
             assert_eq!(debug, "Fixnum<255>");
+        }
+    }
+
+    #[test]
+    fn inspect_fixnum() {
+        unsafe {
+            let interp = Interpreter::create().expect("mrb init");
+
+            let value = Value::try_from_mrb(&interp, 255).expect("convert");
+            let debug = value.inspect();
+            assert_eq!(debug, "255");
         }
     }
 
@@ -176,6 +224,17 @@ mod tests {
     }
 
     #[test]
+    fn inspect_string() {
+        unsafe {
+            let interp = Interpreter::create().expect("mrb init");
+
+            let value = Value::try_from_mrb(&interp, "interstate").expect("convert");
+            let debug = value.inspect();
+            assert_eq!(debug, r#""interstate""#);
+        }
+    }
+
+    #[test]
     fn to_s_empty_string() {
         unsafe {
             let interp = Interpreter::create().expect("mrb init");
@@ -194,6 +253,17 @@ mod tests {
             let value = Value::try_from_mrb(&interp, "").expect("convert");
             let debug = value.to_s_debug();
             assert_eq!(debug, r#"String<"">"#);
+        }
+    }
+
+    #[test]
+    fn inspect_empty_string() {
+        unsafe {
+            let interp = Interpreter::create().expect("mrb init");
+
+            let value = Value::try_from_mrb(&interp, "").expect("convert");
+            let debug = value.inspect();
+            assert_eq!(debug, r#""""#);
         }
     }
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+nightly-2019-05-07


### PR DESCRIPTION
This branch introduces a `mruby-bin` crate that includes binaries for interacting with the interpreter exposed by the `mruby` crate.

Implement one executable: `rirb`, an `irb` clone. `rirb` is a readline-based REPL that can detect open code blocks and scroll through history. `rirb` does not persist history to disk.

This feature required fixing some bugs in `EvalContext` handling. I also implemented `Value::inspect` for printing return values in the REPL.

Fixes GH-30.