### PR TITLE
Improve the class and module spec API on State

### DIFF
--- a/foolsgold/src/sources/foolsgold.rs
+++ b/foolsgold/src/sources/foolsgold.rs
@@ -5,7 +5,7 @@ use mruby::file::MrbFile;
 use mruby::interpreter::Mrb;
 use mruby::sys::{self, DescribeState};
 use mruby::value::Value;
-use mruby::{interpreter_or_raise, unwrap_or_raise};
+use mruby::{interpreter_or_raise, unwrap_value_or_raise};
 use std::cell::RefCell;
 use std::ffi::c_void;
 use std::mem;
@@ -60,7 +60,7 @@ impl MrbFile for Counter {
 
                 // We can probably relax the ordering constraint.
                 let value = SEEN_REQUESTS_COUNTER.load(Ordering::SeqCst);
-                unwrap_or_raise!(interp, Value::try_from_mrb(&interp, value))
+                unwrap_value_or_raise!(interp, Value::try_from_mrb(&interp, value))
             }
         }
 
@@ -198,7 +198,7 @@ impl MrbFile for RequestContext {
                 let trace_id = data.borrow().trace_id;
                 info!("Retrieved trace id {} in {:?}", trace_id, interp);
                 mem::forget(data);
-                unwrap_or_raise!(interp, Value::try_from_mrb(&interp, trace_id.to_string()))
+                unwrap_value_or_raise!(interp, Value::try_from_mrb(&interp, trace_id.to_string()))
             }
         }
 

--- a/foolsgold/src/sources/foolsgold.rs
+++ b/foolsgold/src/sources/foolsgold.rs
@@ -83,8 +83,10 @@ impl MrbFile for Counter {
                 spec: Rc::clone(&spec),
             };
             let spec = api.def_class::<Self>("Counter", Some(parent), None);
-            spec.borrow_mut().add_method("get", get, sys::mrb_args_none());
-            spec.borrow_mut().add_method("inc", inc, sys::mrb_args_none());
+            spec.borrow_mut()
+                .add_method("get", get, sys::mrb_args_none());
+            spec.borrow_mut()
+                .add_method("inc", inc, sys::mrb_args_none());
             spec
         };
         spec.borrow().define(&interp).expect("class install");
@@ -120,8 +122,13 @@ impl MrbFile for Metrics {
                 spec: Rc::clone(&spec),
             };
             let spec = api.def_module::<Self>("Metrics", Some(parent));
-            spec.borrow_mut().add_method("total_requests", total_requests, sys::mrb_args_none());
-            spec.borrow_mut().add_self_method("total_requests", total_requests, sys::mrb_args_none());
+            spec.borrow_mut()
+                .add_method("total_requests", total_requests, sys::mrb_args_none());
+            spec.borrow_mut().add_self_method(
+                "total_requests",
+                total_requests,
+                sys::mrb_args_none(),
+            );
             spec
         };
         spec.borrow().define(&interp).expect("module install");
@@ -199,9 +206,12 @@ impl MrbFile for RequestContext {
             };
             let spec = api.def_class::<Self>("RequestContext", Some(parent), Some(free));
             spec.borrow_mut().mrb_value_is_rust_backed(true);
-            spec.borrow_mut().add_method("initialize", initialize, sys::mrb_args_none());
-            spec.borrow_mut().add_method("trace_id", trace_id, sys::mrb_args_none());
-            spec.borrow_mut().add_method("metrics", metrics, sys::mrb_args_none());
+            spec.borrow_mut()
+                .add_method("initialize", initialize, sys::mrb_args_none());
+            spec.borrow_mut()
+                .add_method("trace_id", trace_id, sys::mrb_args_none());
+            spec.borrow_mut()
+                .add_method("metrics", metrics, sys::mrb_args_none());
             spec
         };
         spec.borrow().define(&interp).expect("class install");

--- a/foolsgold/src/sources/foolsgold.rs
+++ b/foolsgold/src/sources/foolsgold.rs
@@ -78,7 +78,9 @@ impl MrbFile for Counter {
 
         let spec = {
             let mut api = interp.borrow_mut();
-            let spec = api.module_spec::<Metrics>();
+            // TODO: return Err instead of expects when require is fallible. See
+            // GH-25.
+            let spec = api.module_spec::<Metrics>().expect("Metrics not defined");
             let parent = Parent::Module {
                 spec: Rc::clone(&spec),
             };
@@ -110,14 +112,17 @@ impl MrbFile for Metrics {
         ) -> sys::mrb_value {
             let interp = unsafe { interpreter_or_raise!(mrb) };
             let api = interp.borrow();
-            let spec = api.class_spec::<Counter>();
+            // TODO: raise instead of expects
+            let spec = api.class_spec::<Counter>().expect("Counter not defined");
             let rclass = spec.borrow().rclass(Rc::clone(&interp));
             unsafe { sys::mrb_obj_new(mrb, rclass, 0, std::ptr::null()) }
         }
 
         let spec = {
             let mut api = interp.borrow_mut();
-            let spec = api.module_spec::<Lib>();
+            // TODO: return Err instead of expects when require is fallible. See
+            // GH-25.
+            let spec = api.module_spec::<Lib>().expect("lib not defined");
             let parent = Parent::Module {
                 spec: Rc::clone(&spec),
             };
@@ -163,8 +168,12 @@ impl MrbFile for RequestContext {
                 let interp = interpreter_or_raise!(mrb);
                 {
                     let api = interp.borrow();
-                    let spec = api.class_spec::<RequestContext>();
-                    sys::mrb_sys_data_init(&mut slf, ptr, spec.borrow().data_type());
+                    // TODO: raise instead of expect
+                    let spec = api
+                        .class_spec::<RequestContext>()
+                        .expect("RequestContext not defined");
+                    let borrow = spec.borrow();
+                    sys::mrb_sys_data_init(&mut slf, ptr, borrow.data_type());
                 };
 
                 info!("initialized RequestContext with trace id {}", request_id);
@@ -178,7 +187,10 @@ impl MrbFile for RequestContext {
 
                 let ptr = {
                     let api = interp.borrow();
-                    let spec = api.class_spec::<RequestContext>();
+                    // TODO: raise instead of expects
+                    let spec = api
+                        .class_spec::<RequestContext>()
+                        .expect("RequestContext not defined");
                     let borrow = spec.borrow();
                     sys::mrb_data_get_ptr(mrb, slf, borrow.data_type())
                 };
@@ -193,14 +205,17 @@ impl MrbFile for RequestContext {
         extern "C" fn metrics(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
             let interp = unsafe { interpreter_or_raise!(mrb) };
             let api = interp.borrow();
-            let spec = api.module_spec::<Metrics>();
+            // TODO: raise instead of expects
+            let spec = api.module_spec::<Metrics>().expect("Metrics not defined");
             let rclass = spec.borrow().rclass(Rc::clone(&interp));
             unsafe { sys::mrb_sys_class_value(rclass) }
         }
 
         let spec = {
             let mut api = interp.borrow_mut();
-            let spec = api.module_spec::<Lib>();
+            // TODO: return Err instead of expects when require is fallible. See
+            // GH-25.
+            let spec = api.module_spec::<Lib>().expect("lib not defined");
             let parent = Parent::Module {
                 spec: Rc::clone(&spec),
             };

--- a/foolsgold/src/sources/foolsgold.rs
+++ b/foolsgold/src/sources/foolsgold.rs
@@ -179,8 +179,8 @@ impl MrbFile for RequestContext {
                 let ptr = {
                     let api = interp.borrow();
                     let spec = api.class_spec::<RequestContext>();
-                    let ispec = spec.borrow();
-                    sys::mrb_data_get_ptr(mrb, slf, ispec.data_type())
+                    let borrow = spec.borrow();
+                    sys::mrb_data_get_ptr(mrb, slf, borrow.data_type())
                 };
                 let data = mem::transmute::<*mut c_void, Rc<RefCell<RequestContext>>>(ptr);
                 let trace_id = data.borrow().trace_id;

--- a/mruby/README.md
+++ b/mruby/README.md
@@ -75,7 +75,7 @@ use mruby::interpreter::{Interpreter, Mrb};
 use mruby::interpreter_or_raise;
 use mruby::load::MrbLoadSources;
 use mruby::sys;
-use mruby::unwrap_or_raise;
+use mruby::unwrap_value_or_raise;
 use mruby::value::Value;
 use std::cell::RefCell;
 use std::ffi::{c_void, CString};
@@ -120,7 +120,7 @@ impl MrbFile for Container {
                 let data = mem::transmute::<*mut c_void, Rc<RefCell<Container>>>(ptr);
                 let clone = Rc::clone(&data);
                 let cont = clone.borrow();
-                let value = unwrap_or_raise!(interp, Value::try_from_mrb(&interp, cont.inner));
+                let value = unwrap_value_or_raise!(interp, Value::try_from_mrb(&interp, cont.inner));
                 mem::forget(data);
                 value
             }

--- a/mruby/src/class.rs
+++ b/mruby/src/class.rs
@@ -197,24 +197,20 @@ mod tests {
         struct BaseClass;
         struct SubClass;
         let interp = Interpreter::create().expect("mrb init");
-        {
+        let (base, sub) = {
             let mut api = interp.borrow_mut();
             let base = api.def_class::<BaseClass>("BaseClass", None, None);
             let sub = api.def_class::<SubClass>("SubClass", None, None);
             sub.borrow_mut().with_super_class(Rc::clone(&base));
-        }
-        {
-            let api = interp.borrow();
-            let base = api.class_spec::<BaseClass>();
-            base.borrow().define(&interp).expect("def class");
-            let sub = api.class_spec::<SubClass>();
-            sub.borrow().define(&interp).expect("def class");
-        }
+            (base, sub)
+        };
+        base.borrow().define(&interp).expect("def class");
+        sub.borrow().define(&interp).expect("def class");
         {
             let api = interp.borrow();
             // this should not panic
-            let _ = api.class_spec::<BaseClass>().borrow_mut();
-            let _ = api.class_spec::<SubClass>().borrow_mut();
+            let _ = api.class_spec::<BaseClass>().unwrap().borrow_mut();
+            let _ = api.class_spec::<SubClass>().unwrap().borrow_mut();
         }
     }
 }

--- a/mruby/src/class.rs
+++ b/mruby/src/class.rs
@@ -193,7 +193,7 @@ mod tests {
     }
 
     #[test]
-    fn weak_ref_allows_mutable_class_specs_after_attached_as_parent() {
+    fn refcell_allows_mutable_class_specs_after_attached_as_parent() {
         struct BaseClass;
         struct SubClass;
         let interp = Interpreter::create().expect("mrb init");

--- a/mruby/src/def.rs
+++ b/mruby/src/def.rs
@@ -152,49 +152,65 @@ mod tests {
 
         let api = interp.borrow();
         api.module_spec::<Root>()
+            .unwrap()
             .borrow()
             .define(&interp)
             .expect("def module");
         api.module_spec::<ModuleUnderRoot>()
+            .unwrap()
             .borrow()
             .define(&interp)
             .expect("def module");
         api.class_spec::<ClassUnderRoot>()
+            .unwrap()
             .borrow()
             .define(&interp)
             .expect("def class");
         api.class_spec::<ClassUnderModule>()
+            .unwrap()
             .borrow()
             .define(&interp)
             .expect("def class");
         api.module_spec::<ModuleUnderClass>()
+            .unwrap()
             .borrow()
             .define(&interp)
             .expect("def module");
         api.class_spec::<ClassUnderClass>()
+            .unwrap()
             .borrow()
             .define(&interp)
             .expect("def class");
 
-        let spec = api.module_spec::<Root>();
+        let spec = api.module_spec::<Root>().expect("Root not defined");
         assert_eq!(&spec.borrow().fqname(), "A");
         assert_eq!(&format!("{}", spec.borrow()), "mruby module spec -- A");
-        let spec = api.module_spec::<ModuleUnderRoot>();
+        let spec = api
+            .module_spec::<ModuleUnderRoot>()
+            .expect("ModuleUnderRoot not defined");
         assert_eq!(&spec.borrow().fqname(), "A::B");
         assert_eq!(&format!("{}", spec.borrow()), "mruby module spec -- A::B");
-        let spec = api.class_spec::<ClassUnderRoot>();
+        let spec = api
+            .class_spec::<ClassUnderRoot>()
+            .expect("ClassUnderRoot not defined");
         assert_eq!(&spec.borrow().fqname(), "A::C");
         assert_eq!(&format!("{}", spec.borrow()), "mruby class spec -- A::C");
-        let spec = api.class_spec::<ClassUnderModule>();
+        let spec = api
+            .class_spec::<ClassUnderModule>()
+            .expect("ClassUnderModule not defined");
         assert_eq!(&spec.borrow().fqname(), "A::B::D");
         assert_eq!(&format!("{}", spec.borrow()), "mruby class spec -- A::B::D");
-        let spec = api.module_spec::<ModuleUnderClass>();
+        let spec = api
+            .module_spec::<ModuleUnderClass>()
+            .expect("ModuleUnderClass not defined");
         assert_eq!(&spec.borrow().fqname(), "A::C::E");
         assert_eq!(
             &format!("{}", spec.borrow()),
             "mruby module spec -- A::C::E"
         );
-        let spec = api.class_spec::<ClassUnderClass>();
+        let spec = api
+            .class_spec::<ClassUnderClass>()
+            .expect("ClassUnderClass not defined");
         assert_eq!(&spec.borrow().fqname(), "A::C::F");
         assert_eq!(&format!("{}", spec.borrow()), "mruby class spec -- A::C::F");
     }

--- a/mruby/src/def.rs
+++ b/mruby/src/def.rs
@@ -214,9 +214,11 @@ mod tests {
                     .add_method("value", value, sys::mrb_args_none());
                 cls.borrow_mut()
                     .add_self_method("value", value, sys::mrb_args_none());
-                module.borrow_mut()
+                module
+                    .borrow_mut()
                     .add_method("value", value, sys::mrb_args_none());
-                module.borrow_mut()
+                module
+                    .borrow_mut()
                     .add_self_method("value", value, sys::mrb_args_none());
                 (cls, module)
             };

--- a/mruby/src/def.rs
+++ b/mruby/src/def.rs
@@ -15,7 +15,7 @@ pub type Free = unsafe extern "C" fn(mrb: *mut sys::mrb_state, data: *mut c_void
 pub type Method =
     unsafe extern "C" fn(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
 pub enum Parent {
     Class { spec: Rc<RefCell<class::Spec>> },
     Module { spec: Rc<RefCell<module::Spec>> },
@@ -26,6 +26,22 @@ impl Parent {
         match self {
             Parent::Class { spec } => spec.borrow().rclass(interp),
             Parent::Module { spec } => spec.borrow().rclass(interp),
+        }
+    }
+}
+
+impl Eq for Parent {}
+
+impl PartialEq for Parent {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Parent::Class { spec: self_spec }, Parent::Class { spec: other_spec }) => {
+                self_spec == other_spec
+            }
+            (Parent::Module { spec: self_spec }, Parent::Module { spec: other_spec }) => {
+                self_spec == other_spec
+            }
+            _ => false,
         }
     }
 }

--- a/mruby/src/eval.rs
+++ b/mruby/src/eval.rs
@@ -201,12 +201,13 @@ mod tests {
                 {
                     let mut api = interp.borrow_mut();
                     api.def_module::<Self>("NestedEval", None);
-                    let spec = api.module_spec_mut::<Self>();
-                    spec.add_self_method("file", nested_eval, sys::mrb_args_none());
+                    let spec = api.module_spec::<Self>();
+                    spec.borrow_mut()
+                        .add_self_method("file", nested_eval, sys::mrb_args_none());
                 }
                 let api = interp.borrow();
                 let spec = api.module_spec::<Self>();
-                spec.define(&interp).expect("def method");
+                spec.borrow().define(&interp).expect("def method");
             }
         }
         let mut interp = Interpreter::create().expect("mrb init");

--- a/mruby/src/eval.rs
+++ b/mruby/src/eval.rs
@@ -198,15 +198,14 @@ mod tests {
         struct NestedEval;
         impl MrbFile for NestedEval {
             fn require(interp: Mrb) {
-                {
+                let spec = {
                     let mut api = interp.borrow_mut();
                     api.def_module::<Self>("NestedEval", None);
                     let spec = api.module_spec::<Self>();
                     spec.borrow_mut()
                         .add_self_method("file", nested_eval, sys::mrb_args_none());
-                }
-                let api = interp.borrow();
-                let spec = api.module_spec::<Self>();
+                    spec
+                };
                 spec.borrow().define(&interp).expect("def method");
             }
         }

--- a/mruby/src/eval.rs
+++ b/mruby/src/eval.rs
@@ -200,8 +200,7 @@ mod tests {
             fn require(interp: Mrb) {
                 let spec = {
                     let mut api = interp.borrow_mut();
-                    api.def_module::<Self>("NestedEval", None);
-                    let spec = api.module_spec::<Self>();
+                    let spec = api.def_module::<Self>("NestedEval", None);
                     spec.borrow_mut()
                         .add_self_method("file", nested_eval, sys::mrb_args_none());
                     spec

--- a/mruby/src/eval.rs
+++ b/mruby/src/eval.rs
@@ -158,7 +158,7 @@ mod tests {
     use crate::interpreter::{Interpreter, Mrb};
     use crate::load::MrbLoadSources;
     use crate::sys;
-    use crate::{interpreter_or_raise, unwrap_or_raise};
+    use crate::{interpreter_or_raise, unwrap_value_or_raise};
 
     #[test]
     fn root_eval_context() {
@@ -193,7 +193,7 @@ mod tests {
             _slf: sys::mrb_value,
         ) -> sys::mrb_value {
             let interp = unsafe { interpreter_or_raise!(mrb) };
-            unsafe { unwrap_or_raise!(interp, interp.eval("__FILE__")) }
+            unsafe { unwrap_value_or_raise!(interp, interp.eval("__FILE__")) }
         }
         struct NestedEval;
         impl MrbFile for NestedEval {

--- a/mruby/src/interpreter.rs
+++ b/mruby/src/interpreter.rs
@@ -203,6 +203,7 @@ impl Interpreter {
 
             // Add global extension functions
             // Support for requiring files via `Kernel#require`
+            // TODO: clean this up by making a spec factory
             let mut kernel = module::Spec::new("Kernel", None);
             kernel.add_self_method("require", require, sys::mrb_args_rest());
             kernel.define(&interp).map_err(|_| MrbError::New)?;

--- a/mruby/src/interpreter.rs
+++ b/mruby/src/interpreter.rs
@@ -208,11 +208,13 @@ impl Interpreter {
             kernel.define(&interp).map_err(|_| MrbError::New)?;
             trace!("Installed Kernel#require on {}", mrb.debug());
             let exception = class::Spec::new("Exception", None, None);
+            let exception_rc = Rc::new(RefCell::new(exception));
             let mut script_error = class::Spec::new("ScriptError", None, None);
-            script_error.with_super_class(Rc::new(exception));
+            script_error.with_super_class(Rc::clone(&exception_rc));
             script_error.define(&interp).map_err(|_| MrbError::New)?;
+            let script_error_rc = Rc::new(RefCell::new(script_error));
             let mut load_error = class::Spec::new("LoadError", None, None);
-            load_error.with_super_class(Rc::new(script_error));
+            load_error.with_super_class(Rc::clone(&script_error_rc));
             load_error.define(&interp).map_err(|_| MrbError::New)?;
             trace!("Installed LoadError on {}", mrb.debug());
 

--- a/mruby/src/interpreter.rs
+++ b/mruby/src/interpreter.rs
@@ -92,6 +92,7 @@ extern "C" fn require(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mr
                 }
                 {
                     let api = interp.borrow();
+                    // TODO: fix this abuse of the `unwrap_value_or_raise` macro
                     unwrap_value_or_raise!(
                         interp,
                         api.vfs
@@ -111,6 +112,7 @@ extern "C" fn require(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mr
                     // Create the missing metadata struct to prevent double
                     // requires.
                     let metadata = VfsMetadata::new(None).mark_required();
+                    // TODO: fix this abuse of the `unwrap_value_or_raise` macro
                     unwrap_value_or_raise!(
                         interp,
                         api.vfs.set_metadata(path, metadata).map(|_| interp.nil())

--- a/mruby/src/lib.rs
+++ b/mruby/src/lib.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use std::io;
 
 #[macro_use]
-pub mod interpreter;
+pub mod macros;
 
 pub mod class;
 pub mod convert;
@@ -13,6 +13,7 @@ pub mod def;
 pub mod eval;
 pub mod file;
 pub mod gc;
+pub mod interpreter;
 pub mod load;
 pub mod method;
 pub mod module;

--- a/mruby/src/macros.rs
+++ b/mruby/src/macros.rs
@@ -1,8 +1,9 @@
-//! Macros working with interpreters and `Value`s. Define all macros for the
-//! mruby crate in this source file. It is included first in `lib.rs`, which
-//! means the macros are available in the mruby crate.
+//! This module defines macros for working with interpreters and `Value`s. This
+//! source module is included first in `lib.rs`, which means the macros are
+//! available to all modules within the mruby crate in addition to being
+//! exported.
 
-/// Extract an [`Mrb`] instance from the userdata on a `sys::mrb_state`. If
+/// Extract an [`Mrb`] instance from the userdata on a [`sys::mrb_state`]. If
 /// there is an error when extracting the Rust wrapper around the interpreter,
 /// attempt to raise a `RuntimeError` and return `nil`.
 ///
@@ -31,8 +32,11 @@ macro_rules! interpreter_or_raise {
     };
 }
 
-/// Unwrap a [`Value`] and return the inner [`sys::mrb_value`] or raise a
+/// Unwrap a `Result<Value>` and return the inner [`sys::mrb_value`] or raise a
 /// `RuntimeError` and return `nil`.
+///
+/// This macro is `unsafe` and assumes it is being called from an `extern "C" fn`
+/// that is embedded in an mruby class, module, or function definition.
 #[macro_export]
 macro_rules! unwrap_value_or_raise {
     ($interp:expr, $result:expr) => {
@@ -57,7 +61,7 @@ macro_rules! unwrap_value_or_raise {
     };
 }
 
-/// Lookup a [`class::Spec`] by a Rust type `T`. If the spec does not exist,
+/// Lookup a [`class::Spec`] for a Rust type `T`. If the spec does not exist,
 /// raise on the interpreter and return `nil`.
 ///
 /// This macro is `unsafe` and assumes it is being called from an `extern "C" fn`
@@ -82,7 +86,7 @@ macro_rules! class_spec_or_raise {
     };
 }
 
-/// Lookup a [`module::Spec`] by a Rust type `T`. If the spec does not exist,
+/// Lookup a [`module::Spec`] for a Rust type `T`. If the spec does not exist,
 /// raise on the interpreter and return `nil`.
 ///
 /// This macro is `unsafe` and assumes it is being called from an `extern "C" fn`
@@ -93,8 +97,8 @@ macro_rules! module_spec_or_raise {
         if let Some(spec) = $interp.borrow().module_spec::<$type>() {
             spec
         } else {
-            // The class spec does not exist or has not been deifned with
-            // `State::def_class` yet.
+            // The module spec does not exist or has not been deifned with
+            // `State::def_module` yet.
             let eclass = std::ffi::CString::new("RuntimeError");
             let message = std::ffi::CString::new("Uninitialized Module");
             if let (std::result::Result::Ok(eclass), std::result::Result::Ok(message)) =

--- a/mruby/src/macros.rs
+++ b/mruby/src/macros.rs
@@ -59,6 +59,9 @@ macro_rules! unwrap_value_or_raise {
 
 /// Lookup a [`class::Spec`] by a Rust type `T`. If the spec does not exist,
 /// raise on the interpreter and return `nil`.
+///
+/// This macro is `unsafe` and assumes it is being called from an `extern "C" fn`
+/// that is embedded in an mruby class, module, or function definition.
 #[macro_export]
 macro_rules! class_spec_or_raise {
     ($interp:expr, $type:ty) => {
@@ -81,6 +84,9 @@ macro_rules! class_spec_or_raise {
 
 /// Lookup a [`module::Spec`] by a Rust type `T`. If the spec does not exist,
 /// raise on the interpreter and return `nil`.
+///
+/// This macro is `unsafe` and assumes it is being called from an `extern "C" fn`
+/// that is embedded in an mruby class, module, or function definition.
 #[macro_export]
 macro_rules! module_spec_or_raise {
     ($interp:expr, $type:ty) => {

--- a/mruby/src/macros.rs
+++ b/mruby/src/macros.rs
@@ -1,0 +1,56 @@
+//! Macros working with interpreters and `Value`s. Define all macros for the
+//! mruby crate in this source file. It is included first in `lib.rs`, which
+//! means the macros are available in the mruby crate.
+
+/// Extract an [`Mrb`] instance from the userdata on a `sys::mrb_state`. If
+/// there is an error when extracting the Rust wrapper around the interpreter,
+/// attempt to raise a `RuntimeError` and return `nil`.
+///
+/// This macro is `unsafe` and assumes it is being called from an `extern "C" fn`
+/// that is embedded in an mruby class, module, or function definition.
+#[macro_export]
+macro_rules! interpreter_or_raise {
+    ($mrb:expr) => {
+        match $crate::interpreter::Interpreter::from_user_data($mrb) {
+            std::result::Result::Err(err) => {
+                // Unable to retrieve interpreter from user data pointer in
+                // `mrb_state`.
+                let eclass = std::ffi::CString::new("RuntimeError");
+                let message = std::ffi::CString::new(format!("{}", err));
+                if let (std::result::Result::Ok(eclass), std::result::Result::Ok(message)) =
+                    (eclass, message)
+                {
+                    $crate::sys::mrb_sys_raise($mrb, eclass.as_ptr(), message.as_ptr());
+                }
+                return $crate::sys::mrb_sys_nil_value();
+            }
+            std::result::Result::Ok(interpreter) => interpreter,
+        }
+    };
+}
+
+/// Unwrap a [`Value`] and return the inner [`sys::mrb_value`] or raise a
+/// `RuntimeError` and return `nil`.
+#[macro_export]
+macro_rules! unwrap_value_or_raise {
+    ($interp:expr, $result:expr) => {
+        match $result {
+            std::result::Result::Err(err) => {
+                // There was a TypeError converting to the desired Rust type.
+                let eclass = std::ffi::CString::new("RuntimeError");
+                let message = std::ffi::CString::new(format!("{}", err));
+                if let (std::result::Result::Ok(eclass), std::result::Result::Ok(message)) =
+                    (eclass, message)
+                {
+                    $crate::sys::mrb_sys_raise(
+                        $interp.borrow().mrb,
+                        eclass.as_ptr(),
+                        message.as_ptr(),
+                    );
+                }
+                return $crate::interpreter::MrbApi::nil(&$interp).inner();
+            }
+            std::result::Result::Ok(value) => value.inner(),
+        }
+    };
+}

--- a/mruby/src/state.rs
+++ b/mruby/src/state.rs
@@ -94,6 +94,32 @@ impl State {
     ///
     /// Class specs can also be retrieved from the state after creation with
     /// [`State::class_spec`].
+    ///
+    /// The recommended pattern for using `def_class` looks like this:
+    ///
+    /// ```rust
+    /// use mruby::def::{ClassLike, Define};
+    /// use mruby::interpreter::{Interpreter, MrbApi};
+    /// use mruby::interpreter_or_raise;
+    /// use mruby::sys;
+    ///
+    /// extern "C" fn value(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value
+    /// {
+    ///     let interp = unsafe { interpreter_or_raise!(mrb) };
+    ///     interp.fixnum(29).inner()
+    /// }
+    ///
+    /// let interp = Interpreter::create().expect("mrb init");
+    /// let spec = {
+    ///     let mut api = interp.borrow_mut();
+    ///     let spec = api.def_class::<()>("Container", None, None);
+    ///     spec.borrow_mut().add_method("value", value, sys::mrb_args_none());
+    ///     spec.borrow_mut().add_self_method("value", value, sys::mrb_args_none());
+    ///     spec.borrow_mut().mrb_value_is_rust_backed(true);
+    ///     spec
+    /// };
+    /// spec.borrow().define(&interp).expect("class install");
+    /// ```
     pub fn def_class<T: Any>(
         &mut self,
         name: &str,
@@ -133,6 +159,31 @@ impl State {
     ///
     /// Class specs can also be retrieved from the state after creation with
     /// [`State::class_spec`].
+    ///
+    /// The recommended pattern for using `def_class` looks like this:
+    ///
+    /// ```rust
+    /// use mruby::def::{ClassLike, Define};
+    /// use mruby::interpreter::{Interpreter, MrbApi};
+    /// use mruby::interpreter_or_raise;
+    /// use mruby::sys;
+    ///
+    /// extern "C" fn value(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value
+    /// {
+    ///     let interp = unsafe { interpreter_or_raise!(mrb) };
+    ///     interp.fixnum(29).inner()
+    /// }
+    ///
+    /// let interp = Interpreter::create().expect("mrb init");
+    /// let spec = {
+    ///     let mut api = interp.borrow_mut();
+    ///     let spec = api.def_module::<()>("Container", None);
+    ///     spec.borrow_mut().add_method("value", value, sys::mrb_args_none());
+    ///     spec.borrow_mut().add_self_method("value", value, sys::mrb_args_none());
+    ///     spec
+    /// };
+    /// spec.borrow().define(&interp).expect("class install");
+    /// ```
     pub fn def_module<T: Any>(
         &mut self,
         name: &str,

--- a/mruby/src/state.rs
+++ b/mruby/src/state.rs
@@ -134,17 +134,16 @@ impl State {
 
     /// Retrieve a class definition from the state bound to Rust type `T`.
     ///
-    /// This function panics if type `T` has not had a class spec registered
-    /// for it using [`State::def_class`].
+    /// This function returns `None` if type `T` has not had a class spec
+    /// registered for it using [`State::def_class`].
     ///
     /// Internally, [`class::Spec`]s are stored in an `Rc<RefCell<_>>` which
     /// allows class specs to have multiple owners, such as being a super class
     /// or a parent for a class or a module. To mutate the class spec, call
     /// `borrow_mut` on the return value of this method to get a mutable
     /// reference to the class spec.
-    pub fn class_spec<T: Any>(&self) -> Rc<RefCell<class::Spec>> {
-        let spec = self.classes.get(&TypeId::of::<T>()).expect("class spec");
-        Rc::clone(spec)
+    pub fn class_spec<T: Any>(&self) -> Option<Rc<RefCell<class::Spec>>> {
+        self.classes.get(&TypeId::of::<T>()).map(Rc::clone)
     }
 
     /// Create a module definition bound to a Rust type `T`. Module definitions
@@ -197,17 +196,16 @@ impl State {
 
     /// Retrieve a module definition from the state bound to Rust type `T`.
     ///
-    /// This function panics if type `T` has not had a class spec registered
-    /// for it using [`State::def_module`].
+    /// This function returns `None` if type `T` has not had a class spec
+    /// registered for it using [`State::def_module`].
     ///
     /// Internally, [`module::Spec`]s are stored in an `Rc<RefCell<_>>` which
     /// allows module specs to have multiple owners, such as being a parent for
     /// a class or a module. To mutate the module spec, call `borrow_mut` on the
     /// return value of this method to get a mutable reference to the module
     /// spec.
-    pub fn module_spec<T: Any>(&self) -> Rc<RefCell<module::Spec>> {
-        let spec = self.modules.get(&TypeId::of::<T>()).expect("module spec");
-        Rc::clone(spec)
+    pub fn module_spec<T: Any>(&self) -> Option<Rc<RefCell<module::Spec>>> {
+        self.modules.get(&TypeId::of::<T>()).map(Rc::clone)
     }
 }
 

--- a/mruby/tests/leak_mrb_tt_data_rc.rs
+++ b/mruby/tests/leak_mrb_tt_data_rc.rs
@@ -61,8 +61,12 @@ impl MrbFile for Container {
                 let data = Rc::new(RefCell::new(cont));
                 let ptr = mem::transmute::<Rc<RefCell<Container>>, *mut c_void>(data);
 
-                let spec = api.class_spec::<Container>();
-                sys::mrb_sys_data_init(&mut slf, ptr, spec.borrow().data_type());
+                // TODO: raise instead of expect
+                let spec = api
+                    .class_spec::<Container>()
+                    .expect("Container not defined");
+                let borrow = spec.borrow();
+                sys::mrb_sys_data_init(&mut slf, ptr, borrow.data_type());
 
                 slf
             }

--- a/mruby/tests/leak_mrb_tt_data_rc.rs
+++ b/mruby/tests/leak_mrb_tt_data_rc.rs
@@ -62,22 +62,21 @@ impl MrbFile for Container {
                 let ptr = mem::transmute::<Rc<RefCell<Container>>, *mut c_void>(data);
 
                 let spec = api.class_spec::<Container>();
-                sys::mrb_sys_data_init(&mut slf, ptr, spec.data_type());
+                sys::mrb_sys_data_init(&mut slf, ptr, spec.borrow().data_type());
 
                 slf
             }
         }
 
-        {
+        let spec = {
             let mut api = interp.borrow_mut();
-            api.def_class::<Container>("Container", None, Some(free));
-            let spec = api.class_spec_mut::<Self>();
-            spec.add_method("initialize", initialize, sys::mrb_args_req(1));
-            spec.mrb_value_is_rust_backed(true);
-        }
-        let api = interp.borrow();
-        let spec = api.class_spec::<Self>();
-        spec.define(&interp).expect("class install");
+            let spec = api.def_class::<Self>("Container", None, Some(free));
+            spec.borrow_mut()
+                .add_method("initialize", initialize, sys::mrb_args_req(1));
+            spec.borrow_mut().mrb_value_is_rust_backed(true);
+            spec
+        };
+        spec.borrow().define(&interp).expect("class install");
     }
 }
 

--- a/mruby/tests/leak_mrb_tt_data_rc.rs
+++ b/mruby/tests/leak_mrb_tt_data_rc.rs
@@ -16,9 +16,9 @@ use mruby::def::{ClassLike, Define};
 use mruby::eval::MrbEval;
 use mruby::file::MrbFile;
 use mruby::interpreter::{Interpreter, Mrb};
-use mruby::interpreter_or_raise;
 use mruby::load::MrbLoadSources;
 use mruby::sys;
+use mruby::{class_spec_or_raise, interpreter_or_raise};
 use std::cell::RefCell;
 use std::ffi::{c_void, CStr, CString};
 use std::mem;
@@ -51,7 +51,6 @@ impl MrbFile for Container {
         ) -> sys::mrb_value {
             unsafe {
                 let interp = interpreter_or_raise!(mrb);
-                let api = interp.borrow_mut();
 
                 let string = mem::uninitialized::<*const std::os::raw::c_char>();
                 let argspec = CString::new(sys::specifiers::CSTRING).expect("argspec");
@@ -61,10 +60,7 @@ impl MrbFile for Container {
                 let data = Rc::new(RefCell::new(cont));
                 let ptr = mem::transmute::<Rc<RefCell<Container>>, *mut c_void>(data);
 
-                // TODO: raise instead of expect
-                let spec = api
-                    .class_spec::<Container>()
-                    .expect("Container not defined");
+                let spec = class_spec_or_raise!(interp, Container);
                 let borrow = spec.borrow();
                 sys::mrb_sys_data_init(&mut slf, ptr, borrow.data_type());
 

--- a/mruby/tests/manual.rs
+++ b/mruby/tests/manual.rs
@@ -9,7 +9,7 @@ use mruby::interpreter::{Interpreter, Mrb};
 use mruby::load::MrbLoadSources;
 use mruby::sys;
 use mruby::value::Value;
-use mruby::{interpreter_or_raise, unwrap_or_raise};
+use mruby::{interpreter_or_raise, unwrap_value_or_raise};
 use std::cell::RefCell;
 use std::ffi::{c_void, CString};
 use std::mem;
@@ -80,7 +80,8 @@ impl MrbFile for Container {
                 let clone = Rc::clone(&data);
                 let cont = clone.borrow();
 
-                let value = unwrap_or_raise!(interp, Value::try_from_mrb(&interp, cont.inner));
+                let value =
+                    unwrap_value_or_raise!(interp, Value::try_from_mrb(&interp, cont.inner));
                 mem::forget(data);
                 value
             }

--- a/mruby/tests/manual.rs
+++ b/mruby/tests/manual.rs
@@ -54,7 +54,10 @@ impl MrbFile for Container {
                     "interpreter strong ref count = {}",
                     Rc::strong_count(&interp)
                 );
-                let spec = api.class_spec::<Container>();
+                // TODO: raise instead of expect
+                let spec = api
+                    .class_spec::<Container>()
+                    .expect("Container not defined");
                 sys::mrb_sys_data_init(&mut slf, ptr, spec.borrow().data_type());
 
                 slf
@@ -65,10 +68,14 @@ impl MrbFile for Container {
             unsafe {
                 let interp = interpreter_or_raise!(mrb);
                 let api = interp.borrow();
-                let spec = api.class_spec::<Container>();
+                // TODO: raise instead of expect
+                let spec = api
+                    .class_spec::<Container>()
+                    .expect("Container not defined");
 
                 debug!("pulled mrb_data_type from user data with class: {:?}", spec);
-                let ptr = sys::mrb_data_get_ptr(mrb, slf, spec.borrow().data_type());
+                let borrow = spec.borrow();
+                let ptr = sys::mrb_data_get_ptr(mrb, slf, borrow.data_type());
                 let data = mem::transmute::<*mut c_void, Rc<RefCell<Container>>>(ptr);
                 let clone = Rc::clone(&data);
                 let cont = clone.borrow();


### PR DESCRIPTION
Introduce interior mutability to the `Map`s that store class and module specs on the `State`. This patch makes the `def_class` and `def_module` APIs easier to work with.

The returned spec is wrapped in a `Rc<RefCell<_>>` which means a single Rc can be used mutably and immutably. This also removes the panic from attempting to mutate a spec after it has been used as a parent or as a super class.