### PR TITLE
Refactor rubygem public interface to match YARV and mruby C extension API

### DIFF
--- a/foolsgold/src/execmodel/prefork.rs
+++ b/foolsgold/src/execmodel/prefork.rs
@@ -7,7 +7,6 @@ use mruby::value::types::{Ruby, Rust};
 use mruby::value::Value;
 use mruby::MrbError;
 use mruby_gems::rubygems::rack;
-use mruby_gems::Gem;
 use ref_thread_local::RefThreadLocal;
 use rocket::http::Status;
 use rocket::{get, Response};
@@ -18,7 +17,7 @@ use crate::sources::{foolsgold, rackup};
 ref_thread_local! {
     static managed INTERPRETER: Mrb = {
         let mut interp = interpreter::Interpreter::create().expect("mrb interpreter");
-        rack::Rack::init(&mut interp).expect("Rack gem");
+        rack::init(&mut interp).expect("Rack gem");
         interp.def_file_for_type::<_, foolsgold::Lib>("foolsgold").expect("def foolsgold");
         interp
     };

--- a/foolsgold/src/execmodel/prefork.rs
+++ b/foolsgold/src/execmodel/prefork.rs
@@ -18,7 +18,7 @@ use crate::sources::{foolsgold, rackup};
 ref_thread_local! {
     static managed INTERPRETER: Mrb = {
         let mut interp = interpreter::Interpreter::create().expect("mrb interpreter");
-        rack::Rack::install(&mut interp).expect("Rack gem");
+        rack::Rack::init(&mut interp).expect("Rack gem");
         interp.def_file_for_type::<_, foolsgold::Lib>("foolsgold").expect("def foolsgold");
         interp
     };

--- a/foolsgold/src/execmodel/shared_nothing.rs
+++ b/foolsgold/src/execmodel/shared_nothing.rs
@@ -33,7 +33,7 @@ impl Interpreter for Mrb {
 pub fn rack_app<'a>() -> Result<Response<'a>, Status> {
     info!("Initializing fresh shared nothing mruby interpreter");
     let mut interp = interpreter::Interpreter::create().map_err(|_| Status::InternalServerError)?;
-    rack::Rack::install(&mut interp).map_err(|_| Status::InternalServerError)?;
+    rack::Rack::init(&mut interp).map_err(|_| Status::InternalServerError)?;
     interp
         .def_file_for_type::<_, foolsgold::Lib>("foolsgold")
         .map_err(|_| Status::InternalServerError)?;

--- a/foolsgold/src/execmodel/shared_nothing.rs
+++ b/foolsgold/src/execmodel/shared_nothing.rs
@@ -6,7 +6,6 @@ use mruby::value::types::{Ruby, Rust};
 use mruby::value::Value;
 use mruby::MrbError;
 use mruby_gems::rubygems::rack;
-use mruby_gems::Gem;
 use rocket::http::Status;
 use rocket::{get, Response};
 
@@ -33,7 +32,7 @@ impl Interpreter for Mrb {
 pub fn rack_app<'a>() -> Result<Response<'a>, Status> {
     info!("Initializing fresh shared nothing mruby interpreter");
     let mut interp = interpreter::Interpreter::create().map_err(|_| Status::InternalServerError)?;
-    rack::Rack::init(&mut interp).map_err(|_| Status::InternalServerError)?;
+    rack::init(&mut interp).map_err(|_| Status::InternalServerError)?;
     interp
         .def_file_for_type::<_, foolsgold::Lib>("foolsgold")
         .map_err(|_| Status::InternalServerError)?;

--- a/mruby-gems/README.md
+++ b/mruby-gems/README.md
@@ -12,7 +12,7 @@ Ruby and/or Rust-backed gem to be installed into an interpreter.
 
 ## Implementing a Gem
 
-## Vendor Gem Dependencies
+### Vendor Gem Dependencies
 
 The first step in implementing a new gem is adding it to the
 [`Gemfile`](Gemfile). Peg a gem to a _specific_ version with an `= x.y.z`
@@ -24,6 +24,16 @@ gem 'rack', '= 2.0.7'
 
 Then run `bundle install` and check in the resulting [lock file](Gemfile.lock)
 and vendored gem sources.
+
+### Public Interface
+
+Gem modules should expose one public function:
+
+```rust
+pub fn init(interp: &mut Mrb) -> Result<(), MrbError> {
+    unimplemented!()
+}
+```
 
 ### Pure Ruby
 
@@ -41,9 +51,13 @@ use std::convert::AsRef;
 
 use crate::Gem;
 
+pub fn init(interp: &mut Mrb) -> Result<(), MrbError> {
+    Rack::init(interp)
+}
+
 #[derive(RustEmbed)]
 #[folder = "mruby-gems/vendor/ruby/2.6.0/gems/rack-2.0.7/lib"]
-pub struct Rack;
+struct Rack;
 
 impl Rack {
     fn contents<T: AsRef<str>>(path: T) -> Result<Vec<u8>, MrbError> {

--- a/mruby-gems/README.md
+++ b/mruby-gems/README.md
@@ -55,7 +55,7 @@ impl Rack {
 }
 
 impl Gem for Rack {
-    fn install(interp: &mut Mrb) -> Result<(), MrbError> {
+    fn init(interp: &mut Mrb) -> Result<(), MrbError> {
         for source in Self::iter() {
             let contents = Self::contents(&source)?;
             interp.def_rb_source_file(source, contents)?;

--- a/mruby-gems/src/lib.rs
+++ b/mruby-gems/src/lib.rs
@@ -8,6 +8,8 @@ use mruby::MrbError;
 
 pub mod rubygems;
 
+/// Define a Rubygem that can be installed into an [`Mrb`] interpreter.
 pub trait Gem {
-    fn install(interp: &mut Mrb) -> Result<(), MrbError>;
+    /// Initialize a gem in the [`Mrb`] interpreter.
+    fn init(interp: &mut Mrb) -> Result<(), MrbError>;
 }

--- a/mruby-gems/src/rubygems/rack.rs
+++ b/mruby-gems/src/rubygems/rack.rs
@@ -23,7 +23,7 @@ impl Rack {
 }
 
 impl Gem for Rack {
-    fn install(interp: &mut Mrb) -> Result<(), MrbError> {
+    fn init(interp: &mut Mrb) -> Result<(), MrbError> {
         for source in Self::iter() {
             let contents = Self::contents(&source)?;
             interp.def_rb_source_file(source, contents)?;

--- a/mruby-gems/src/rubygems/rack.rs
+++ b/mruby-gems/src/rubygems/rack.rs
@@ -6,12 +6,16 @@ use std::convert::AsRef;
 
 use crate::Gem;
 
+pub fn init(interp: &mut Mrb) -> Result<(), MrbError> {
+    Rack::init(interp)
+}
+
 /// Rack gem at version 2.0.7.
 #[derive(RustEmbed)]
 // TODO: resolve path relative to CARGO_MANIFEST_DIR
 // https://github.com/pyros2097/rust-embed/pull/59
 #[folder = "mruby-gems/vendor/ruby/2.6.0/gems/rack-2.0.7/lib"]
-pub struct Rack;
+struct Rack;
 
 impl Rack {
     fn contents<T: AsRef<str>>(path: T) -> Result<Vec<u8>, MrbError> {


### PR DESCRIPTION
Gems implemented in C in YARV and mruby have one public function called `rb_gemname_init` which takes an interpreter and defines all the classes and methods the gem implements.

Rename `Gem::install` to `Gem::init`. Hide `Gem` as an implementation detail in `mruby-gems` and have each module in `mruby_gems::rubygems` export one public `init` function.