### PR TITLE
Return Err from eval if code does not parse

### DIFF
--- a/mruby/src/lib.rs
+++ b/mruby/src/lib.rs
@@ -32,6 +32,7 @@ pub enum MrbError {
     NotDefined(String),
     SourceNotFound(String),
     Uninitialized,
+    UnreachableValue(sys::mrb_vtype),
     Vfs(io::Error),
 }
 
@@ -54,6 +55,9 @@ impl fmt::Display for MrbError {
             MrbError::NotDefined(fqname) => write!(f, "{} not defined", fqname),
             MrbError::SourceNotFound(source) => write!(f, "Could not load Ruby source {}", source),
             MrbError::Uninitialized => write!(f, "mrb interpreter not initialized"),
+            MrbError::UnreachableValue(tt) => {
+                write!(f, "extracted unreachable type {:?} from interpreter", tt)
+            }
             MrbError::Vfs(err) => write!(f, "mrb vfs io error: {}", err),
         }
     }

--- a/mruby/src/value/mod.rs
+++ b/mruby/src/value/mod.rs
@@ -27,6 +27,19 @@ impl Value {
         types::Ruby::from(self.value)
     }
 
+    /// Some types like [`sys::mrb_vtype::MRB_TT_UNDEF`] are internal to the
+    /// mruby VM and manipulating them with the [`sys`] API is unspecified and
+    /// may result in a segfault.
+    ///
+    /// After extracting a [`sys::mrb_value`] from the interpreter, check to see
+    /// if the value is [unreachable](types::Ruby::Unreachable) and propagate an
+    /// [`MrbError::UnreachableValue`](crate::MrbError::UnreachableValue) error.
+    ///
+    /// See: <https://github.com/mruby/mruby/issues/4460>
+    pub fn is_unreachable(&self) -> bool {
+        self.ruby_type() == types::Ruby::Unreachable
+    }
+
     pub fn is_dead(&self) -> bool {
         unsafe { sys::mrb_sys_value_is_dead(self.interp.borrow().mrb, self.value) }
     }

--- a/mruby/src/value/types.rs
+++ b/mruby/src/value/types.rs
@@ -148,9 +148,7 @@ impl From<sys::mrb_value> for Ruby {
             // structure stored in its `value.p` field.
             // TODO: how to handle this?
             sys::mrb_vtype::MRB_TT_DATA => Ruby::Data,
-            // Fibers are only implemented in a gem which mruby-sys does not
-            // build.
-            sys::mrb_vtype::MRB_TT_FIBER => Ruby::Unreachable,
+            sys::mrb_vtype::MRB_TT_FIBER => unimplemented!("mruby type fiber"),
             // MRB_TT_ISTRUCT is an "inline structure", or a mrb_value that
             // stores data in a char* buffer inside an mrb_value. These
             // mrb_values cannot have a finalizer and cannot have instance


### PR DESCRIPTION
There are some cases, like when code does not parse, where mrb_load_nstring_cxt
returns mrb_undef_value. undef is meant to never be exposed to the Ruby VM and
doing so is undefined behavior that may result in a segfault.

mruby crate already has a concept of an unreachable mrb_value. This commit
detects if the value we extract from the the interpreter with eval is unreachable
and returns an error true.

See mruby/mruby#4460.