### PR TITLE
Allow files in VFS to be backed by source and an MrbFile impl

### DIFF
--- a/mruby/src/state.rs
+++ b/mruby/src/state.rs
@@ -21,11 +21,8 @@ pub struct VfsMetadata {
 }
 
 impl VfsMetadata {
-    pub fn new(require: Option<fn(Mrb)>) -> Self {
-        Self {
-            require,
-            already_required: false,
-        }
+    pub fn new() -> Self {
+        Self::default()
     }
 
     pub fn mark_required(&self) -> Self {
@@ -37,6 +34,15 @@ impl VfsMetadata {
 
     pub fn is_already_required(&self) -> bool {
         self.already_required
+    }
+}
+
+impl Default for VfsMetadata {
+    fn default() -> Self {
+        Self {
+            require: None,
+            already_required: false,
+        }
     }
 }
 


### PR DESCRIPTION
Significantly refactor require implementation to allow a file in the VFS to
be source and MrbFile backed. This vastly simplifies the branching in the
require function and enables more flexible usage of MrbFile and Gem traits.

Refactor MrbLoadSources to only write stub file to disk if there is no content
already on disk at the path. def_file and def_rb_source_file now use existing
metadata structs at path if they already exist.