### PR TITLE
Remove obsoleted mrb_sys_class_defined_under mruby-sys ext function

### DIFF
--- a/mruby-sys/mruby-sys/include/mruby-sys/ext.h
+++ b/mruby-sys/mruby-sys/include/mruby-sys/ext.h
@@ -127,8 +127,3 @@ void mrb_sys_gc_enable(mrb_state *mrb);
 _Bool mrb_sys_value_is_dead(mrb_state *_mrb, mrb_value value);
 
 int mrb_sys_gc_live_objects(mrb_state *mrb);
-
-// Inspect class hierarchy
-
-_Bool mrb_sys_class_defined_under(struct mrb_state *mrb, struct RClass *outer,
-                                  const char *name);

--- a/mruby-sys/mruby-sys/src/mruby-sys/ext.c
+++ b/mruby-sys/mruby-sys/src/mruby-sys/ext.c
@@ -194,16 +194,3 @@ int mrb_sys_gc_live_objects(mrb_state *mrb) {
   mrb_gc *gc = &mrb->gc;
   return gc->live;
 }
-
-// Inspect class hierarchy
-
-// TODO: implement this utility function in Rust
-_Bool mrb_sys_class_defined_under(struct mrb_state *mrb, struct RClass *outer,
-                                  const char *name) {
-  mrb_value sym = mrb_check_intern_cstr(mrb, name);
-
-  if (mrb_nil_p(sym))
-    return FALSE;
-
-  return mrb_const_defined(mrb, mrb_obj_value(outer), mrb_symbol(sym));
-}

--- a/mruby-sys/src/ffi.rs
+++ b/mruby-sys/src/ffi.rs
@@ -3788,14 +3788,6 @@ extern "C" {
     #[link_name = "\u{1}_mrb_sys_gc_live_objects"]
     pub fn mrb_sys_gc_live_objects(mrb: *mut mrb_state) -> ::std::os::raw::c_int;
 }
-extern "C" {
-    #[link_name = "\u{1}_mrb_sys_class_defined_under"]
-    pub fn mrb_sys_class_defined_under(
-        mrb: *mut mrb_state,
-        outer: *mut RClass,
-        name: *const ::std::os::raw::c_char,
-    ) -> bool;
-}
 pub type __builtin_va_list = [__va_list_tag; 1usize];
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
This function is implemented in Rust using mrb_class_defined_under in class::Spec
and module::Spec in the rclass method. This code was introduced in commit
2ef570e890571e23cd6c79d519578ba2b78afd3c.