### PR TITLE
Make MrbFile::require fallible

### DIFF
--- a/foolsgold/src/foolsgold.rs
+++ b/foolsgold/src/foolsgold.rs
@@ -7,9 +7,6 @@ use mruby::load::MrbLoadSources;
 use mruby::sys::{self, DescribeState};
 use mruby::value::Value;
 use mruby::MrbError;
-use mruby::{
-    class_spec_or_raise, interpreter_or_raise, module_spec_or_raise, unwrap_value_or_raise,
-};
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::convert::AsRef;

--- a/foolsgold/src/main.rs
+++ b/foolsgold/src/main.rs
@@ -6,6 +6,8 @@
 #[macro_use]
 extern crate log;
 #[macro_use]
+extern crate mruby;
+#[macro_use]
 extern crate ref_thread_local;
 #[macro_use]
 extern crate rust_embed;

--- a/mruby/src/eval.rs
+++ b/mruby/src/eval.rs
@@ -207,7 +207,7 @@ mod tests {
         }
         struct NestedEval;
         impl MrbFile for NestedEval {
-            fn require(interp: Mrb) {
+            fn require(interp: Mrb) -> Result<(), MrbError> {
                 let spec = {
                     let mut api = interp.borrow_mut();
                     let spec = api.def_module::<Self>("NestedEval", None);
@@ -215,7 +215,8 @@ mod tests {
                         .add_self_method("file", nested_eval, sys::mrb_args_none());
                     spec
                 };
-                spec.borrow().define(&interp).expect("def method");
+                spec.borrow().define(&interp)?;
+                Ok(())
             }
         }
         let interp = Interpreter::create().expect("mrb init");

--- a/mruby/src/file.rs
+++ b/mruby/src/file.rs
@@ -1,11 +1,6 @@
 use crate::interpreter::Mrb;
 
 #[allow(clippy::module_name_repetitions)]
-pub trait MrbFile
-where
-    Self: Sized,
-{
-    fn require(interp: Mrb)
-    where
-        Self: Sized;
+pub trait MrbFile {
+    fn require(interp: Mrb);
 }

--- a/mruby/src/file.rs
+++ b/mruby/src/file.rs
@@ -1,6 +1,7 @@
 use crate::interpreter::Mrb;
+use crate::MrbError;
 
 #[allow(clippy::module_name_repetitions)]
 pub trait MrbFile {
-    fn require(interp: Mrb);
+    fn require(interp: Mrb) -> Result<(), MrbError>;
 }

--- a/mruby/src/interpreter.rs
+++ b/mruby/src/interpreter.rs
@@ -98,7 +98,7 @@ extern "C" fn require(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mr
         if let Some(require) = metadata.require {
             // dynamic, Rust-backed `MrbFile` require
             interp.push_context(context);
-            unwrap_or_raise!(require(Rc::clone(&interp)));
+            unsafe { unwrap_or_raise!(interp, require(Rc::clone(&interp)), interp.nil().inner()) };
             interp.pop_context();
         }
         let metadata = metadata.mark_required();
@@ -389,8 +389,9 @@ mod tests {
     fn require() {
         struct InterpreterRequireTest;
         impl MrbFile for InterpreterRequireTest {
-            fn require(interp: Mrb) {
-                interp.eval("@i = 255").expect("eval");
+            fn require(interp: Mrb) -> Result<(), MrbError> {
+                interp.eval("@i = 255")?;
+                Ok(())
             }
         }
 
@@ -449,8 +450,9 @@ mod tests {
     fn require_path_defined_as_source_then_mrbfile() {
         struct Foo;
         impl MrbFile for Foo {
-            fn require(interp: Mrb) {
-                interp.eval("module Foo; RUST = 7; end").expect("eval");
+            fn require(interp: Mrb) -> Result<(), MrbError> {
+                interp.eval("module Foo; RUST = 7; end")?;
+                Ok(())
             }
         }
         let interp = Interpreter::create().expect("mrb init");
@@ -473,8 +475,9 @@ mod tests {
     fn require_path_defined_as_mrbfile_then_source() {
         struct Foo;
         impl MrbFile for Foo {
-            fn require(interp: Mrb) {
-                interp.eval("module Foo; RUST = 7; end").expect("eval");
+            fn require(interp: Mrb) -> Result<(), MrbError> {
+                interp.eval("module Foo; RUST = 7; end")?;
+                Ok(())
             }
         }
         let interp = Interpreter::create().expect("mrb init");

--- a/mruby/src/interpreter.rs
+++ b/mruby/src/interpreter.rs
@@ -98,16 +98,16 @@ extern "C" fn require(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mr
         if let Some(require) = metadata.require {
             // dynamic, Rust-backed `MrbFile` require
             interp.push_context(context);
-            require(Rc::clone(&interp));
+            unwrap_or_raise!(require(Rc::clone(&interp)));
             interp.pop_context();
         }
         let metadata = metadata.mark_required();
         unsafe {
             let api = interp.borrow();
-            // TODO: fix this abuse of the `unwrap_value_or_raise` macro
-            unwrap_value_or_raise!(
+            unwrap_or_raise!(
                 interp,
-                api.vfs.set_metadata(&path, metadata).map(|_| interp.nil())
+                api.vfs.set_metadata(&path, metadata),
+                interp.nil().inner()
             );
         }
         success = true;

--- a/mruby/src/load.rs
+++ b/mruby/src/load.rs
@@ -19,7 +19,11 @@ where
     /// filesystem relative to [`RUBY_LOAD_PATH`]. If the path is absolute, the
     /// file is placed directly on the filesystem. Anscestor directories are
     /// created automatically.
-    fn def_file<T>(&self, filename: T, require: fn(Self) -> Result<(), MrbError>) -> Result<(), MrbError>
+    fn def_file<T>(
+        &self,
+        filename: T,
+        require: fn(Self) -> Result<(), MrbError>,
+    ) -> Result<(), MrbError>
     where
         T: AsRef<str>;
 
@@ -62,7 +66,11 @@ where
 }
 
 impl MrbLoadSources for Mrb {
-    fn def_file<T>(&self, filename: T, require: fn(Self) -> Result<(), MrbError>) -> Result<(), MrbError>
+    fn def_file<T>(
+        &self,
+        filename: T,
+        require: fn(Self) -> Result<(), MrbError>,
+    ) -> Result<(), MrbError>
     where
         T: AsRef<str>,
     {

--- a/mruby/src/load.rs
+++ b/mruby/src/load.rs
@@ -19,7 +19,7 @@ where
     /// filesystem relative to [`RUBY_LOAD_PATH`]. If the path is absolute, the
     /// file is placed directly on the filesystem. Anscestor directories are
     /// created automatically.
-    fn def_file<T>(&self, filename: T, require: fn(Self)) -> Result<(), MrbError>
+    fn def_file<T>(&self, filename: T, require: fn(Self) -> Result<(), MrbError>) -> Result<(), MrbError>
     where
         T: AsRef<str>;
 
@@ -62,7 +62,7 @@ where
 }
 
 impl MrbLoadSources for Mrb {
-    fn def_file<T>(&self, filename: T, require: fn(Self)) -> Result<(), MrbError>
+    fn def_file<T>(&self, filename: T, require: fn(Self) -> Result<(), MrbError>) -> Result<(), MrbError>
     where
         T: AsRef<str>,
     {

--- a/mruby/src/macros.rs
+++ b/mruby/src/macros.rs
@@ -68,7 +68,12 @@ macro_rules! unwrap_or_raise {
 #[macro_export]
 macro_rules! unwrap_value_or_raise {
     ($interp:expr, $result:expr) => {
-        unwrap_or_raise!($interp, $result, $crate::interpreter::MrbApi::nil(&$interp).inner()).inner()
+        unwrap_or_raise!(
+            $interp,
+            $result,
+            $crate::interpreter::MrbApi::nil(&$interp).inner()
+        )
+        .inner()
     };
 }
 

--- a/mruby/src/state.rs
+++ b/mruby/src/state.rs
@@ -13,10 +13,11 @@ use crate::eval::EvalContext;
 use crate::interpreter::Mrb;
 use crate::module;
 use crate::sys::{self, DescribeState};
+use crate::MrbError;
 
 #[derive(Clone, Debug)]
 pub struct VfsMetadata {
-    pub require: Option<fn(Mrb)>,
+    pub require: Option<fn(Mrb) -> Result<(), MrbError>>,
     already_required: bool,
 }
 

--- a/mruby/tests/leak_mrb_tt_data_rc.rs
+++ b/mruby/tests/leak_mrb_tt_data_rc.rs
@@ -21,6 +21,7 @@ use mruby::file::MrbFile;
 use mruby::interpreter::{Interpreter, Mrb};
 use mruby::load::MrbLoadSources;
 use mruby::sys;
+use mruby::MrbError;
 use std::cell::RefCell;
 use std::ffi::{c_void, CStr, CString};
 use std::mem;
@@ -39,7 +40,7 @@ struct Container {
 }
 
 impl MrbFile for Container {
-    fn require(interp: Mrb) {
+    fn require(interp: Mrb) -> Result<(), MrbError> {
         extern "C" fn free(_mrb: *mut sys::mrb_state, data: *mut c_void) {
             unsafe {
                 // Implictly dropped by going out of scope
@@ -78,7 +79,8 @@ impl MrbFile for Container {
             spec.borrow_mut().mrb_value_is_rust_backed(true);
             spec
         };
-        spec.borrow().define(&interp).expect("class install");
+        spec.borrow().define(&interp)?;
+        Ok(())
     }
 }
 

--- a/mruby/tests/leak_mrb_tt_data_rc.rs
+++ b/mruby/tests/leak_mrb_tt_data_rc.rs
@@ -12,13 +12,15 @@
 //! This test fails before commit
 //! `34ee3ddc1c5f4eb1d20f19dd772b0ca348391b2f` with a fairly massive leak.
 
+#[macro_use]
+extern crate mruby;
+
 use mruby::def::{ClassLike, Define};
 use mruby::eval::MrbEval;
 use mruby::file::MrbFile;
 use mruby::interpreter::{Interpreter, Mrb};
 use mruby::load::MrbLoadSources;
 use mruby::sys;
-use mruby::{class_spec_or_raise, interpreter_or_raise};
 use std::cell::RefCell;
 use std::ffi::{c_void, CStr, CString};
 use std::mem;

--- a/mruby/tests/manual.rs
+++ b/mruby/tests/manual.rs
@@ -1,5 +1,7 @@
 #[macro_use]
 extern crate log;
+#[macro_use]
+extern crate mruby;
 
 use mruby::convert::TryFromMrb;
 use mruby::def::{ClassLike, Define};
@@ -9,7 +11,6 @@ use mruby::interpreter::{Interpreter, Mrb};
 use mruby::load::MrbLoadSources;
 use mruby::sys;
 use mruby::value::Value;
-use mruby::{class_spec_or_raise, interpreter_or_raise, unwrap_value_or_raise};
 use std::cell::RefCell;
 use std::ffi::{c_void, CString};
 use std::mem;

--- a/mruby/tests/manual.rs
+++ b/mruby/tests/manual.rs
@@ -11,6 +11,7 @@ use mruby::interpreter::{Interpreter, Mrb};
 use mruby::load::MrbLoadSources;
 use mruby::sys;
 use mruby::value::Value;
+use mruby::MrbError;
 use std::cell::RefCell;
 use std::ffi::{c_void, CString};
 use std::mem;
@@ -22,7 +23,7 @@ struct Container {
 }
 
 impl MrbFile for Container {
-    fn require(interp: Mrb) {
+    fn require(interp: Mrb) -> Result<(), MrbError> {
         extern "C" fn free(_mrb: *mut sys::mrb_state, data: *mut c_void) {
             unsafe {
                 debug!("preparing to free Container instance");
@@ -90,7 +91,8 @@ impl MrbFile for Container {
             spec.borrow_mut().mrb_value_is_rust_backed(true);
             spec
         };
-        spec.borrow().define(&interp).expect("class install");
+        spec.borrow().define(&interp)?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Return `Result<(), MrbError>` from require so we don't need to `expect`.