### PR TITLE
Split nemesis request out of handler module

### DIFF
--- a/foolsgold/src/execmodel/prefork.rs
+++ b/foolsgold/src/execmodel/prefork.rs
@@ -1,7 +1,7 @@
 use mruby::gc::GarbageCollection;
 use mruby::interpreter::Mrb;
 use mruby::MrbError;
-use nemesis::handler::RackRequest;
+use nemesis::request::Request;
 use nemesis::{self, handler};
 use ref_thread_local::RefThreadLocal;
 use rocket::{get, Response};
@@ -15,7 +15,7 @@ ref_thread_local! {
 
 #[get("/fools-gold/prefork")]
 #[allow(clippy::needless_pass_by_value)]
-pub fn rack_app<'a>(req: RackRequest) -> Result<Response<'a>, Error> {
+pub fn rack_app<'a>(req: Request) -> Result<Response<'a>, Error> {
     info!("Using prefork thread local mruby interpreter");
     match *INTERPRETER.borrow() {
         Ok(ref interp) => {

--- a/foolsgold/src/execmodel/shared_nothing.rs
+++ b/foolsgold/src/execmodel/shared_nothing.rs
@@ -1,4 +1,4 @@
-use nemesis::handler::RackRequest;
+use nemesis::request::Request;
 use nemesis::{self, handler};
 use rocket::{get, Response};
 
@@ -7,7 +7,7 @@ use crate::foolsgold::RACKUP;
 
 #[get("/fools-gold")]
 #[allow(clippy::needless_pass_by_value)]
-pub fn rack_app<'a>(req: RackRequest) -> Result<Response<'a>, Error> {
+pub fn rack_app<'a>(req: Request) -> Result<Response<'a>, Error> {
     info!("Initializing fresh shared nothing mruby interpreter");
     let interp = super::interpreter()?;
     let adapter = handler::adapter_from_rackup(&interp, RACKUP)?;

--- a/nemesis/src/lib.rs
+++ b/nemesis/src/lib.rs
@@ -14,10 +14,15 @@ use rubygems::nemesis;
 pub fn init(interp: &Mrb) -> Result<(), MrbError> {
     rack::init(interp)?;
     nemesis::init(interp)?;
-    // TODO: properly implement Module#autoload and remove this hack to allow
-    // access to Rack constants defined in rack.rb.
+    // The Rack module makes heavy use of `Module#autoload` for dynamically
+    // resolving constants. For now, we don't care about this and manually
+    // require the bits of Rack we need. Create a stub implementation of
+    // `Module#autoload` that to allow the module to successfully eval on
+    // require.
+    //
+    // TODO: remove this stub once GH-12 is resolved.
     interp.eval(r#"class Module; def autoload(*args); end; end"#)?;
-    // Preload required gems
+    // Preload required gem sources
     interp.eval("require 'rack'")?;
     interp.eval("require 'rack/builder'")?;
     interp.eval("require 'nemesis/response'")?;

--- a/nemesis/src/lib.rs
+++ b/nemesis/src/lib.rs
@@ -7,6 +7,7 @@ use mruby::MrbError;
 use mruby_gems::rubygems::rack;
 
 pub mod handler;
+pub mod request;
 mod rubygems;
 
 use rubygems::nemesis;

--- a/nemesis/src/request.rs
+++ b/nemesis/src/request.rs
@@ -49,21 +49,30 @@ impl<'a> Request<'a> {
     pub fn to_env(&self, interp: &Mrb) -> Result<Value, Error> {
         // The keys in the environment hash are required by the Rack spec:
         // https://www.rubydoc.info/github/rack/rack/file/SPEC#label-The+Environment
+        //
+        // This implementation is incomplete (GH-61):
+        // TODO: Set SCRIPT_NAME from Rocket mount path.
+        // TODO: Set SERVER_NAME instead of hardcoding 'localhost'.
+        // TODO: Set SERVER_PORT instead of hardcoding it to 8000.
+        // TODO: Set HTTP_VERSION instead of hardcoding it to '1.1'.
+        // TODO: Set RACK_URL_SCHEME instead of hardcoding it to 'http'.
+        // TODO: Set RACK_INPUT and RACK_ERRORS once IO is implemented. See GH-9.
+        // TODO: RUN_ONCE should be true if in shared nothing execution mode
         interp
             .eval(format!(
                 r#"
                 {{
                     Rack::REQUEST_METHOD => '{method}',
-                    Rack::SCRIPT_NAME => '', # TODO: Rocket mount path
+                    Rack::SCRIPT_NAME => '',
                     Rack::PATH_INFO => '{path}',
                     Rack::QUERY_STRING => '{query}',
-                    Rack::SERVER_NAME => 'localhost', # TODO: set this correctly
-                    Rack::SERVER_PORT => 8000, # TODO: set this correctly
-                    Rack::HTTP_VERSION => '1.1', # TODO: set this correctly
+                    Rack::SERVER_NAME => 'localhost',
+                    Rack::SERVER_PORT => 8000,
+                    Rack::HTTP_VERSION => '1.1',
                     Rack::RACK_VERSION => Rack::VERSION,
-                    Rack::RACK_URL_SCHEME => 'http', # TODO: set this correctly
-                    Rack::RACK_INPUT => nil, # TODO: implement IO
-                    Rack::RACK_ERRORS => nil, # TODO: implement IO
+                    Rack::RACK_URL_SCHEME => 'http',
+                    Rack::RACK_INPUT => nil,
+                    Rack::RACK_ERRORS => nil,
                     Rack::RACK_MULTITHREAD => false,
                     Rack::RACK_MULTIPROCESS => false,
                     Rack::RACK_RUNONCE => false,

--- a/nemesis/src/request.rs
+++ b/nemesis/src/request.rs
@@ -1,0 +1,89 @@
+//! Convert a [`rocket::Request`] to a
+//! [Rack environment](https://www.rubydoc.info/github/rack/rack/file/SPEC#label-The+Environment).
+//!
+//! Based on
+//! [`Rack::Handler::Webrick`](https://github.com/rack/rack/blob/2.0.7/lib/rack/handler/webrick.rb).
+
+use mruby::eval::MrbEval;
+use mruby::interpreter::Mrb;
+use mruby::value::Value;
+use mruby::MrbError;
+use rocket::http::uri::Origin;
+use rocket::http::Method;
+use rocket::request::{self, FromRequest};
+use rocket::Outcome;
+use std::error;
+use std::fmt;
+
+#[derive(Debug)]
+pub enum Error {
+    Mrb(MrbError),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::Mrb(inner) => write!(f, "{}", inner),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        "nemesis rack environment error"
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match self {
+            Error::Mrb(inner) => Some(inner),
+        }
+    }
+}
+
+pub struct Request<'a> {
+    method: Method,
+    origin: Origin<'a>,
+}
+
+impl<'a> Request<'a> {
+    pub fn to_env(&self, interp: &Mrb) -> Result<Value, Error> {
+        // The keys in the environment hash are required by the Rack spec:
+        // https://www.rubydoc.info/github/rack/rack/file/SPEC#label-The+Environment
+        interp
+            .eval(format!(
+                r#"
+                {{
+                    Rack::REQUEST_METHOD => '{method}',
+                    Rack::SCRIPT_NAME => '', # TODO: Rocket mount path
+                    Rack::PATH_INFO => '{path}',
+                    Rack::QUERY_STRING => '{query}',
+                    Rack::SERVER_NAME => 'localhost', # TODO: set this correctly
+                    Rack::SERVER_PORT => 8000, # TODO: set this correctly
+                    Rack::HTTP_VERSION => '1.1', # TODO: set this correctly
+                    Rack::RACK_VERSION => Rack::VERSION,
+                    Rack::RACK_URL_SCHEME => 'http', # TODO: set this correctly
+                    Rack::RACK_INPUT => nil, # TODO: implement IO
+                    Rack::RACK_ERRORS => nil, # TODO: implement IO
+                    Rack::RACK_MULTITHREAD => false,
+                    Rack::RACK_MULTIPROCESS => false,
+                    Rack::RACK_RUNONCE => false,
+                }}
+                "#,
+                method = self.method,
+                path = self.origin.path(),
+                query = self.origin.query().unwrap_or_else(|| "")
+            ))
+            .map_err(Error::Mrb)
+    }
+}
+
+impl<'a, 'r> FromRequest<'a, 'r> for Request<'a> {
+    type Error = ();
+
+    fn from_request(request: &'a request::Request<'r>) -> request::Outcome<Self, Self::Error> {
+        Outcome::Success(Request {
+            method: request.method(),
+            origin: request.uri().clone(),
+        })
+    }
+}

--- a/nemesis/src/response.rs
+++ b/nemesis/src/response.rs
@@ -1,0 +1,167 @@
+//! Convert a
+//! [`Nemesis::Response`](https://github.com/lopopolo/ferrocarril/blob/master/nemesis/ruby/lib/nemesis/response.rb)
+//! Rack response to a [`rocket::Response`].
+//!
+//! Based on
+//! [`Rack::Response`](https://github.com/rack/rack/blob/2.0.7/lib/rack/response.rb).
+
+use log::warn;
+use mruby::class;
+use mruby::convert::TryFromMrb;
+use mruby::def::{ClassLike, Parent};
+use mruby::interpreter::Mrb;
+use mruby::module;
+use mruby::sys;
+use mruby::value::Value;
+use mruby::MrbError;
+use rocket::http::Status;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::convert::TryFrom;
+use std::error;
+use std::fmt;
+use std::rc::Rc;
+
+#[derive(Debug)]
+pub enum Error {
+    Mrb(MrbError),
+    RackResponse,
+    Status,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::Mrb(inner) => write!(f, "{}", inner),
+            Error::RackResponse => write!(f, "malformed Rack response tuple"),
+            Error::Status => write!(f, "status is not a valid HTTP status code"),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        "nemesis rack response error"
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match self {
+            Error::Mrb(inner) => Some(inner),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Response {
+    status: Status,
+    headers: HashMap<String, String>,
+    body: Vec<u8>,
+}
+
+impl Response {
+    const RACK_RESPONSE_TUPLE_LEN: usize = 3;
+
+    /// Convert from a Rack `[status, headers, body]` response tuple to a Rust
+    /// representation. This code converts a response tuple using the Ruby class
+    /// `Nemesis::Response`.
+    pub fn from(interp: &Mrb, value: Value) -> Result<Self, Error> {
+        let response = unsafe { <Vec<Value>>::try_from_mrb(interp, value) }
+            .map_err(MrbError::ConvertToRust)
+            .map_err(Error::Mrb)?;
+        if response.len() != Self::RACK_RESPONSE_TUPLE_LEN {
+            warn!(
+                "malformed rack response: {:?}",
+                response.iter().map(Value::to_s_debug).collect::<Vec<_>>()
+            );
+            return Err(Error::RackResponse);
+        }
+        let nemesis = module::Spec::new("Nemesis", None);
+        let parent = Parent::Module {
+            spec: Rc::new(RefCell::new(nemesis)),
+        };
+        let class = class::Spec::new("Response", Some(parent), None);
+        let rclass = class
+            .rclass(Rc::clone(interp))
+            .ok_or_else(|| Error::Mrb(MrbError::NotDefined(class.fqname())))?;
+        let args = response.iter().map(Value::inner).collect::<Vec<_>>();
+        // Nemesis::Response.new(status, headers, body)
+        let response = unsafe { sys::mrb_obj_new(interp.borrow().mrb, rclass, 3, args.as_ptr()) };
+        let response = Value::new(interp, response);
+        Ok(Self {
+            status: Self::status(interp, response)?,
+            headers: Self::headers(interp, response)?,
+            body: Self::body(interp, response)?,
+        })
+    }
+
+    fn status(interp: &Mrb, response: Value) -> Result<Status, Error> {
+        let accessor = "status";
+        let args = &[];
+        let status = unsafe {
+            let sym = sys::mrb_intern(
+                interp.borrow().mrb,
+                accessor.as_ptr() as *const i8,
+                accessor.len(),
+            );
+            // response.status
+            let value =
+                sys::mrb_funcall_argv(interp.borrow().mrb, response.inner(), sym, 0, args.as_ptr());
+            Value::new(interp, value)
+        };
+        let status = unsafe { i64::try_from_mrb(interp, status) }
+            .map_err(MrbError::ConvertToRust)
+            .map_err(Error::Mrb)?;
+        let status = u16::try_from(status).map_err(|_| Error::Status)?;
+        Status::from_code(status).ok_or(Error::Status)
+    }
+
+    fn headers(interp: &Mrb, response: Value) -> Result<HashMap<String, String>, Error> {
+        let accessor = "headers";
+        let args = &[];
+        let headers = unsafe {
+            let sym = sys::mrb_intern(
+                interp.borrow().mrb,
+                accessor.as_ptr() as *const i8,
+                accessor.len(),
+            );
+            // response.headers
+            let value =
+                sys::mrb_funcall_argv(interp.borrow().mrb, response.inner(), sym, 0, args.as_ptr());
+            Value::new(interp, value)
+        };
+        let pairs = unsafe { <Vec<(Value, Value)>>::try_from_mrb(interp, headers) }
+            .map_err(MrbError::ConvertToRust)
+            .map_err(Error::Mrb)?;
+        let mut headers = HashMap::new();
+        for (key, value) in pairs {
+            let key = unsafe { String::try_from_mrb(&interp, key) }
+                .map_err(MrbError::ConvertToRust)
+                .map_err(Error::Mrb)?;
+            let value = unsafe { String::try_from_mrb(&interp, value) }
+                .map_err(MrbError::ConvertToRust)
+                .map_err(Error::Mrb)?;
+            headers.insert(key, value);
+        }
+        Ok(headers)
+    }
+
+    fn body(interp: &Mrb, response: Value) -> Result<Vec<u8>, Error> {
+        let accessor = "body_bytes";
+        let args = &[];
+        let body = unsafe {
+            let sym = sys::mrb_intern(
+                interp.borrow().mrb,
+                accessor.as_ptr() as *const i8,
+                accessor.len(),
+            );
+            // response.body_bytes
+            let value =
+                sys::mrb_funcall_argv(interp.borrow().mrb, response.inner(), sym, 0, args.as_ptr());
+            Value::new(interp, value)
+        };
+        unsafe { <Vec<u8>>::try_from_mrb(interp, body) }
+            .map_err(MrbError::ConvertToRust)
+            .map_err(Error::Mrb)
+    }
+}


### PR DESCRIPTION
To make GH-54 easier (and smaller) to implement, split apart the monolithic handler module.

This has forced some refactoring around errors. The request parsing code is now broken into pieces instead of a 150 line function 💪 