### PR TITLE
Split nemesis::handler::RackResponse into its own module

### DIFF
--- a/nemesis/src/handler.rs
+++ b/nemesis/src/handler.rs
@@ -3,32 +3,22 @@
 //! Based on `Rack::Handler::Webrick`:
 //! <https://github.com/rack/rack/blob/2.0.7/lib/rack/handler/webrick.rb>
 
-use log::warn;
-use mruby::class;
-use mruby::convert::TryFromMrb;
-use mruby::def::{ClassLike, Parent};
 use mruby::eval::MrbEval;
 use mruby::interpreter::Mrb;
-use mruby::module;
 use mruby::sys;
 use mruby::value::Value;
 use mruby::MrbError;
-use rocket::http::Status;
-use rocket::Response;
-use std::cell::RefCell;
-use std::collections::HashMap;
-use std::convert::{AsRef, TryFrom};
+use std::convert::AsRef;
 use std::error;
 use std::fmt;
-use std::io::Cursor;
-use std::rc::Rc;
 
 use crate::request::{self, Request};
+use crate::response::{self, Response};
 
 #[derive(Debug)]
 pub enum Error {
     Request(request::Error),
-    Response(ResponseError),
+    Response(response::Error),
 }
 
 impl fmt::Display for Error {
@@ -53,131 +43,6 @@ impl error::Error for Error {
     }
 }
 
-#[derive(Debug)]
-struct RackResponse {
-    status: Status,
-    headers: HashMap<String, String>,
-    body: Vec<u8>,
-}
-
-#[derive(Debug)]
-pub enum ResponseError {
-    InvalidStatus,
-    Mrb(MrbError),
-    RackResponseNot3Tuple,
-}
-
-impl fmt::Display for ResponseError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            ResponseError::InvalidStatus => write!(f, "status is not a valid HTTP status code"),
-            ResponseError::Mrb(inner) => write!(f, "{}", inner),
-            ResponseError::RackResponseNot3Tuple => write!(f, "malformed Rack response tuple"),
-        }
-    }
-}
-
-impl error::Error for ResponseError {
-    fn description(&self) -> &str {
-        "nemesis rack error"
-    }
-
-    fn cause(&self) -> Option<&error::Error> {
-        match self {
-            ResponseError::Mrb(inner) => Some(inner),
-            _ => None,
-        }
-    }
-}
-
-impl RackResponse {
-    fn from(interp: &Mrb, value: Value) -> Result<Self, ResponseError> {
-        let response = unsafe { <Vec<Value>>::try_from_mrb(interp, value) }
-            .map_err(MrbError::ConvertToRust)
-            .map_err(ResponseError::Mrb)?;
-        if response.len() != 3 {
-            warn!(
-                "malformed rack response: {:?}",
-                response.iter().map(Value::to_s_debug).collect::<Vec<_>>()
-            );
-            return Err(ResponseError::RackResponseNot3Tuple);
-        }
-        let nemesis = module::Spec::new("Nemesis", None);
-        let parent = Parent::Module {
-            spec: Rc::new(RefCell::new(nemesis)),
-        };
-        let class = class::Spec::new("Response", Some(parent), None);
-        let rclass = class
-            .rclass(Rc::clone(interp))
-            .ok_or_else(|| ResponseError::Mrb(MrbError::NotDefined(class.fqname())))?;
-        let args = response.iter().map(Value::inner).collect::<Vec<_>>();
-        // Nemesis::Response.new(status, headers, body)
-        let response = unsafe { sys::mrb_obj_new(interp.borrow().mrb, rclass, 3, args.as_ptr()) };
-        let status = unsafe {
-            let accessor = "status";
-            let sym = sys::mrb_intern(
-                interp.borrow().mrb,
-                accessor.as_ptr() as *const i8,
-                accessor.len(),
-            );
-            let args = &[];
-            // response.status
-            let value = sys::mrb_funcall_argv(interp.borrow().mrb, response, sym, 0, args.as_ptr());
-            Value::new(interp, value)
-        };
-        let status = unsafe { i64::try_from_mrb(interp, status) }
-            .map_err(MrbError::ConvertToRust)
-            .map_err(ResponseError::Mrb)?;
-        let status = u16::try_from(status).map_err(|_| ResponseError::InvalidStatus)?;
-        let status = Status::from_code(status).ok_or_else(|| ResponseError::InvalidStatus)?;
-        let headers = unsafe {
-            let accessor = "headers";
-            let sym = sys::mrb_intern(
-                interp.borrow().mrb,
-                accessor.as_ptr() as *const i8,
-                accessor.len(),
-            );
-            let args = &[];
-            // response.headers
-            let value = sys::mrb_funcall_argv(interp.borrow().mrb, response, sym, 0, args.as_ptr());
-            Value::new(interp, value)
-        };
-        let header_pairs = unsafe { <Vec<(Value, Value)>>::try_from_mrb(interp, headers) }
-            .map_err(MrbError::ConvertToRust)
-            .map_err(ResponseError::Mrb)?;
-        let mut headers = HashMap::new();
-        for (key, value) in header_pairs {
-            let key = unsafe { String::try_from_mrb(&interp, key) }
-                .map_err(MrbError::ConvertToRust)
-                .map_err(ResponseError::Mrb)?;
-            let value = unsafe { String::try_from_mrb(&interp, value) }
-                .map_err(MrbError::ConvertToRust)
-                .map_err(ResponseError::Mrb)?;
-            headers.insert(key, value);
-        }
-        let body = unsafe {
-            let accessor = "body_bytes";
-            let sym = sys::mrb_intern(
-                interp.borrow().mrb,
-                accessor.as_ptr() as *const i8,
-                accessor.len(),
-            );
-            let args = &[];
-            // response.body_bytes
-            let value = sys::mrb_funcall_argv(interp.borrow().mrb, response, sym, 0, args.as_ptr());
-            Value::new(interp, value)
-        };
-        let body = unsafe { <Vec<u8>>::try_from_mrb(interp, body) }
-            .map_err(MrbError::ConvertToRust)
-            .map_err(ResponseError::Mrb)?;
-        Ok(Self {
-            status,
-            headers,
-            body,
-        })
-    }
-}
-
 pub fn adapter_from_rackup<T>(interp: &Mrb, source: T) -> Result<Value, MrbError>
 where
     T: AsRef<str>,
@@ -192,26 +57,20 @@ where
     ))
 }
 
-pub fn run<'a>(interp: &Mrb, app: &Value, request: &Request) -> Result<Response<'a>, Error> {
+pub fn run<'a>(interp: &Mrb, app: &Value, request: &Request) -> Result<rocket::Response<'a>, Error> {
+    let fun = "call";
     // build env hash that is passed to app.call
     let args = &[request.to_env(interp).map_err(Error::Request)?.inner()];
     let response = unsafe {
-        let call_str = "call";
-        let call_sym = sys::mrb_intern(
+        let sym = sys::mrb_intern(
             interp.borrow().mrb,
-            call_str.as_ptr() as *const i8,
-            call_str.len(),
+            fun.as_ptr() as *const i8,
+            fun.len(),
         );
         // app.call(env)
-        sys::mrb_funcall_argv(interp.borrow().mrb, app.inner(), call_sym, 1, args.as_ptr())
+        sys::mrb_funcall_argv(interp.borrow().mrb, app.inner(), sym, 1, args.as_ptr())
     };
     let response =
-        RackResponse::from(interp, Value::new(interp, response)).map_err(Error::Response)?;
-    let mut build = Response::build();
-    build.status(response.status);
-    build.sized_body(Cursor::new(response.body));
-    for (key, value) in &response.headers {
-        build.raw_header(key.clone(), value.clone());
-    }
-    Ok(build.finalize())
+        Response::from(interp, Value::new(interp, response)).map_err(Error::Response)?;
+    Ok(response.into_rocket())
 }

--- a/nemesis/src/handler.rs
+++ b/nemesis/src/handler.rs
@@ -1,7 +1,4 @@
-//! A Rack handler that glues together a [`rocket::Request`] and a Rack app.
-//!
-//! Based on `Rack::Handler::Webrick`:
-//! <https://github.com/rack/rack/blob/2.0.7/lib/rack/handler/webrick.rb>
+//! Run a Rack app with an environment derived from the request.
 
 use mruby::eval::MrbEval;
 use mruby::interpreter::Mrb;

--- a/nemesis/src/lib.rs
+++ b/nemesis/src/lib.rs
@@ -11,6 +11,7 @@ use mruby_gems::rubygems::rack;
 
 pub mod handler;
 pub mod request;
+pub mod response;
 mod rubygems;
 
 use rubygems::nemesis;

--- a/nemesis/src/lib.rs
+++ b/nemesis/src/lib.rs
@@ -1,3 +1,6 @@
+#![deny(warnings, intra_doc_link_resolution_failure)]
+#![deny(clippy::all, clippy::pedantic)]
+
 #[macro_use]
 extern crate rust_embed;
 

--- a/nemesis/src/response.rs
+++ b/nemesis/src/response.rs
@@ -92,12 +92,12 @@ impl Response {
             spec: Rc::new(RefCell::new(nemesis)),
         };
         let class = class::Spec::new("Response", Some(parent), None);
-        let rclass = class
+        let classptr = class
             .rclass(Rc::clone(interp))
             .ok_or_else(|| Error::Mrb(MrbError::NotDefined(class.fqname())))?;
         let args = response.iter().map(Value::inner).collect::<Vec<_>>();
         // Nemesis::Response.new(status, headers, body)
-        let response = unsafe { sys::mrb_obj_new(interp.borrow().mrb, rclass, 3, args.as_ptr()) };
+        let response = unsafe { sys::mrb_obj_new(interp.borrow().mrb, classptr, 3, args.as_ptr()) };
         let response = Value::new(interp, response);
         Ok(Self {
             status: Self::status(interp, &response)?,

--- a/nemesis/src/response.rs
+++ b/nemesis/src/response.rs
@@ -20,6 +20,7 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::error;
 use std::fmt;
+use std::io::Cursor;
 use std::rc::Rc;
 
 #[derive(Debug)]
@@ -53,7 +54,7 @@ impl error::Error for Error {
 }
 
 #[derive(Debug)]
-struct Response {
+pub struct Response {
     status: Status,
     headers: HashMap<String, String>,
     body: Vec<u8>,
@@ -61,6 +62,16 @@ struct Response {
 
 impl Response {
     const RACK_RESPONSE_TUPLE_LEN: usize = 3;
+
+    pub fn into_rocket<'a>(self) -> rocket::Response<'a> {
+        let mut response = rocket::Response::build();
+        response.status(self.status);
+        response.sized_body(Cursor::new(self.body));
+        for (key, value) in self.headers {
+            response.raw_header(key, value);
+        }
+        response.finalize()
+    }
 
     /// Convert from a Rack `[status, headers, body]` response tuple to a Rust
     /// representation. This code converts a response tuple using the Ruby class
@@ -89,13 +100,13 @@ impl Response {
         let response = unsafe { sys::mrb_obj_new(interp.borrow().mrb, rclass, 3, args.as_ptr()) };
         let response = Value::new(interp, response);
         Ok(Self {
-            status: Self::status(interp, response)?,
-            headers: Self::headers(interp, response)?,
-            body: Self::body(interp, response)?,
+            status: Self::status(interp, &response)?,
+            headers: Self::headers(interp, &response)?,
+            body: Self::body(interp, &response)?,
         })
     }
 
-    fn status(interp: &Mrb, response: Value) -> Result<Status, Error> {
+    fn status(interp: &Mrb, response: &Value) -> Result<Status, Error> {
         let accessor = "status";
         let args = &[];
         let status = unsafe {
@@ -116,7 +127,7 @@ impl Response {
         Status::from_code(status).ok_or(Error::Status)
     }
 
-    fn headers(interp: &Mrb, response: Value) -> Result<HashMap<String, String>, Error> {
+    fn headers(interp: &Mrb, response: &Value) -> Result<HashMap<String, String>, Error> {
         let accessor = "headers";
         let args = &[];
         let headers = unsafe {
@@ -146,7 +157,7 @@ impl Response {
         Ok(headers)
     }
 
-    fn body(interp: &Mrb, response: Value) -> Result<Vec<u8>, Error> {
+    fn body(interp: &Mrb, response: &Value) -> Result<Vec<u8>, Error> {
         let accessor = "body_bytes";
         let args = &[];
         let body = unsafe {


### PR DESCRIPTION
In a similar spirit of GH-60, break apart the monolithic handler module to make it easier to test and implement GH-54.

This PR adds missing deny directives to the nemsis crate and fixes some clippy violations.