### PR TITLE
Implement a funcall interface for Value-shaped things

### DIFF
--- a/mruby/src/lib.rs
+++ b/mruby/src/lib.rs
@@ -31,6 +31,7 @@ pub enum MrbError {
     New,
     NotDefined(String),
     SourceNotFound(String),
+    TooManyArgs { given: usize, max: usize },
     Uninitialized,
     UnreachableValue(sys::mrb_vtype),
     Vfs(io::Error),
@@ -54,6 +55,11 @@ impl fmt::Display for MrbError {
             MrbError::New => write!(f, "failed to create mrb interpreter"),
             MrbError::NotDefined(fqname) => write!(f, "{} not defined", fqname),
             MrbError::SourceNotFound(source) => write!(f, "Could not load Ruby source {}", source),
+            MrbError::TooManyArgs { given, max } => write!(
+                f,
+                "Too many args for funcall. Gave {}, but max is {}",
+                given, max
+            ),
             MrbError::Uninitialized => write!(f, "mrb interpreter not initialized"),
             MrbError::UnreachableValue(tt) => {
                 write!(f, "extracted unreachable type {:?} from interpreter", tt)

--- a/mruby/src/value/mod.rs
+++ b/mruby/src/value/mod.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use crate::convert::TryFromMrb;
+use crate::convert::{FromMrb, TryFromMrb};
 use crate::gc::GarbageCollection;
 use crate::interpreter::Mrb;
 use crate::sys;
@@ -76,6 +76,16 @@ impl Value {
         debug
     }
 }
+
+impl FromMrb<Value> for Value {
+    type From = types::Ruby;
+    type To = types::Rust;
+
+    fn from_mrb(_interp: &Mrb, value: Self) -> Self {
+        value
+    }
+}
+
 
 #[cfg(test)]
 mod tests {

--- a/mruby/src/value/mod.rs
+++ b/mruby/src/value/mod.rs
@@ -1,3 +1,4 @@
+use log::{trace, warn};
 use std::convert::TryFrom;
 use std::rc::Rc;
 
@@ -30,12 +31,18 @@ where
         let arena = self.interp().create_arena_savepoint();
         let args = args.as_ref().iter().map(Value::inner).collect::<Vec<_>>();
         if args.len() > Self::MRB_FUNCALL_ARGC_MAX {
+            warn!(
+                "Too many args supplied to funcall: given {}, max {}.",
+                args.len(),
+                Self::MRB_FUNCALL_ARGC_MAX
+            );
             return Err(MrbError::TooManyArgs {
                 given: args.len(),
                 max: Self::MRB_FUNCALL_ARGC_MAX,
             });
         }
         let method = method.as_ref();
+        trace!("Calling {}#{}", types::Ruby::from(self.inner()), method);
         // Scope the borrow so because we might require a borrow_mut in Rust
         // code we call into via the Ruby VM.
         let mrb = { self.interp().borrow().mrb };

--- a/mruby/src/value/mod.rs
+++ b/mruby/src/value/mod.rs
@@ -25,10 +25,10 @@ where
     where
         T: TryFromMrb<Value, From = types::Ruby, To = types::Rust>,
         M: AsRef<str>,
-        A: AsRef<[Self]>,
+        A: AsRef<[Value]>,
     {
         let arena = self.interp().create_arena_savepoint();
-        let args = args.as_ref().iter().map(Self::inner).collect::<Vec<_>>();
+        let args = args.as_ref().iter().map(Value::inner).collect::<Vec<_>>();
         if args.len() > Self::MRB_FUNCALL_ARGC_MAX {
             return Err(MrbError::TooManyArgs {
                 given: args.len(),
@@ -141,7 +141,6 @@ impl FromMrb<Value> for Value {
         value
     }
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -398,5 +397,14 @@ mod tests {
             .funcall::<Vec<String>, _, _>("split", &[delim])
             .expect("split");
         assert_eq!(split, vec!["f".to_owned(), "o".to_owned(), "o".to_owned()])
+    }
+
+    #[test]
+    fn funcall_different_types() {
+        let interp = Interpreter::create().expect("mrb init");
+        let nil = interp.nil();
+        let s = interp.string("foo");
+        let eql = nil.funcall::<bool, _, _>("==", &[s]);
+        assert_eq!(eql, Ok(false));
     }
 }

--- a/mruby/tests/leak_funcall.rs
+++ b/mruby/tests/leak_funcall.rs
@@ -1,0 +1,37 @@
+//! This integration test checks for memory leaks that stem from improper
+//! arena handling in `ValueLike::funcall`.
+//!
+//! Checks for memory leaks stemming from improperly grabage collecting Ruby
+//! objects created in C functions, like the call to `sys::mrb_funcall_argv`.
+//!
+//! This test creates a 1MB Ruby string and calls `dup` in a loop. The test
+//! reuses one mruby interpreter for all `ITERATIONS`.
+//!
+//! If resident memory increases more than 10MB during the test, we likely are
+//! leaking memory.
+
+use mruby::gc::GarbageCollection;
+use mruby::interpreter::{Interpreter, MrbApi};
+use mruby::value::ValueLike;
+
+mod leak;
+
+use leak::LeakDetector;
+
+const ITERATIONS: usize = 100;
+const LEAK_TOLERANCE: i64 = 1024 * 1024 * 30;
+
+#[test]
+fn funcall_arena() {
+    let interp = Interpreter::create().expect("mrb init");
+    let s = interp.string("a".repeat(1024 * 1024));
+
+    LeakDetector::new("current exception", ITERATIONS, LEAK_TOLERANCE).check_leaks(|_| {
+        let expected = format!(r#""{}""#, "a".repeat(1024 * 1024));
+        // we have to call a function that calls into the Ruby VM, so we can't
+        // just use `to_s`.
+        let inspect = s.funcall::<String, _, _>("inspect", &[]);
+        assert_eq!(inspect, Ok(expected));
+        interp.incremental_gc();
+    });
+}

--- a/mruby/tests/leak_funcall.rs
+++ b/mruby/tests/leak_funcall.rs
@@ -26,7 +26,7 @@ fn funcall_arena() {
     let interp = Interpreter::create().expect("mrb init");
     let s = interp.string("a".repeat(1024 * 1024));
 
-    LeakDetector::new("current exception", ITERATIONS, LEAK_TOLERANCE).check_leaks(|_| {
+    LeakDetector::new("ValueLike::funcall", ITERATIONS, LEAK_TOLERANCE).check_leaks(|_| {
         let expected = format!(r#""{}""#, "a".repeat(1024 * 1024));
         // we have to call a function that calls into the Ruby VM, so we can't
         // just use `to_s`.


### PR DESCRIPTION
Add a `ValueLike` trait to encapsulate all mutable wrappers, see GH-17. Implement a default `funcall` method that delegates to `sys::mrb_funcall_argv`. This function properly manages the arena to prevent leaks (see integration test). This function handles converting results to any type that implements `TryFromMrb`.

Fixes GH-66.
Fixes GH-46.
Partial implementation for GH-43.