### PR TITLE
Return previous GC state when enabling and disabling mruby GC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,7 +410,7 @@ dependencies = [
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "mruby-sys 2.0.1-sys.3.c078758",
+ "mruby-sys 2.0.1-sys.4.c078758",
  "mruby-vfs 0.5.0-alpha",
  "quickcheck 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck_macros 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -435,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "mruby-sys"
-version = "2.0.1-sys.3.c078758"
+version = "2.0.1-sys.4.c078758"
 dependencies = [
  "bindgen 0.49.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/mruby-sys/Cargo.toml
+++ b/mruby-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mruby-sys"
-version = "2.0.1-sys.3.c078758"
+version = "2.0.1-sys.4.c078758"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 links = "mruby"

--- a/mruby-sys/mruby-sys/include/mruby-sys/ext.h
+++ b/mruby-sys/mruby-sys/include/mruby-sys/ext.h
@@ -120,9 +120,15 @@ int mrb_sys_gc_arena_save(mrb_state *mrb);
  */
 void mrb_sys_gc_arena_restore(mrb_state *mrb, int arena_index);
 
-void mrb_sys_gc_disable(mrb_state *mrb);
+/**
+ * Disable GC. Returns previous enabled state.
+ */
+_Bool mrb_sys_gc_disable(mrb_state *mrb);
 
-void mrb_sys_gc_enable(mrb_state *mrb);
+/**
+ * Enable GC. Returns previous enabled state.
+ */
+_Bool mrb_sys_gc_enable(mrb_state *mrb);
 
 _Bool mrb_sys_value_is_dead(mrb_state *_mrb, mrb_value value);
 

--- a/mruby-sys/mruby-sys/src/mruby-sys/ext.c
+++ b/mruby-sys/mruby-sys/src/mruby-sys/ext.c
@@ -164,14 +164,18 @@ void mrb_sys_gc_arena_restore(mrb_state *mrb, int arena_index) {
   mrb_gc_arena_restore(mrb, arena_index);
 }
 
-void mrb_sys_gc_disable(mrb_state *mrb) {
+_Bool mrb_sys_gc_disable(mrb_state *mrb) {
   mrb_gc *gc = &mrb->gc;
+  _Bool was_enabled = !gc->disabled;
   gc->disabled = 1;
+  return was_enabled;
 }
 
-void mrb_sys_gc_enable(mrb_state *mrb) {
+_Bool mrb_sys_gc_enable(mrb_state *mrb) {
   mrb_gc *gc = &mrb->gc;
+  _Bool was_enabled = !gc->disabled;
   gc->disabled = 0;
+  return was_enabled;
 }
 
 _Bool mrb_sys_value_is_dead(mrb_state *mrb, mrb_value value) {

--- a/mruby-sys/src/ffi.rs
+++ b/mruby-sys/src/ffi.rs
@@ -3774,11 +3774,11 @@ extern "C" {
 }
 extern "C" {
     #[link_name = "\u{1}_mrb_sys_gc_disable"]
-    pub fn mrb_sys_gc_disable(mrb: *mut mrb_state);
+    pub fn mrb_sys_gc_disable(mrb: *mut mrb_state) -> bool;
 }
 extern "C" {
     #[link_name = "\u{1}_mrb_sys_gc_enable"]
-    pub fn mrb_sys_gc_enable(mrb: *mut mrb_state);
+    pub fn mrb_sys_gc_enable(mrb: *mut mrb_state) -> bool;
 }
 extern "C" {
     #[link_name = "\u{1}_mrb_sys_value_is_dead"]

--- a/mruby/src/gc.rs
+++ b/mruby/src/gc.rs
@@ -39,9 +39,13 @@ pub trait GarbageCollection {
 
     fn full_gc(&self);
 
-    fn enable_gc(&self);
+    /// Enable garbage collection. Returns true if GC was enabled, false
+    /// otherwise.
+    fn enable_gc(&self) -> bool;
 
-    fn disable_gc(&self);
+    /// Disable garbage collection. Returns true if GC was enabled, false
+    /// otherwise.
+    fn disable_gc(&self) -> bool;
 }
 
 impl GarbageCollection for Mrb {
@@ -68,12 +72,12 @@ impl GarbageCollection for Mrb {
         unsafe { sys::mrb_full_gc(self.borrow().mrb) };
     }
 
-    fn enable_gc(&self) {
-        unsafe { sys::mrb_sys_gc_enable(self.borrow().mrb) };
+    fn enable_gc(&self) -> bool {
+        unsafe { sys::mrb_sys_gc_enable(self.borrow().mrb) }
     }
 
-    fn disable_gc(&self) {
-        unsafe { sys::mrb_sys_gc_disable(self.borrow().mrb) };
+    fn disable_gc(&self) -> bool {
+        unsafe { sys::mrb_sys_gc_disable(self.borrow().mrb) }
     }
 }
 


### PR DESCRIPTION
This commit bumps the mruby-sys version.

This is useful if you want to temporarily disable the GC and restore it to its previous enabled state.