### PR TITLE
Implement nemesis crate with funcall interface

### DIFF
--- a/foolsgold/src/execmodel/prefork.rs
+++ b/foolsgold/src/execmodel/prefork.rs
@@ -19,8 +19,8 @@ pub fn rack_app<'a>(req: Request) -> Result<Response<'a>, Error> {
     info!("Using prefork thread local mruby interpreter");
     match *INTERPRETER.borrow() {
         Ok(ref interp) => {
-            let adapter = adapter::from_rackup(&interp, RACKUP)?;
             let arena = interp.create_arena_savepoint();
+            let adapter = adapter::from_rackup(&interp, RACKUP)?;
             let response = handler::run(interp, &adapter, &req)?;
             arena.restore();
             interp.incremental_gc();

--- a/foolsgold/src/foolsgold.rs
+++ b/foolsgold/src/foolsgold.rs
@@ -103,9 +103,11 @@ impl MrbFile for Counter {
 
         let spec = {
             let mut api = interp.borrow_mut();
-            let spec = api.module_spec::<FoolsGold>().expect("Metrics not defined");
+            let parent = api
+                .module_spec::<FoolsGold>()
+                .ok_or(MrbError::NotDefined("FoolsGold".to_owned()))?;
             let parent = Parent::Module {
-                spec: Rc::clone(&spec),
+                spec: Rc::clone(&parent),
             };
             let spec = api.def_class::<Self>("Counter", Some(parent), None);
             spec.borrow_mut()

--- a/foolsgold/src/foolsgold.rs
+++ b/foolsgold/src/foolsgold.rs
@@ -43,7 +43,8 @@ impl FoolsGold {
 
 impl MrbFile for FoolsGold {
     fn require(interp: Mrb) -> Result<(), MrbError> {
-        interp.borrow_mut().def_module::<Self>("FoolsGold", None);
+        let module = interp.borrow_mut().def_module::<Self>("FoolsGold", None);
+        module.borrow().define(&interp)?;
         interp.eval("require 'foolsgold/ext/stats'")?;
         interp.eval("require 'foolsgold/metrics'")?;
         interp.eval("require 'foolsgold/ext/counter'")?;
@@ -132,9 +133,10 @@ impl MrbFile for Metrics {
         let parent = Parent::Module {
             spec: Rc::clone(&parent),
         };
-        interp
+        let spec = interp
             .borrow_mut()
             .def_module::<Self>("Metrics", Some(parent));
+        spec.borrow().define(&interp)?;
         Ok(())
     }
 }

--- a/mruby-gems/src/lib.rs
+++ b/mruby-gems/src/lib.rs
@@ -13,3 +13,62 @@ pub trait Gem {
     /// Initialize a gem in the [`Mrb`] interpreter.
     fn init(interp: &Mrb) -> Result<(), MrbError>;
 }
+
+#[cfg(test)]
+mod tests {
+    use mruby::def::Parent;
+    use mruby::eval::MrbEval;
+    use mruby::file::MrbFile;
+    use mruby::interpreter::{Interpreter, Mrb};
+    use mruby::load::MrbLoadSources;
+    use mruby::MrbError;
+    use std::rc::Rc;
+
+    use crate::Gem;
+
+    struct Foo;
+
+    impl Gem for Foo {
+        fn init(interp: &Mrb) -> Result<(), MrbError> {
+            interp
+                .def_rb_source_file("foo.rb", "require 'foo/bar'; module Foo; CONST = 10; end")?;
+            interp
+                .def_rb_source_file("foo/bar.rb", "module Foo; module Bar; CONST = 10; end; end")?;
+            interp.def_file_for_type::<_, Foo>("foo.rb")?;
+            interp.def_file_for_type::<_, Bar>("foo/bar.rb")?;
+            Ok(())
+        }
+    }
+
+    impl MrbFile for Foo {
+        fn require(interp: Mrb) -> Result<(), MrbError> {
+            interp.borrow_mut().def_module::<Self>("Foo", None);
+            Ok(())
+        }
+    }
+
+    struct Bar;
+
+    impl MrbFile for Bar {
+        fn require(interp: Mrb) -> Result<(), MrbError> {
+            let parent = interp
+                .borrow()
+                .module_spec::<Foo>()
+                .ok_or(MrbError::NotDefined("Foo".to_owned()))?;
+            let parent = Parent::Module {
+                spec: Rc::clone(&parent),
+            };
+            interp
+                .borrow_mut()
+                .def_class::<Self>("Bar", Some(parent), None);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn require_mrbfile_before_sources() {
+        let interp = Interpreter::create().expect("mrb init");
+        Foo::init(&interp).expect("gem init");
+        assert_eq!(interp.eval("require 'foo'").map(|_| ()), Ok(()));
+    }
+}

--- a/nemesis/ruby/lib/nemesis/response.rb
+++ b/nemesis/ruby/lib/nemesis/response.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+# Based on `Rack::Response`
+# https://github.com/rack/rack/blob/2.0.7/lib/rack/response.rb
+# Copyright (c) 2007-2016 Christian Neukirchen <purl.org/net/chneukirchen>
+# MIT License
+
 module Nemesis
   class Response
     attr_accessor :length, :status, :body
@@ -18,7 +23,7 @@ module Nemesis
 
       @body = []
 
-      if body.respond_to? :to_str
+      if body.respond_to?(:to_str)
         write body.to_str
       elsif body.respond_to?(:each)
         body.each do |part|
@@ -39,7 +44,7 @@ module Nemesis
       @length += s.size
       @writer.call s
 
-      set_header(Rack::CONTENT_LENGTH, @length.to_s)
+      set_header(Rack::CONTENT_LENGTH, @length)
       str
     end
 
@@ -48,11 +53,7 @@ module Nemesis
     end
 
     def set_header(key, value)
-      headers[key] = value
-    end
-
-    def body_bytes
-      @body.join
+      headers[key.to_s] = value.to_s
     end
   end
 end

--- a/nemesis/src/handler.rs
+++ b/nemesis/src/handler.rs
@@ -1,8 +1,7 @@
 //! Run a Rack app with an environment derived from the request.
 
 use mruby::interpreter::Mrb;
-use mruby::sys;
-use mruby::value::Value;
+use mruby::value::{Value, ValueLike};
 use std::error;
 use std::fmt;
 
@@ -37,19 +36,27 @@ impl error::Error for Error {
     }
 }
 
+impl From<request::Error> for Error {
+    fn from(error: request::Error) -> Self {
+        Error::Request(error)
+    }
+}
+
+impl From<response::Error> for Error {
+    fn from(error: response::Error) -> Self {
+        Error::Response(error)
+    }
+}
+
 pub fn run<'a>(
     interp: &Mrb,
     app: &Value,
     request: &Request,
 ) -> Result<rocket::Response<'a>, Error> {
-    let fun = "call";
-    // build env hash that is passed to app.call
-    let args = &[request.to_env(interp).map_err(Error::Request)?.inner()];
-    let response = unsafe {
-        let sym = sys::mrb_intern(interp.borrow().mrb, fun.as_ptr() as *const i8, fun.len());
-        // app.call(env)
-        sys::mrb_funcall_argv(interp.borrow().mrb, app.inner(), sym, 1, args.as_ptr())
-    };
-    let response = Response::from(interp, Value::new(interp, response)).map_err(Error::Response)?;
+    let args = &[request.to_env(interp)?];
+    let response = app
+        .funcall::<Value, _, _>("call", args)
+        .map_err(response::Error::Mrb)?;
+    let response = Response::from(interp, response)?;
     Ok(response.into_rocket())
 }

--- a/nemesis/src/handler.rs
+++ b/nemesis/src/handler.rs
@@ -57,7 +57,7 @@ pub fn run<'a>(
     let _arena = interp.create_arena_savepoint();
     let args = &[request.to_env(interp)?];
     let response = app
-        .funcall::<Value, _, _>("call", args)
+        .funcall::<Vec<Value>, _, _>("call", args)
         .map_err(response::Error::Mrb)?;
     let response = Response::from(interp, response)?;
     Ok(response.into_rocket())

--- a/nemesis/src/handler.rs
+++ b/nemesis/src/handler.rs
@@ -1,5 +1,6 @@
 //! Run a Rack app with an environment derived from the request.
 
+use mruby::gc::GarbageCollection;
 use mruby::interpreter::Mrb;
 use mruby::value::{Value, ValueLike};
 use std::error;
@@ -53,6 +54,7 @@ pub fn run<'a>(
     app: &Value,
     request: &Request,
 ) -> Result<rocket::Response<'a>, Error> {
+    let _arena = interp.create_arena_savepoint();
     let args = &[request.to_env(interp)?];
     let response = app
         .funcall::<Value, _, _>("call", args)

--- a/nemesis/src/lib.rs
+++ b/nemesis/src/lib.rs
@@ -30,6 +30,7 @@ pub fn init(interp: &Mrb) -> Result<(), MrbError> {
     // Preload required gem sources
     interp.eval("require 'rack'")?;
     interp.eval("require 'rack/builder'")?;
+    interp.eval("require 'nemesis'")?;
     interp.eval("require 'nemesis/response'")?;
     Ok(())
 }

--- a/nemesis/src/response.rs
+++ b/nemesis/src/response.rs
@@ -6,7 +6,6 @@
 //! [`Rack::Response`](https://github.com/rack/rack/blob/2.0.7/lib/rack/response.rb).
 
 use log::warn;
-use mruby::convert::TryFromMrb;
 use mruby::def::ClassLike;
 use mruby::interpreter::Mrb;
 use mruby::sys;
@@ -81,10 +80,7 @@ impl Response {
     /// Convert from a Rack `[status, headers, body]` response tuple to a Rust
     /// representation. This code converts a response tuple using the Ruby class
     /// `Nemesis::Response`.
-    pub fn from(interp: &Mrb, value: Value) -> Result<Self, Error> {
-        let response = unsafe { <Vec<Value>>::try_from_mrb(interp, value) }
-            .map_err(MrbError::ConvertToRust)
-            .map_err(Error::Mrb)?;
+    pub fn from(interp: &Mrb, response: Vec<Value>) -> Result<Self, Error> {
         if response.len() != Self::RACK_RESPONSE_TUPLE_LEN {
             warn!(
                 "malformed rack response: {:?}",

--- a/nemesis/src/response.rs
+++ b/nemesis/src/response.rs
@@ -6,22 +6,21 @@
 //! [`Rack::Response`](https://github.com/rack/rack/blob/2.0.7/lib/rack/response.rb).
 
 use log::warn;
-use mruby::class;
 use mruby::convert::TryFromMrb;
-use mruby::def::{ClassLike, Parent};
+use mruby::def::ClassLike;
 use mruby::interpreter::Mrb;
-use mruby::module;
 use mruby::sys;
-use mruby::value::Value;
+use mruby::value::{Value, ValueLike};
 use mruby::MrbError;
 use rocket::http::Status;
-use std::cell::RefCell;
 use std::collections::HashMap;
-use std::convert::TryFrom;
+use std::convert::{self, TryFrom};
 use std::error;
 use std::fmt;
 use std::io::Cursor;
 use std::rc::Rc;
+
+use crate::nemesis;
 
 #[derive(Debug)]
 pub enum Error {
@@ -50,6 +49,12 @@ impl error::Error for Error {
             Error::Mrb(inner) => Some(inner),
             _ => None,
         }
+    }
+}
+
+impl From<MrbError> for Error {
+    fn from(error: MrbError) -> Self {
+        Error::Mrb(error)
     }
 }
 
@@ -87,92 +92,38 @@ impl Response {
             );
             return Err(Error::RackResponse);
         }
-        let nemesis = module::Spec::new("Nemesis", None);
-        let parent = Parent::Module {
-            spec: Rc::new(RefCell::new(nemesis)),
-        };
-        let class = class::Spec::new("Response", Some(parent), None);
-        let classptr = class
-            .rclass(Rc::clone(interp))
-            .ok_or_else(|| Error::Mrb(MrbError::NotDefined(class.fqname())))?;
-        let args = response.iter().map(Value::inner).collect::<Vec<_>>();
-        // Nemesis::Response.new(status, headers, body)
-        let response = unsafe { sys::mrb_obj_new(interp.borrow().mrb, classptr, 3, args.as_ptr()) };
-        let response = Value::new(interp, response);
+        let classptr = interp
+            .borrow()
+            .class_spec::<nemesis::Response>()
+            .and_then(|spec| spec.borrow().rclass(Rc::clone(interp)))
+            .ok_or_else(|| Error::Mrb(MrbError::NotDefined("Nemesis::Response".to_owned())))?;
+        let class = unsafe { sys::mrb_sys_class_value(classptr) };
+        let class = Value::new(interp, class);
+        let response = class.funcall::<Value, _, _>("new", response)?;
         Ok(Self {
-            status: Self::status(interp, &response)?,
-            headers: Self::headers(interp, &response)?,
-            body: Self::body(interp, &response)?,
+            status: Self::status(&response)?,
+            headers: Self::headers(&response)?,
+            body: Self::body(&response)?,
         })
     }
 
-    fn status(interp: &Mrb, response: &Value) -> Result<Status, Error> {
-        let accessor = "status";
-        let args = &[];
-        let status = unsafe {
-            let sym = sys::mrb_intern(
-                interp.borrow().mrb,
-                accessor.as_ptr() as *const i8,
-                accessor.len(),
-            );
-            // response.status
-            let value =
-                sys::mrb_funcall_argv(interp.borrow().mrb, response.inner(), sym, 0, args.as_ptr());
-            Value::new(interp, value)
-        };
-        let status = unsafe { i64::try_from_mrb(interp, status) }
-            .map_err(MrbError::ConvertToRust)
-            .map_err(Error::Mrb)?;
+    fn status(response: &Value) -> Result<Status, Error> {
+        let status = response.funcall::<i64, _, _>("status", &[])?;
         let status = u16::try_from(status).map_err(|_| Error::Status)?;
         Status::from_code(status).ok_or(Error::Status)
     }
 
-    fn headers(interp: &Mrb, response: &Value) -> Result<HashMap<String, String>, Error> {
-        let accessor = "headers";
-        let args = &[];
-        let headers = unsafe {
-            let sym = sys::mrb_intern(
-                interp.borrow().mrb,
-                accessor.as_ptr() as *const i8,
-                accessor.len(),
-            );
-            // response.headers
-            let value =
-                sys::mrb_funcall_argv(interp.borrow().mrb, response.inner(), sym, 0, args.as_ptr());
-            Value::new(interp, value)
-        };
-        let pairs = unsafe { <Vec<(Value, Value)>>::try_from_mrb(interp, headers) }
-            .map_err(MrbError::ConvertToRust)
-            .map_err(Error::Mrb)?;
-        let mut headers = HashMap::new();
-        for (key, value) in pairs {
-            let key = unsafe { String::try_from_mrb(&interp, key) }
-                .map_err(MrbError::ConvertToRust)
-                .map_err(Error::Mrb)?;
-            let value = unsafe { String::try_from_mrb(&interp, value) }
-                .map_err(MrbError::ConvertToRust)
-                .map_err(Error::Mrb)?;
-            headers.insert(key, value);
-        }
+    fn headers(response: &Value) -> Result<HashMap<String, String>, Error> {
+        let headers = response.funcall::<HashMap<String, String>, _, _>("headers", &[])?;
         Ok(headers)
     }
 
-    fn body(interp: &Mrb, response: &Value) -> Result<Vec<u8>, Error> {
-        let accessor = "body_bytes";
-        let args = &[];
-        let body = unsafe {
-            let sym = sys::mrb_intern(
-                interp.borrow().mrb,
-                accessor.as_ptr() as *const i8,
-                accessor.len(),
-            );
-            // response.body_bytes
-            let value =
-                sys::mrb_funcall_argv(interp.borrow().mrb, response.inner(), sym, 0, args.as_ptr());
-            Value::new(interp, value)
-        };
-        unsafe { <Vec<u8>>::try_from_mrb(interp, body) }
-            .map_err(MrbError::ConvertToRust)
-            .map_err(Error::Mrb)
+    fn body(response: &Value) -> Result<Vec<u8>, Error> {
+        let parts = response.funcall::<Vec<Vec<u8>>, _, _>("body", &[])?;
+        let bytes = parts
+            .into_iter()
+            .flat_map(convert::identity)
+            .collect::<Vec<_>>();
+        Ok(bytes)
     }
 }


### PR DESCRIPTION
- Implement `nemesis::handler::run` with `funcall`.
- Implement `nemesis::response::Response::from` with `funcall`.
- Fix a leak in prefork adapter creation code.
- Alter `Kernel#require` to require Rust `MrbFile` implementations before Ruby sources because Ruby sources can require arbitrary (Rust-backed) files that might depend on the module and class defs created in the `MrbFile` impl.
- Add license and copyright to `Nemesis::Response` Ruby source.

This PR reduces the number of `unsafe` blocks in `nemesis` crate from 11 to 1.
This PR reduces the usage of `mruby::sys` in `nemesis` crate from 9 to 1.