### PR TITLE
Clean up the API for class and module specs

### DIFF
--- a/foolsgold/src/foolsgold.rs
+++ b/foolsgold/src/foolsgold.rs
@@ -198,9 +198,11 @@ impl MrbFile for RequestContext {
         extern "C" fn metrics(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
             let interp = unsafe { interpreter_or_raise!(mrb) };
             let spec = unsafe { module_spec_or_raise!(interp, Metrics) };
-            let rclass = spec.borrow().rclass(&interp);
-            unsafe { rclass.map(|cls| sys::mrb_sys_class_value(cls)) }
-                .unwrap_or_else(|| interp.nil().inner())
+            let borrow = spec.borrow();
+            borrow
+                .value(&interp)
+                .unwrap_or_else(|| interp.nil())
+                .inner()
         }
 
         let spec = {

--- a/foolsgold/src/foolsgold.rs
+++ b/foolsgold/src/foolsgold.rs
@@ -198,7 +198,7 @@ impl MrbFile for RequestContext {
         extern "C" fn metrics(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
             let interp = unsafe { interpreter_or_raise!(mrb) };
             let spec = unsafe { module_spec_or_raise!(interp, Metrics) };
-            let rclass = spec.borrow().rclass(Rc::clone(&interp));
+            let rclass = spec.borrow().rclass(&interp);
             unsafe { rclass.map(|cls| sys::mrb_sys_class_value(cls)) }
                 .unwrap_or_else(|| interp.nil().inner())
         }

--- a/mruby/src/class.rs
+++ b/mruby/src/class.rs
@@ -10,6 +10,7 @@ use crate::def::{ClassLike, Define, Free, Method, Parent};
 use crate::interpreter::Mrb;
 use crate::method;
 use crate::sys;
+use crate::value::Value;
 use crate::MrbError;
 
 pub struct Spec {
@@ -41,6 +42,12 @@ impl Spec {
             super_class: None,
             is_mrb_tt_data: false,
         }
+    }
+
+    pub fn value(&self, interp: &Mrb) -> Option<Value> {
+        let rclass = self.rclass(interp)?;
+        let module = unsafe { sys::mrb_sys_class_value(rclass) };
+        Some(Value::new(interp, module))
     }
 
     pub fn data_type(&self) -> &sys::mrb_data_type {

--- a/mruby/src/def.rs
+++ b/mruby/src/def.rs
@@ -22,7 +22,7 @@ pub enum Parent {
 }
 
 impl Parent {
-    pub fn rclass(&self, interp: Mrb) -> Option<*mut sys::RClass> {
+    pub fn rclass(&self, interp: &Mrb) -> Option<*mut sys::RClass> {
         match self {
             Parent::Class { spec } => spec.borrow().rclass(interp),
             Parent::Module { spec } => spec.borrow().rclass(interp),
@@ -86,7 +86,7 @@ where
 
     fn parent(&self) -> Option<Parent>;
 
-    fn rclass(&self, interp: Mrb) -> Option<*mut sys::RClass>;
+    fn rclass(&self, interp: &Mrb) -> Option<*mut sys::RClass>;
 
     fn fqname(&self) -> String {
         if let Some(parent) = self.parent() {

--- a/mruby/src/module.rs
+++ b/mruby/src/module.rs
@@ -8,6 +8,7 @@ use crate::def::{ClassLike, Define, Method, Parent};
 use crate::interpreter::Mrb;
 use crate::method;
 use crate::sys;
+use crate::value::Value;
 use crate::MrbError;
 
 pub struct Spec {
@@ -29,6 +30,12 @@ impl Spec {
             methods: HashSet::new(),
             parent,
         }
+    }
+
+    pub fn value(&self, interp: &Mrb) -> Option<Value> {
+        let rclass = self.rclass(interp)?;
+        let module = unsafe { sys::mrb_sys_module_value(rclass) };
+        Some(Value::new(interp, module))
     }
 }
 

--- a/nemesis/src/lib.rs
+++ b/nemesis/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(warnings, intra_doc_link_resolution_failure)]
 #![deny(clippy::all, clippy::pedantic)]
+#![forbid(unsafe_code)]
 
 #[macro_use]
 extern crate rust_embed;

--- a/nemesis/src/response.rs
+++ b/nemesis/src/response.rs
@@ -17,7 +17,6 @@ use std::convert::{self, TryFrom};
 use std::error;
 use std::fmt;
 use std::io::Cursor;
-use std::rc::Rc;
 
 use crate::nemesis;
 
@@ -91,7 +90,7 @@ impl Response {
         let classptr = interp
             .borrow()
             .class_spec::<nemesis::Response>()
-            .and_then(|spec| spec.borrow().rclass(Rc::clone(interp)))
+            .and_then(|spec| spec.borrow().rclass(interp))
             .ok_or_else(|| Error::Mrb(MrbError::NotDefined("Nemesis::Response".to_owned())))?;
         let class = unsafe { sys::mrb_sys_class_value(classptr) };
         let class = Value::new(interp, class);

--- a/nemesis/src/response.rs
+++ b/nemesis/src/response.rs
@@ -6,9 +6,7 @@
 //! [`Rack::Response`](https://github.com/rack/rack/blob/2.0.7/lib/rack/response.rb).
 
 use log::warn;
-use mruby::def::ClassLike;
 use mruby::interpreter::Mrb;
-use mruby::sys;
 use mruby::value::{Value, ValueLike};
 use mruby::MrbError;
 use rocket::http::Status;
@@ -87,13 +85,11 @@ impl Response {
             );
             return Err(Error::RackResponse);
         }
-        let classptr = interp
+        let class = interp
             .borrow()
             .class_spec::<nemesis::Response>()
-            .and_then(|spec| spec.borrow().rclass(interp))
+            .and_then(|spec| spec.borrow().value(interp))
             .ok_or_else(|| Error::Mrb(MrbError::NotDefined("Nemesis::Response".to_owned())))?;
-        let class = unsafe { sys::mrb_sys_class_value(classptr) };
-        let class = Value::new(interp, class);
         let response = class.funcall::<Value, _, _>("new", response)?;
         Ok(Self {
             status: Self::status(&response)?,


### PR DESCRIPTION
- Simplify `ClassLike::rclass` calls by taking `&Mrb`.
- Add `class::Spec::value` which turns the spec's `RClass *` into a `Value` with ruby type `Ruby::Class`.
- Add `module::Spec::value` which turns the spec's `RClass *` into a `Value` with ruby type `Ruby::Module`.

Use the new `value` APIs in nemesis and foolsgold crates.

nemesis now has no unsafe code and I have added `#![forbid(unsafe_code)]` to `nemesis/src/lib.rs`.