### PR TITLE
Infallible converters from HashMap to Value

### DIFF
--- a/mruby/src/convert/hash.rs
+++ b/mruby/src/convert/hash.rs
@@ -147,6 +147,33 @@ impl TryFromMrb<Value> for Vec<(Value, Value)> {
 
 macro_rules! hash_converter {
     ($key:ty => $value:ty) => {
+        impl FromMrb<Vec<($key, $value)>> for Value {
+            type From = Rust;
+            type To = Ruby;
+
+            fn from_mrb(interp: &Mrb, value: Vec<($key, $value)>) -> Self {
+                let pairs = value
+                    .into_iter()
+                    .map(|(key, value)| {
+                        let key = Value::from_mrb(&interp, key);
+                        let value = Value::from_mrb(&interp, value);
+                        (key, value)
+                    })
+                    .collect::<Vec<(Value, Value)>>();
+                Self::from_mrb(interp, pairs)
+            }
+        }
+
+        impl FromMrb<HashMap<$key, $value>> for Value {
+            type From = Rust;
+            type To = Ruby;
+
+            fn from_mrb(interp: &Mrb, value: HashMap<$key, $value>) -> Self {
+                let pairs = value.into_iter().collect::<Vec<($key, $value)>>();
+                Self::from_mrb(interp, pairs)
+            }
+        }
+
         impl<S: BuildHasher + Default> TryFromMrb<Value> for HashMap<$key, $value, S> {
             type From = Ruby;
             type To = Rust;

--- a/mruby/src/convert/hash.rs
+++ b/mruby/src/convert/hash.rs
@@ -35,6 +35,81 @@ impl FromMrb<Vec<(Value, Value)>> for Value {
     }
 }
 
+impl FromMrb<Vec<(Option<Value>, Value)>> for Value {
+    type From = Rust;
+    type To = Ruby;
+
+    fn from_mrb(interp: &Mrb, value: Vec<(Option<Self>, Self)>) -> Self {
+        // We can initalize a `Hash` with a known capacity using
+        // `sys::mrb_hash_new_capa`, but doing so requires converting from
+        // `usize` to `i64` which is fallible. To simplify the code and make
+        // `Vec<(Value, Value)>` easier to work with, use an infallible `Hash`
+        // constructor.
+        let hash = unsafe { sys::mrb_hash_new(interp.borrow().mrb) };
+        for (key, val) in value {
+            unsafe {
+                sys::mrb_hash_set(
+                    interp.borrow().mrb,
+                    hash,
+                    Value::from_mrb(interp, key).inner(),
+                    val.inner(),
+                )
+            };
+        }
+        Self::new(interp, hash)
+    }
+}
+
+impl FromMrb<Vec<(Value, Option<Value>)>> for Value {
+    type From = Rust;
+    type To = Ruby;
+
+    fn from_mrb(interp: &Mrb, value: Vec<(Self, Option<Self>)>) -> Self {
+        // We can initalize a `Hash` with a known capacity using
+        // `sys::mrb_hash_new_capa`, but doing so requires converting from
+        // `usize` to `i64` which is fallible. To simplify the code and make
+        // `Vec<(Value, Value)>` easier to work with, use an infallible `Hash`
+        // constructor.
+        let hash = unsafe { sys::mrb_hash_new(interp.borrow().mrb) };
+        for (key, val) in value {
+            unsafe {
+                sys::mrb_hash_set(
+                    interp.borrow().mrb,
+                    hash,
+                    key.inner(),
+                    Value::from_mrb(interp, val).inner(),
+                )
+            };
+        }
+        Self::new(interp, hash)
+    }
+}
+
+impl FromMrb<Vec<(Option<Value>, Option<Value>)>> for Value {
+    type From = Rust;
+    type To = Ruby;
+
+    fn from_mrb(interp: &Mrb, value: Vec<(Option<Self>, Option<Self>)>) -> Self {
+        // We can initalize a `Hash` with a known capacity using
+        // `sys::mrb_hash_new_capa`, but doing so requires converting from
+        // `usize` to `i64` which is fallible. To simplify the code and make
+        // `Vec<(Value, Value)>` easier to work with, use an infallible `Hash`
+        // constructor.
+        let hash = unsafe { sys::mrb_hash_new(interp.borrow().mrb) };
+        for (key, val) in value {
+            unsafe {
+                sys::mrb_hash_set(
+                    interp.borrow().mrb,
+                    hash,
+                    Value::from_mrb(interp, key).inner(),
+                    Value::from_mrb(interp, val).inner(),
+                )
+            };
+        }
+        Self::new(interp, hash)
+    }
+}
+
 impl TryFromMrb<Value> for Vec<(Value, Value)> {
     type From = Ruby;
     type To = Rust;

--- a/mruby/src/convert/hash.rs
+++ b/mruby/src/convert/hash.rs
@@ -51,7 +51,7 @@ impl FromMrb<Vec<(Option<Value>, Value)>> for Value {
                 sys::mrb_hash_set(
                     interp.borrow().mrb,
                     hash,
-                    Value::from_mrb(interp, key).inner(),
+                    Self::from_mrb(interp, key).inner(),
                     val.inner(),
                 )
             };
@@ -77,7 +77,7 @@ impl FromMrb<Vec<(Value, Option<Value>)>> for Value {
                     interp.borrow().mrb,
                     hash,
                     key.inner(),
-                    Value::from_mrb(interp, val).inner(),
+                    Self::from_mrb(interp, val).inner(),
                 )
             };
         }
@@ -101,8 +101,8 @@ impl FromMrb<Vec<(Option<Value>, Option<Value>)>> for Value {
                 sys::mrb_hash_set(
                     interp.borrow().mrb,
                     hash,
-                    Value::from_mrb(interp, key).inner(),
-                    Value::from_mrb(interp, val).inner(),
+                    Self::from_mrb(interp, key).inner(),
+                    Self::from_mrb(interp, val).inner(),
                 )
             };
         }
@@ -147,6 +147,7 @@ impl TryFromMrb<Value> for Vec<(Value, Value)> {
 
 macro_rules! hash_converter {
     ($key:ty => $value:ty) => {
+        #[allow(clippy::use_self)]
         impl FromMrb<Vec<($key, $value)>> for Value {
             type From = Rust;
             type To = Ruby;
@@ -155,15 +156,16 @@ macro_rules! hash_converter {
                 let pairs = value
                     .into_iter()
                     .map(|(key, value)| {
-                        let key = Value::from_mrb(&interp, key);
-                        let value = Value::from_mrb(&interp, value);
+                        let key = Self::from_mrb(&interp, key);
+                        let value = Self::from_mrb(&interp, value);
                         (key, value)
                     })
-                    .collect::<Vec<(Value, Value)>>();
+                    .collect::<Vec<(Self, Self)>>();
                 Self::from_mrb(interp, pairs)
             }
         }
 
+        #[allow(clippy::use_self)]
         impl FromMrb<HashMap<$key, $value>> for Value {
             type From = Rust;
             type To = Ruby;

--- a/mruby/src/convert/hash.rs
+++ b/mruby/src/convert/hash.rs
@@ -40,23 +40,15 @@ impl FromMrb<Vec<(Option<Value>, Value)>> for Value {
     type To = Ruby;
 
     fn from_mrb(interp: &Mrb, value: Vec<(Option<Self>, Self)>) -> Self {
-        // We can initalize a `Hash` with a known capacity using
-        // `sys::mrb_hash_new_capa`, but doing so requires converting from
-        // `usize` to `i64` which is fallible. To simplify the code and make
-        // `Vec<(Value, Value)>` easier to work with, use an infallible `Hash`
-        // constructor.
-        let hash = unsafe { sys::mrb_hash_new(interp.borrow().mrb) };
-        for (key, val) in value {
-            unsafe {
-                sys::mrb_hash_set(
-                    interp.borrow().mrb,
-                    hash,
-                    Self::from_mrb(interp, key).inner(),
-                    val.inner(),
-                )
-            };
-        }
-        Self::new(interp, hash)
+        let pairs = value
+            .into_iter()
+            .map(|(key, value)| {
+                let key = Self::from_mrb(&interp, key);
+                let value = Self::from_mrb(&interp, value);
+                (key, value)
+            })
+            .collect::<Vec<(Self, Self)>>();
+        Self::from_mrb(interp, pairs)
     }
 }
 
@@ -65,23 +57,15 @@ impl FromMrb<Vec<(Value, Option<Value>)>> for Value {
     type To = Ruby;
 
     fn from_mrb(interp: &Mrb, value: Vec<(Self, Option<Self>)>) -> Self {
-        // We can initalize a `Hash` with a known capacity using
-        // `sys::mrb_hash_new_capa`, but doing so requires converting from
-        // `usize` to `i64` which is fallible. To simplify the code and make
-        // `Vec<(Value, Value)>` easier to work with, use an infallible `Hash`
-        // constructor.
-        let hash = unsafe { sys::mrb_hash_new(interp.borrow().mrb) };
-        for (key, val) in value {
-            unsafe {
-                sys::mrb_hash_set(
-                    interp.borrow().mrb,
-                    hash,
-                    key.inner(),
-                    Self::from_mrb(interp, val).inner(),
-                )
-            };
-        }
-        Self::new(interp, hash)
+        let pairs = value
+            .into_iter()
+            .map(|(key, value)| {
+                let key = Self::from_mrb(&interp, key);
+                let value = Self::from_mrb(&interp, value);
+                (key, value)
+            })
+            .collect::<Vec<(Self, Self)>>();
+        Self::from_mrb(interp, pairs)
     }
 }
 
@@ -90,23 +74,15 @@ impl FromMrb<Vec<(Option<Value>, Option<Value>)>> for Value {
     type To = Ruby;
 
     fn from_mrb(interp: &Mrb, value: Vec<(Option<Self>, Option<Self>)>) -> Self {
-        // We can initalize a `Hash` with a known capacity using
-        // `sys::mrb_hash_new_capa`, but doing so requires converting from
-        // `usize` to `i64` which is fallible. To simplify the code and make
-        // `Vec<(Value, Value)>` easier to work with, use an infallible `Hash`
-        // constructor.
-        let hash = unsafe { sys::mrb_hash_new(interp.borrow().mrb) };
-        for (key, val) in value {
-            unsafe {
-                sys::mrb_hash_set(
-                    interp.borrow().mrb,
-                    hash,
-                    Self::from_mrb(interp, key).inner(),
-                    Self::from_mrb(interp, val).inner(),
-                )
-            };
-        }
-        Self::new(interp, hash)
+        let pairs = value
+            .into_iter()
+            .map(|(key, value)| {
+                let key = Self::from_mrb(&interp, key);
+                let value = Self::from_mrb(&interp, value);
+                (key, value)
+            })
+            .collect::<Vec<(Self, Self)>>();
+        Self::from_mrb(interp, pairs)
     }
 }
 


### PR DESCRIPTION
All of the key-value types implemented with the `hash_impl` macro have infallible conversions to `Value` and we have an infallible conversion from `Vec<(Value, Value)>` to `Hash`, so we can implement infallible converters from `HashMap<K, V>` to `Value` for primitive Ruby types.