### PR TITLE
Add a generic free func for Rc<RefCell<T>> backed MRB_TT_DATA mrb_values

### DIFF
--- a/mruby/src/def.rs
+++ b/mruby/src/def.rs
@@ -17,7 +17,7 @@ pub type Method =
     unsafe extern "C" fn(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value;
 
 pub unsafe extern "C" fn rust_data_free<T>(_mrb: *mut sys::mrb_state, data: *mut c_void) {
-    // Implictly dropped by going out of scope
+    // Implicitly dropped by going out of scope
     mem::transmute::<*mut c_void, Rc<RefCell<T>>>(data);
 }
 

--- a/mruby/src/def.rs
+++ b/mruby/src/def.rs
@@ -2,6 +2,7 @@ use std::cell::RefCell;
 use std::ffi::{c_void, CString};
 use std::fmt;
 use std::hash::{Hash, Hasher};
+use std::mem;
 use std::rc::Rc;
 
 use crate::class;
@@ -14,6 +15,11 @@ use crate::MrbError;
 pub type Free = unsafe extern "C" fn(mrb: *mut sys::mrb_state, data: *mut c_void);
 pub type Method =
     unsafe extern "C" fn(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value;
+
+pub unsafe extern "C" fn rust_data_free<T>(_mrb: *mut sys::mrb_state, data: *mut c_void) {
+    // Implictly dropped by going out of scope
+    mem::transmute::<*mut c_void, Rc<RefCell<T>>>(data);
+}
 
 #[derive(Clone, Debug)]
 pub enum Parent {


### PR DESCRIPTION
Saves some code duplication and potential for error.