### PR TITLE
Ergonomic Argument Extraction for mruby C functions in manual.rs

### DIFF
--- a/mruby/src/lib.rs
+++ b/mruby/src/lib.rs
@@ -26,6 +26,7 @@ pub use mruby_sys as sys;
 
 #[derive(Debug)]
 pub enum MrbError {
+    ArgSpec,
     ConvertToRuby(convert::Error<value::types::Rust, value::types::Ruby>),
     ConvertToRust(convert::Error<value::types::Ruby, value::types::Rust>),
     Exec(String),
@@ -50,6 +51,7 @@ impl PartialEq for MrbError {
 impl fmt::Display for MrbError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            MrbError::ArgSpec => write!(f, "could not generate argspec"),
             MrbError::ConvertToRuby(inner) => write!(f, "conversion error: {}", inner),
             MrbError::ConvertToRust(inner) => write!(f, "conversion error: {}", inner),
             MrbError::Exec(backtrace) => write!(f, "mruby exception: {}", backtrace),

--- a/mruby/tests/manual.rs
+++ b/mruby/tests/manual.rs
@@ -1,3 +1,6 @@
+#![deny(clippy::all, clippy::pedantic)]
+#![deny(warnings, intra_doc_link_resolution_failure)]
+
 #[macro_use]
 extern crate mruby;
 
@@ -49,7 +52,7 @@ impl Container {
 
         let args =
             unsafe { unwrap_or_raise!(interp, Args::extract(&interp), interp.nil().inner()) };
-        let cont = Container { inner: args.inner };
+        let cont = Self { inner: args.inner };
         let data = Rc::new(RefCell::new(cont));
         unsafe {
             let ptr = mem::transmute::<Rc<RefCell<Self>>, *mut c_void>(data);

--- a/mruby/tests/manual.rs
+++ b/mruby/tests/manual.rs
@@ -100,10 +100,8 @@ fn define_rust_backed_ruby_class() {
 
     interp.eval("require 'container'").expect("require");
     let result = interp.eval("Container.new(15).value").expect("eval");
-    let cint = unsafe { i64::try_from_mrb(&interp, result).expect("convert") };
-    assert_eq!(cint, 15);
+    assert_eq!(unsafe { i64::try_from_mrb(&interp, result) }, Ok(15));
     // Ensure Rc is cloned correctly and still points to valid memory.
     let result = interp.eval("Container.new(15).value").expect("eval");
-    let cint = unsafe { i64::try_from_mrb(&interp, result).expect("convert") };
-    assert_eq!(cint, 15);
+    assert_eq!(unsafe { i64::try_from_mrb(&interp, result) }, Ok(15));
 }

--- a/mruby/tests/manual.rs
+++ b/mruby/tests/manual.rs
@@ -93,17 +93,17 @@ impl MrbFile for Container {
 
 #[test]
 fn define_rust_backed_ruby_class() {
-    env_logger::Builder::from_env("MRUBY_LOG").init();
-
     let interp = Interpreter::create().expect("mrb init");
     interp
-        .def_file_for_type::<_, Container>("container")
+        .def_file_for_type::<_, Container>("container.rb")
         .expect("def file");
 
-    let code = "require 'container'; Container.new(15).value";
-    let result = interp.eval(code).expect("no exceptions");
+    interp.eval("require 'container'").expect("require");
+    let result = interp.eval("Container.new(15).value").expect("eval");
     let cint = unsafe { i64::try_from_mrb(&interp, result).expect("convert") };
     assert_eq!(cint, 15);
-
-    drop(interp);
+    // Ensure Rc is cloned correctly and still points to valid memory.
+    let result = interp.eval("Container.new(15).value").expect("eval");
+    let cint = unsafe { i64::try_from_mrb(&interp, result).expect("convert") };
+    assert_eq!(cint, 15);
 }


### PR DESCRIPTION
- Add an `Args` extractor for `Container#intialize` in manual.rs.
- Restructures `extern "C"` functions so they live on the `Container` impl and are declared `unsafe`.
- Add clippy denies to manual.rs.
- Add test that `Rc` is cloned properly in `Container#value`.