### PR TITLE
Ergonomic argument extraction

### DIFF
--- a/mruby/src/extn/core/kernel.rs
+++ b/mruby/src/extn/core/kernel.rs
@@ -1,6 +1,6 @@
 use log::trace;
 use mruby_vfs::FileSystem;
-use std::ffi::CString;
+use std::io::Write;
 use std::mem;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -19,7 +19,7 @@ pub fn patch(interp: &Mrb) -> Result<(), MrbError> {
     let kernel = interp.borrow_mut().def_module::<Kernel>("Kernel", None);
     kernel
         .borrow_mut()
-        .add_self_method("require", require, sys::mrb_args_rest());
+        .add_self_method("require", Kernel::require, sys::mrb_args_rest());
     kernel.borrow().define(interp).map_err(|_| MrbError::New)?;
     trace!("Patched Kernel#require onto interpreter");
     Ok(())
@@ -27,97 +27,107 @@ pub fn patch(interp: &Mrb) -> Result<(), MrbError> {
 
 pub struct Kernel;
 
-extern "C" fn require(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
-    let interp = unsafe { interpreter_or_raise!(mrb) };
-    // Extract required filename from arguments
-    let name = unsafe {
-        let name = mem::uninitialized::<sys::mrb_value>();
-        let argspec = CString::new(sys::specifiers::OBJECT).expect("argspec");
-        sys::mrb_get_args(mrb, argspec.as_ptr(), &name);
-        Value::new(&interp, name)
-    };
-    let name = unsafe {
-        unwrap_or_raise!(
-            interp,
-            String::try_from_mrb(&interp, name),
-            interp.nil().inner()
-        )
-    };
+impl Kernel {
+    unsafe extern "C" fn require(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
+        struct Args {
+            filename: String,
+        }
 
-    // track whether any iterations of the loop successfully required a file
-    let mut success = false;
-    let mut path = PathBuf::from(&name);
-    if path.is_relative() {
-        path = PathBuf::from(RUBY_LOAD_PATH);
-    }
-    let files = vec![path.join(&name), path.join(format!("{}.rb", name))];
-    for path in files {
-        let is_file = {
-            let api = interp.borrow();
-            api.vfs.is_file(&path)
-        };
-        if !is_file {
-            // If no paths are files in the VFS, then the require does
-            // nothing.
-            continue;
-        }
-        let metadata = {
-            let api = interp.borrow();
-            api.vfs.metadata(&path).unwrap_or_else(VfsMetadata::new)
-        };
-        // If a file is already required, short circuit
-        if metadata.is_already_required() {
-            return interp.bool(false).inner();
-        }
-        let context = if let Some(filename) = &path.to_str() {
-            EvalContext::new(filename)
-        } else {
-            EvalContext::new("(require)")
-        };
-        // Require Rust MrbFile first because an MrbFile may define classes and
-        // module with `MrbLoadSources` and Ruby files can require arbitrary
-        // other files, including some child sources that may depend on these
-        // module definitions. This behavior is enforced with a test in crate
-        // mruby-gems. See mruby-gems/src/lib.rs.
-        if let Some(require) = metadata.require {
-            // dynamic, Rust-backed `MrbFile` require
-            interp.push_context(context.clone());
-            unsafe { unwrap_or_raise!(interp, require(Rc::clone(&interp)), interp.nil().inner()) };
-            interp.pop_context();
-        }
-        let contents = {
-            let api = interp.borrow();
-            api.vfs.read_file(&path)
-        };
-        if let Ok(contents) = contents {
-            unsafe {
-                unwrap_value_or_raise!(interp, interp.eval_with_context(contents, context));
+        impl Args {
+            unsafe fn extract(interp: &Mrb) -> Result<Self, MrbError> {
+                let inner = mem::uninitialized::<sys::mrb_value>();
+                let mut argspec = vec![];
+                argspec
+                    .write_all(sys::specifiers::OBJECT.as_bytes())
+                    .map_err(|_| MrbError::ArgSpec)?;
+                argspec.write_all(b"\0").map_err(|_| MrbError::ArgSpec)?;
+                sys::mrb_get_args(interp.borrow().mrb, argspec.as_ptr() as *const i8, &inner);
+                let filename = Value::new(interp, inner);
+                let filename =
+                    String::try_from_mrb(&interp, filename).map_err(MrbError::ConvertToRust)?;
+                Ok(Self { filename })
             }
-        } else {
-            // this branch should be unreachable because the `Mrb` interpreter
-            // is not `Send` so it can only be owned and accessed by one thread.
-            return LoadError::raise(&interp, &name);
         }
-        let metadata = metadata.mark_required();
-        unsafe {
+
+        let interp = interpreter_or_raise!(mrb);
+        let args = unwrap_or_raise!(interp, Args::extract(&interp), interp.nil().inner());
+
+        // Track whether any iterations of the loop successfully required some
+        // Ruby sources.
+        let mut success = false;
+        let mut path = PathBuf::from(&args.filename);
+        if path.is_relative() {
+            path = PathBuf::from(RUBY_LOAD_PATH);
+        }
+        let files = vec![
+            path.join(&args.filename),
+            path.join(format!("{}.rb", args.filename)),
+        ];
+        for path in files {
+            let is_file = {
+                let api = interp.borrow();
+                api.vfs.is_file(&path)
+            };
+            if !is_file {
+                // If no paths are files in the VFS, then the require does
+                // nothing.
+                continue;
+            }
+            let metadata = {
+                let api = interp.borrow();
+                api.vfs.metadata(&path).unwrap_or_else(VfsMetadata::new)
+            };
+            // If a file is already required, short circuit.
+            if metadata.is_already_required() {
+                return interp.bool(false).inner();
+            }
+            let context = if let Some(filename) = &path.to_str() {
+                EvalContext::new(filename)
+            } else {
+                EvalContext::new("(require)")
+            };
+            // Require Rust MrbFile first because an MrbFile may define classes
+            // and module with `MrbLoadSources` and Ruby files can require
+            // arbitrary other files, including some child sources that may
+            // depend on these module definitions. This behavior is enforced
+            // with a test in crate mruby-gems. See mruby-gems/src/lib.rs.
+            if let Some(require) = metadata.require {
+                // dynamic, Rust-backed `MrbFile` require
+                interp.push_context(context.clone());
+                unwrap_or_raise!(interp, require(Rc::clone(&interp)), interp.nil().inner());
+                interp.pop_context();
+            }
+            let contents = {
+                let api = interp.borrow();
+                api.vfs.read_file(&path)
+            };
+            if let Ok(contents) = contents {
+                unwrap_value_or_raise!(interp, interp.eval_with_context(contents, context));
+            } else {
+                // this branch should be unreachable because the `Mrb`
+                // interpreter is not `Send` so it can only be owned and
+                // accessed by one thread.
+                return LoadError::raise(&interp, &args.filename);
+            }
+            let metadata = metadata.mark_required();
             let api = interp.borrow();
             unwrap_or_raise!(
                 interp,
                 api.vfs.set_metadata(&path, metadata),
                 interp.nil().inner()
             );
+            success = true;
+            trace!(
+                r#"Successful require of "{}" at {:?} on {:?}"#,
+                args.filename,
+                path,
+                api
+            );
         }
-        success = true;
-        trace!(
-            r#"Successful require of "{}" at {:?} on {:?}"#,
-            name,
-            path,
-            interp.borrow()
-        );
-    }
-    if success {
-        interp.bool(success).inner()
-    } else {
-        LoadError::raise(&interp, &name)
+        if success {
+            interp.bool(success).inner()
+        } else {
+            LoadError::raise(&interp, &args.filename)
+        }
     }
 }

--- a/mruby/src/interpreter.rs
+++ b/mruby/src/interpreter.rs
@@ -177,12 +177,10 @@ impl MrbApi for Mrb {
 
 #[cfg(test)]
 mod tests {
-    use crate::convert::TryFromMrb;
     use crate::eval::MrbEval;
-    use crate::file::MrbFile;
-    use crate::interpreter::{Interpreter, Mrb, MrbError};
-    use crate::load::MrbLoadSources;
+    use crate::interpreter::Interpreter;
     use crate::sys;
+    use crate::MrbError;
 
     #[test]
     fn from_user_data_null_pointer() {
@@ -241,122 +239,5 @@ mod tests {
 (eval):1
        "#;
         assert_eq!(result, Err(MrbError::Exec(expected.trim().to_owned())));
-    }
-
-    #[test]
-    // Test that require behaves as expected:
-    // - require side effects (e.g. ivar set or class def) affect the interpreter
-    // - Successful first require returns `true`.
-    // - Second require returns `false`.
-    // - Second require does not cause require side effects.
-    // - Require non-existing file raises and returns `nil`.
-    fn require() {
-        struct InterpreterRequireTest;
-        impl MrbFile for InterpreterRequireTest {
-            fn require(interp: Mrb) -> Result<(), MrbError> {
-                interp.eval("@i = 255")?;
-                Ok(())
-            }
-        }
-
-        unsafe {
-            let interp = Interpreter::create().expect("mrb init");
-            interp
-                .def_file_for_type::<_, InterpreterRequireTest>("require-test.rb")
-                .expect("def file");
-            let result = interp.eval("require 'require-test'").expect("eval");
-            let require_result = bool::try_from_mrb(&interp, result);
-            assert_eq!(require_result, Ok(true));
-            let result = interp.eval("@i").expect("eval");
-            let i_result = i64::try_from_mrb(&interp, result);
-            assert_eq!(i_result, Ok(255));
-            let result = interp
-                .eval("@i = 1000; require 'require-test'")
-                .expect("eval");
-            let second_require_result = bool::try_from_mrb(&interp, result);
-            assert_eq!(second_require_result, Ok(false));
-            let result = interp.eval("@i").expect("eval");
-            let second_i_result = i64::try_from_mrb(&interp, result);
-            assert_eq!(second_i_result, Ok(1000));
-            let result = interp.eval("require 'non-existent-source'").map(|_| ());
-            let expected = r#"
-(eval):1: cannot load such file -- non-existent-source (LoadError)
-(eval):1
-            "#;
-            assert_eq!(result, Err(MrbError::Exec(expected.trim().to_owned())));
-        }
-    }
-
-    #[test]
-    fn require_absolute_path() {
-        let interp = Interpreter::create().expect("mrb init");
-        interp
-            .def_rb_source_file("/foo/bar/source.rb", "# a source file")
-            .expect("def file");
-        let result = interp.eval("require '/foo/bar/source.rb'").expect("value");
-        assert!(unsafe { bool::try_from_mrb(&interp, result).expect("convert") });
-        let result = interp.eval("require '/foo/bar/source.rb'").expect("value");
-        assert!(!unsafe { bool::try_from_mrb(&interp, result).expect("convert") });
-    }
-
-    #[test]
-    fn require_directory() {
-        let interp = Interpreter::create().expect("mrb init");
-        let result = interp.eval("require '/src'").map(|_| ());
-        let expected = r#"
-(eval):1: cannot load such file -- /src (LoadError)
-(eval):1
-        "#;
-        assert_eq!(result, Err(MrbError::Exec(expected.trim().to_owned())));
-    }
-
-    #[test]
-    fn require_path_defined_as_source_then_mrbfile() {
-        struct Foo;
-        impl MrbFile for Foo {
-            fn require(interp: Mrb) -> Result<(), MrbError> {
-                interp.eval("module Foo; RUST = 7; end")?;
-                Ok(())
-            }
-        }
-        let interp = Interpreter::create().expect("mrb init");
-        interp
-            .def_rb_source_file("foo.rb", "module Foo; RUBY = 3; end")
-            .expect("def");
-        interp.def_file_for_type::<_, Foo>("foo.rb").expect("def");
-        let result = interp.eval("require 'foo'").expect("eval");
-        let result = unsafe { bool::try_from_mrb(&interp, result).expect("convert") };
-        assert!(result, "successfully required foo.rb");
-        let result = interp.eval("Foo::RUBY + Foo::RUST").expect("eval");
-        let result = unsafe { i64::try_from_mrb(&interp, result).expect("convert") };
-        assert_eq!(
-            result, 10,
-            "defined Ruby and Rust sources from single require"
-        );
-    }
-
-    #[test]
-    fn require_path_defined_as_mrbfile_then_source() {
-        struct Foo;
-        impl MrbFile for Foo {
-            fn require(interp: Mrb) -> Result<(), MrbError> {
-                interp.eval("module Foo; RUST = 7; end")?;
-                Ok(())
-            }
-        }
-        let interp = Interpreter::create().expect("mrb init");
-        interp.def_file_for_type::<_, Foo>("foo.rb").expect("def");
-        interp
-            .def_rb_source_file("foo.rb", "module Foo; RUBY = 3; end")
-            .expect("def");
-        let result = interp.eval("require 'foo'").expect("eval");
-        let result = unsafe { bool::try_from_mrb(&interp, result).expect("convert") };
-        assert!(result, "successfully required foo.rb");
-        let result = interp.eval("Foo::RUBY + Foo::RUST").expect("eval");
-        let result = unsafe { i64::try_from_mrb(&interp, result).expect("convert") };
-        assert_eq!(
-            result, 10,
-            "defined Ruby and Rust sources from single require"
-        );
     }
 }

--- a/mruby/tests/leak_mrb_tt_data_rc.rs
+++ b/mruby/tests/leak_mrb_tt_data_rc.rs
@@ -15,15 +15,18 @@
 #[macro_use]
 extern crate mruby;
 
+use mruby::convert::TryFromMrb;
 use mruby::def::{rust_data_free, ClassLike, Define};
 use mruby::eval::MrbEval;
 use mruby::file::MrbFile;
-use mruby::interpreter::{Interpreter, Mrb};
+use mruby::interpreter::{Interpreter, Mrb, MrbApi};
 use mruby::load::MrbLoadSources;
 use mruby::sys;
+use mruby::value::Value;
 use mruby::MrbError;
 use std::cell::RefCell;
-use std::ffi::{c_void, CStr, CString};
+use std::ffi::c_void;
+use std::io::Write;
 use std::mem;
 use std::rc::Rc;
 
@@ -39,36 +42,50 @@ struct Container {
     inner: String,
 }
 
-impl MrbFile for Container {
-    fn require(interp: Mrb) -> Result<(), MrbError> {
-        extern "C" fn initialize(
-            mrb: *mut sys::mrb_state,
-            mut slf: sys::mrb_value,
-        ) -> sys::mrb_value {
-            unsafe {
-                let interp = interpreter_or_raise!(mrb);
+impl Container {
+    unsafe extern "C" fn initialize(
+        mrb: *mut sys::mrb_state,
+        mut slf: sys::mrb_value,
+    ) -> sys::mrb_value {
+        struct Args {
+            inner: String,
+        }
 
-                let string = mem::uninitialized::<*const std::os::raw::c_char>();
-                let argspec = CString::new(sys::specifiers::CSTRING).expect("argspec");
-                sys::mrb_get_args(mrb, argspec.as_ptr(), &string);
-                let string = CStr::from_ptr(string).to_string_lossy().to_string();
-                let cont = Container { inner: string };
-                let data = Rc::new(RefCell::new(cont));
-                let ptr = mem::transmute::<Rc<RefCell<Container>>, *mut c_void>(data);
-
-                let spec = class_spec_or_raise!(interp, Container);
-                let borrow = spec.borrow();
-                sys::mrb_sys_data_init(&mut slf, ptr, borrow.data_type());
-
-                slf
+        impl Args {
+            unsafe fn extract(interp: &Mrb) -> Result<Self, MrbError> {
+                let inner = mem::uninitialized::<sys::mrb_value>();
+                let mut argspec = vec![];
+                argspec
+                    .write_all(sys::specifiers::OBJECT.as_bytes())
+                    .map_err(|_| MrbError::ArgSpec)?;
+                argspec.write_all(b"\0").map_err(|_| MrbError::ArgSpec)?;
+                sys::mrb_get_args(interp.borrow().mrb, argspec.as_ptr() as *const i8, &inner);
+                let inner = Value::new(interp, inner);
+                let inner =
+                    String::try_from_mrb(&interp, inner).map_err(MrbError::ConvertToRust)?;
+                Ok(Self { inner })
             }
         }
 
+        let interp = interpreter_or_raise!(mrb);
+        let args = unwrap_or_raise!(interp, Args::extract(&interp), interp.nil().inner());
+
+        let container = Self { inner: args.inner };
+        let data = Rc::new(RefCell::new(container));
+        let ptr = mem::transmute::<Rc<RefCell<Self>>, *mut c_void>(data);
+        let spec = class_spec_or_raise!(interp, Self);
+        sys::mrb_sys_data_init(&mut slf, ptr, spec.borrow().data_type());
+
+        slf
+    }
+}
+impl MrbFile for Container {
+    fn require(interp: Mrb) -> Result<(), MrbError> {
         let spec = {
             let mut api = interp.borrow_mut();
             let spec = api.def_class::<Self>("Container", None, Some(rust_data_free::<Self>));
             spec.borrow_mut()
-                .add_method("initialize", initialize, sys::mrb_args_req(1));
+                .add_method("initialize", Self::initialize, sys::mrb_args_req(1));
             spec.borrow_mut().mrb_value_is_rust_backed(true);
             spec
         };

--- a/mruby/tests/manual.rs
+++ b/mruby/tests/manual.rs
@@ -4,7 +4,7 @@
 #[macro_use]
 extern crate mruby;
 
-use mruby::convert::TryFromMrb;
+use mruby::convert::{FromMrb, TryFromMrb};
 use mruby::def::{rust_data_free, ClassLike, Define};
 use mruby::eval::MrbEval;
 use mruby::file::MrbFile;
@@ -70,7 +70,7 @@ impl Container {
         let container = Rc::clone(&data);
         mem::forget(data);
         let borrow = container.borrow();
-        unwrap_value_or_raise!(interp, Value::try_from_mrb(&interp, borrow.inner))
+        Value::from_mrb(&interp, borrow.inner).inner()
     }
 }
 


### PR DESCRIPTION
Following up on GH-81, use the same pattern in the rest of the places that extract args in ferrocarril.

- `Kernel#require`
- `Regexp::compile`
- `Regexp#initialize`
- `Container#initialize` in data leak test

Closes GH-7.