### PR TITLE
Parent factories

### DIFF
--- a/foolsgold/src/foolsgold.rs
+++ b/foolsgold/src/foolsgold.rs
@@ -103,10 +103,8 @@ impl MrbFile for Counter {
             let mut api = interp.borrow_mut();
             let parent = api
                 .module_spec::<FoolsGold>()
+                .map(Parent::module)
                 .ok_or(MrbError::NotDefined("FoolsGold".to_owned()))?;
-            let parent = Parent::Module {
-                spec: Rc::clone(&parent),
-            };
             // We do not need to define a free method since we are not storing
             // any data in the `mrb_value`.
             let spec = api.def_class::<Self>("Counter", Some(parent), None);
@@ -128,10 +126,8 @@ impl MrbFile for Metrics {
         let parent = interp
             .borrow()
             .module_spec::<FoolsGold>()
+            .map(Parent::module)
             .ok_or(MrbError::NotDefined("FoolsGold".to_owned()))?;
-        let parent = Parent::Module {
-            spec: Rc::clone(&parent),
-        };
         let spec = interp
             .borrow_mut()
             .def_module::<Self>("Metrics", Some(parent));
@@ -199,12 +195,10 @@ impl MrbFile for RequestContext {
 
         let spec = {
             let mut api = interp.borrow_mut();
-            let spec = api
+            let parent = api
                 .module_spec::<FoolsGold>()
+                .map(Parent::module)
                 .ok_or(MrbError::NotDefined("FoolsGold".to_owned()))?;
-            let parent = Parent::Module {
-                spec: Rc::clone(&spec),
-            };
             let spec =
                 api.def_class::<Self>("RequestContext", Some(parent), Some(rust_data_free::<Self>));
             spec.borrow_mut().mrb_value_is_rust_backed(true);

--- a/mruby-gems/src/lib.rs
+++ b/mruby-gems/src/lib.rs
@@ -22,7 +22,6 @@ mod tests {
     use mruby::interpreter::{Interpreter, Mrb};
     use mruby::load::MrbLoadSources;
     use mruby::MrbError;
-    use std::rc::Rc;
 
     use crate::Gem;
 
@@ -54,10 +53,8 @@ mod tests {
             let parent = interp
                 .borrow()
                 .module_spec::<Foo>()
+                .map(Parent::module)
                 .ok_or(MrbError::NotDefined("Foo".to_owned()))?;
-            let parent = Parent::Module {
-                spec: Rc::clone(&parent),
-            };
             interp
                 .borrow_mut()
                 .def_class::<Self>("Bar", Some(parent), None);

--- a/mruby/src/class.rs
+++ b/mruby/src/class.rs
@@ -247,9 +247,7 @@ mod tests {
     fn rclass_for_undef_nested_class() {
         let interp = Interpreter::create().expect("mrb init");
         let parent = module::Spec::new("Kernel", None);
-        let parent = Parent::Module {
-            spec: Rc::new(RefCell::new(parent)),
-        };
+        let parent = Parent::module(Rc::new(RefCell::new(parent)));
         let spec = Spec::new("Foo", Some(parent), None);
         assert!(spec.rclass(&interp).is_none());
     }
@@ -268,9 +266,7 @@ mod tests {
             .eval("module Foo; class Bar; end; end")
             .expect("eval");
         let parent = module::Spec::new("Foo", None);
-        let parent = Parent::Module {
-            spec: Rc::new(RefCell::new(parent)),
-        };
+        let parent = Parent::module(Rc::new(RefCell::new(parent)));
         let spec = Spec::new("Bar", Some(parent), None);
         assert!(spec.rclass(&interp).is_some());
     }
@@ -280,9 +276,7 @@ mod tests {
         let interp = Interpreter::create().expect("mrb init");
         interp.eval("class Foo; class Bar; end; end").expect("eval");
         let parent = Spec::new("Foo", None, None);
-        let parent = Parent::Class {
-            spec: Rc::new(RefCell::new(parent)),
-        };
+        let parent = Parent::class(Rc::new(RefCell::new(parent)));
         let spec = Spec::new("Bar", Some(parent), None);
         assert!(spec.rclass(&interp).is_some());
     }

--- a/mruby/src/def.rs
+++ b/mruby/src/def.rs
@@ -93,6 +93,7 @@ impl Parent {
     ///     api.def_class::<Inner>("Inner", Some(parent), None);
     /// }
     /// ```
+    #[allow(clippy::needless_pass_by_value)]
     pub fn class(spec: Rc<RefCell<class::Spec>>) -> Self {
         Parent::Class {
             spec: Rc::clone(&spec),
@@ -118,6 +119,7 @@ impl Parent {
     ///     api.def_class::<Inner>("Inner", Some(parent), None);
     /// }
     /// ```
+    #[allow(clippy::needless_pass_by_value)]
     pub fn module(spec: Rc<RefCell<module::Spec>>) -> Self {
         Parent::Module {
             spec: Rc::clone(&spec),

--- a/mruby/src/def.rs
+++ b/mruby/src/def.rs
@@ -246,39 +246,18 @@ mod tests {
         {
             let mut api = interp.borrow_mut();
             let root = api.def_module::<Root>("A", None);
-            let mod_under_root = api.def_module::<ModuleUnderRoot>(
-                "B",
-                Some(Parent::Module {
-                    spec: Rc::clone(&root),
-                }),
-            );
-            let cls_under_root = api.def_class::<ClassUnderRoot>(
-                "C",
-                Some(Parent::Module {
-                    spec: Rc::clone(&root),
-                }),
-                None,
-            );
-            let _cls_under_mod = api.def_class::<ClassUnderModule>(
-                "D",
-                Some(Parent::Module {
-                    spec: Rc::clone(&mod_under_root),
-                }),
-                None,
-            );
+            let mod_under_root =
+                api.def_module::<ModuleUnderRoot>("B", Some(Parent::module(Rc::clone(&root))));
+            let cls_under_root =
+                api.def_class::<ClassUnderRoot>("C", Some(Parent::module(root)), None);
+            let _cls_under_mod =
+                api.def_class::<ClassUnderModule>("D", Some(Parent::module(mod_under_root)), None);
             let _mod_under_cls = api.def_module::<ModuleUnderClass>(
                 "E",
-                Some(Parent::Class {
-                    spec: Rc::clone(&cls_under_root),
-                }),
+                Some(Parent::class(Rc::clone(&cls_under_root))),
             );
-            let _cls_under_cls = api.def_class::<ClassUnderClass>(
-                "F",
-                Some(Parent::Class {
-                    spec: Rc::clone(&cls_under_root),
-                }),
-                None,
-            );
+            let _cls_under_cls =
+                api.def_class::<ClassUnderClass>("F", Some(Parent::class(cls_under_root)), None);
         }
 
         let api = interp.borrow();

--- a/mruby/src/def.rs
+++ b/mruby/src/def.rs
@@ -74,6 +74,56 @@ pub enum Parent {
 }
 
 impl Parent {
+    /// Factory for [`Parent::Class`] that clones an `Rc` smart pointer wrapped
+    /// [`class::Spec`].
+    ///
+    /// This function is useful when extracting a parent class from the class
+    /// registry:
+    ///
+    /// ```rust
+    /// use mruby::def::Parent;
+    /// use mruby::interpreter::Interpreter;
+    ///
+    /// struct Fixnum;
+    /// struct Inner;
+    ///
+    /// let interp = Interpreter::create().expect("mrb init");
+    /// let mut api = interp.borrow_mut();
+    /// if let Some(parent) = api.class_spec::<Fixnum>().map(Parent::class) {
+    ///     api.def_class::<Inner>("Inner", Some(parent), None);
+    /// }
+    /// ```
+    pub fn class(spec: Rc<RefCell<class::Spec>>) -> Self {
+        Parent::Class {
+            spec: Rc::clone(&spec),
+        }
+    }
+
+    /// Factory for [`Parent::Module`] that clones an `Rc` smart pointer wrapped
+    /// [`module::Spec`].
+    ///
+    /// This function is useful when extracting a parent module from the module
+    /// registry:
+    ///
+    /// ```rust
+    /// use mruby::def::Parent;
+    /// use mruby::interpreter::Interpreter;
+    ///
+    /// struct Kernel;
+    /// struct Inner;
+    ///
+    /// let interp = Interpreter::create().expect("mrb init");
+    /// let mut api = interp.borrow_mut();
+    /// if let Some(parent) = api.module_spec::<Kernel>().map(Parent::module) {
+    ///     api.def_class::<Inner>("Inner", Some(parent), None);
+    /// }
+    /// ```
+    pub fn module(spec: Rc<RefCell<module::Spec>>) -> Self {
+        Parent::Module {
+            spec: Rc::clone(&spec),
+        }
+    }
+
     /// Resolve the [`RClass *`](sys::RClass) of the wrapped [`ClassLike`].
     ///
     /// Return [`None`] if the `ClassLike` has no [`Parent`].

--- a/mruby/src/def.rs
+++ b/mruby/src/def.rs
@@ -19,9 +19,9 @@ pub type Free = unsafe extern "C" fn(mrb: *mut sys::mrb_state, data: *mut c_void
 /// [`mrb_value`](sys::mrb_value)s that store an owned copy of an [`Rc`] smart
 /// pointer.
 ///
-/// *Warning*: This free function assumes the data pointer of the `mrb_value` is
-/// a `Rc<RefCell<T>>`. If that assumption does not hold, this function has
-/// undefined behavior.
+/// **Warning**: This free function assumes the `data` pointer is an
+/// `Rc<RefCell<T>>`. If that assumption does not hold, this function has
+/// undefined behavior and may result in a segfault.
 pub unsafe extern "C" fn rust_data_free<T>(_mrb: *mut sys::mrb_state, data: *mut c_void) {
     // Implicitly dropped by going out of scope
     mem::transmute::<*mut c_void, Rc<RefCell<T>>>(data);

--- a/mruby/src/def.rs
+++ b/mruby/src/def.rs
@@ -11,23 +11,75 @@ use crate::module;
 use crate::sys;
 use crate::MrbError;
 
-// Types
+/// Typedef for an mruby free function for an [`mrb_value`](sys::mrb_value) with
+/// `tt` [`MRB_TT_DATA`](sys::mrb_vtype::MRB_TT_DATA).
 pub type Free = unsafe extern "C" fn(mrb: *mut sys::mrb_state, data: *mut c_void);
-pub type Method =
-    unsafe extern "C" fn(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value;
 
+/// A generic implementation of a [`Free`] function for
+/// [`mrb_value`](sys::mrb_value)s that store an owned copy of an [`Rc`] smart
+/// pointer.
+///
+/// *Warning*: This free function assumes the data pointer of the `mrb_value` is
+/// a `Rc<RefCell<T>>`. If that assumption does not hold, this function has
+/// undefined behavior.
 pub unsafe extern "C" fn rust_data_free<T>(_mrb: *mut sys::mrb_state, data: *mut c_void) {
     // Implicitly dropped by going out of scope
     mem::transmute::<*mut c_void, Rc<RefCell<T>>>(data);
 }
 
+/// Typedef for a method exposed in the mruby interpreter.
+///
+/// This function signature is used for all types of mruby methods, including
+/// instance methods, class methods, singleton methods, and global methods.
+///
+/// `slf` is the method receiver, e.g. `s` in the following invocation of
+/// `String#start_with?`.
+///
+/// ```ruby
+/// s = 'mruby crate'
+/// s.start_with?('mruby')
+/// ```
+///
+/// To extract method arguments, use [`sys::mrb_get_args`] and the suppilied
+/// interpreter.
+pub type Method =
+    unsafe extern "C" fn(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value;
+
+/// Typesafe wrapper for the [`RClass *`](sys::RClass) of the enclosing scope
+/// for an mruby `Module` or `Class`.
+///
+/// In Ruby, classes and modules can be defined inside of another class or
+/// module. mruby only supports resolving [`RClass`](sys::RClass) pointers
+/// relative to an enclosing scope. This can be the top level with
+/// [`mrb_class_get`](sys::mrb_class_get) and
+/// [`mrb_module_get`](sys::mrb_module_get) or it can be under another
+/// [`ClassLike`] with [`mrb_class_get_under`](sys::mrb_class_get_under) and
+/// [`mrb_module_get_under`](sys::mrb_module_get_under).
+///
+/// Because there is no C API to resolve class and module names directly, each
+/// [`ClassLike`] holds a reference to its parent so it can recursively resolve
+/// its [`RClass *`](sys::RClass).
 #[derive(Clone, Debug)]
 pub enum Parent {
-    Class { spec: Rc<RefCell<class::Spec>> },
-    Module { spec: Rc<RefCell<module::Spec>> },
+    /// Reference to a Ruby `Class` parent scope.
+    Class {
+        /// Shared copy of the underlying [class definition](class::Spec).
+        spec: Rc<RefCell<class::Spec>>,
+    },
+    /// Reference to a Ruby `Module` parent scope.
+    Module {
+        /// Shared copy of the underlying [module definition](module::Spec).
+        spec: Rc<RefCell<module::Spec>>,
+    },
 }
 
 impl Parent {
+    /// Resolve the [`RClass *`](sys::RClass) of the wrapped [`ClassLike`].
+    ///
+    /// Return [`None`] if the `ClassLike` has no [`Parent`].
+    ///
+    /// The current implemention results in recursive calls to this function
+    /// for each enclosing scope.
     pub fn rclass(&self, interp: &Mrb) -> Option<*mut sys::RClass> {
         match self {
             Parent::Class { spec } => spec.borrow().rclass(interp),
@@ -35,6 +87,19 @@ impl Parent {
         }
     }
 
+    /// Get the fully qualified name of the wrapped [`ClassLike`].
+    ///
+    /// For example, in the following Ruby code, `C` has an fqname of `A::B::C`.
+    ///
+    /// ```ruby
+    /// module A
+    ///   class B
+    ///     module C
+    ///       CONST = 1
+    ///     end
+    ///   end
+    /// end
+    /// ```
     pub fn fqname(&self) -> String {
         match self {
             Parent::Class { spec } => spec.borrow().fqname(),
@@ -74,6 +139,9 @@ pub trait Define
 where
     Self: ClassLike,
 {
+    /// Define the class or module and all of its methods into the interpreter.
+    ///
+    /// Returns the [`RClass *`](sys::RClass) of the newly defined item.
     fn define(&self, interp: &Mrb) -> Result<*mut sys::RClass, MrbError>;
 }
 

--- a/mruby/src/module.rs
+++ b/mruby/src/module.rs
@@ -172,9 +172,7 @@ mod tests {
     fn rclass_for_undef_nested_module() {
         let interp = Interpreter::create().expect("mrb init");
         let parent = Spec::new("Kernel", None);
-        let parent = Parent::Module {
-            spec: Rc::new(RefCell::new(parent)),
-        };
+        let parent = Parent::module(Rc::new(RefCell::new(parent)));
         let spec = Spec::new("Foo", Some(parent));
         assert!(spec.rclass(&interp).is_none());
     }
@@ -193,9 +191,7 @@ mod tests {
             .eval("module Foo; module Bar; end; end")
             .expect("eval");
         let parent = Spec::new("Foo", None);
-        let parent = Parent::Module {
-            spec: Rc::new(RefCell::new(parent)),
-        };
+        let parent = Parent::module(Rc::new(RefCell::new(parent)));
         let spec = Spec::new("Bar", Some(parent));
         assert!(spec.rclass(&interp).is_some());
     }
@@ -207,9 +203,7 @@ mod tests {
             .eval("class Foo; module Bar; end; end")
             .expect("eval");
         let parent = class::Spec::new("Foo", None, None);
-        let parent = Parent::Class {
-            spec: Rc::new(RefCell::new(parent)),
-        };
+        let parent = Parent::class(Rc::new(RefCell::new(parent)));
         let spec = Spec::new("Bar", Some(parent));
         assert!(spec.rclass(&interp).is_some());
     }

--- a/nemesis/src/rubygems/nemesis.rs
+++ b/nemesis/src/rubygems/nemesis.rs
@@ -6,7 +6,6 @@ use mruby::MrbError;
 use mruby_gems::Gem;
 use std::borrow::Cow;
 use std::convert::AsRef;
-use std::rc::Rc;
 
 pub fn init(interp: &Mrb) -> Result<(), MrbError> {
     Nemesis::init(interp)
@@ -53,10 +52,8 @@ impl MrbFile for Response {
         let parent = interp
             .borrow()
             .module_spec::<Nemesis>()
+            .map(Parent::module)
             .ok_or(MrbError::NotDefined("Nemesis".to_owned()))?;
-        let parent = Parent::Module {
-            spec: Rc::clone(&parent),
-        };
         interp
             .borrow_mut()
             .def_class::<Self>("Response", Some(parent), None);


### PR DESCRIPTION
Creating `Parent` references to class and module specs was not super ergonomic and cumbersome when extracing specs from the class and module registries. This PR adds factories for class and module `Parent`s that handle cloning an `Rc` smart pointer. They can be used like this:

```rust
use mruby::def::Parent;
use mruby::interpreter::Interpreter;

struct Kernel;
struct Inner;

let interp = Interpreter::create().expect("mrb init");
let mut api = interp.borrow_mut();
if let Some(parent) = api.module_spec::<Kernel>().map(Parent::module) {
    api.def_class::<Inner>("Inner", Some(parent), None);
}
```

This PR also adds a boatload of documentation to the items in `def` module.