### PR TITLE
Add stdlib implementations of Thread, Mutex, and Monitor

### DIFF
--- a/mruby/src/extn/core/module.rs
+++ b/mruby/src/extn/core/module.rs
@@ -2,13 +2,11 @@ use crate::eval::MrbEval;
 use crate::interpreter::Mrb;
 use crate::MrbError;
 
-const PATCH: &str = include_str!("module.rb");
-
 pub fn patch(interp: &Mrb) -> Result<(), MrbError> {
     interp
         .borrow_mut()
         .def_class::<Module>("Module", None, None);
-    interp.eval(PATCH)?;
+    interp.eval(include_str!("module.rb"))?;
     Ok(())
 }
 

--- a/mruby/src/extn/stdlib/mod.rs
+++ b/mruby/src/extn/stdlib/mod.rs
@@ -1,3 +1,4 @@
+use crate::eval::MrbEval;
 use crate::interpreter::Mrb;
 use crate::MrbError;
 
@@ -7,5 +8,7 @@ pub mod thread;
 pub fn patch(interp: &Mrb) -> Result<(), MrbError> {
     monitor::init(interp)?;
     thread::init(interp)?;
+    // https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/UnneededRequireStatement
+    interp.eval("require 'thread'")?;
     Ok(())
 }

--- a/mruby/src/extn/stdlib/mod.rs
+++ b/mruby/src/extn/stdlib/mod.rs
@@ -2,8 +2,10 @@ use crate::interpreter::Mrb;
 use crate::MrbError;
 
 pub mod monitor;
+pub mod thread;
 
 pub fn patch(interp: &Mrb) -> Result<(), MrbError> {
     monitor::init(interp)?;
+    thread::init(interp)?;
     Ok(())
 }

--- a/mruby/src/extn/stdlib/mod.rs
+++ b/mruby/src/extn/stdlib/mod.rs
@@ -1,4 +1,3 @@
-use crate::eval::MrbEval;
 use crate::interpreter::Mrb;
 use crate::MrbError;
 
@@ -8,7 +7,5 @@ pub mod thread;
 pub fn patch(interp: &Mrb) -> Result<(), MrbError> {
     monitor::init(interp)?;
     thread::init(interp)?;
-    // https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/UnneededRequireStatement
-    interp.eval("require 'thread'")?;
     Ok(())
 }

--- a/mruby/src/extn/stdlib/mod.rs
+++ b/mruby/src/extn/stdlib/mod.rs
@@ -1,11 +1,9 @@
 use crate::interpreter::Mrb;
 use crate::MrbError;
 
-pub mod core;
-pub mod stdlib;
+pub mod monitor;
 
 pub fn patch(interp: &Mrb) -> Result<(), MrbError> {
-    core::patch(interp)?;
-    stdlib::patch(interp)?;
+    monitor::init(interp)?;
     Ok(())
 }

--- a/mruby/src/extn/stdlib/monitor.rb
+++ b/mruby/src/extn/stdlib/monitor.rb
@@ -1,0 +1,323 @@
+# frozen_string_literal: false
+# = monitor.rb
+#
+# Copyright (C) 2001  Shugo Maeda <shugo@ruby-lang.org>
+#
+# This library is distributed under the terms of the Ruby license.
+# You can freely distribute/modify this library.
+#
+
+#
+# In concurrent programming, a monitor is an object or module intended to be
+# used safely by more than one thread.  The defining characteristic of a
+# monitor is that its methods are executed with mutual exclusion.  That is, at
+# each point in time, at most one thread may be executing any of its methods.
+# This mutual exclusion greatly simplifies reasoning about the implementation
+# of monitors compared to reasoning about parallel code that updates a data
+# structure.
+#
+# You can read more about the general principles on the Wikipedia page for
+# Monitors[http://en.wikipedia.org/wiki/Monitor_%28synchronization%29]
+#
+# == Examples
+#
+# === Simple object.extend
+#
+#   require 'monitor.rb'
+#
+#   buf = []
+#   buf.extend(MonitorMixin)
+#   empty_cond = buf.new_cond
+#
+#   # consumer
+#   Thread.start do
+#     loop do
+#       buf.synchronize do
+#         empty_cond.wait_while { buf.empty? }
+#         print buf.shift
+#       end
+#     end
+#   end
+#
+#   # producer
+#   while line = ARGF.gets
+#     buf.synchronize do
+#       buf.push(line)
+#       empty_cond.signal
+#     end
+#   end
+#
+# The consumer thread waits for the producer thread to push a line to buf
+# while <tt>buf.empty?</tt>.  The producer thread (main thread) reads a
+# line from ARGF and pushes it into buf then calls <tt>empty_cond.signal</tt>
+# to notify the consumer thread of new data.
+#
+# === Simple Class include
+#
+#   require 'monitor'
+#
+#   class SynchronizedArray < Array
+#
+#     include MonitorMixin
+#
+#     def initialize(*args)
+#       super(*args)
+#     end
+#
+#     alias :old_shift :shift
+#     alias :old_unshift :unshift
+#
+#     def shift(n=1)
+#       self.synchronize do
+#         self.old_shift(n)
+#       end
+#     end
+#
+#     def unshift(item)
+#       self.synchronize do
+#         self.old_unshift(item)
+#       end
+#     end
+#
+#     # other methods ...
+#   end
+#
+# +SynchronizedArray+ implements an Array with synchronized access to items.
+# This Class is implemented as subclass of Array which includes the
+# MonitorMixin module.
+#
+module MonitorMixin
+  #
+  # FIXME: This isn't documented in Nutshell.
+  #
+  # Since MonitorMixin.new_cond returns a ConditionVariable, and the example
+  # above calls while_wait and signal, this class should be documented.
+  #
+  class ConditionVariable
+    class Timeout < Exception; end
+
+    #
+    # Releases the lock held in the associated monitor and waits; reacquires the lock on wakeup.
+    #
+    # If +timeout+ is given, this method returns after +timeout+ seconds passed,
+    # even if no other thread doesn't signal.
+    #
+    def wait(timeout = nil)
+      Thread.handle_interrupt(Exception => :never) do
+        @monitor.__send__(:mon_check_owner)
+        count = @monitor.__send__(:mon_exit_for_cond)
+        begin
+          Thread.handle_interrupt(Exception => :immediate) do
+            @cond.wait(@monitor.instance_variable_get(:@mon_mutex), timeout)
+          end
+          return true
+        ensure
+          @monitor.__send__(:mon_enter_for_cond, count)
+        end
+      end
+    end
+
+    #
+    # Calls wait repeatedly while the given block yields a truthy value.
+    #
+    def wait_while
+      while yield
+        wait
+      end
+    end
+
+    #
+    # Calls wait repeatedly until the given block yields a truthy value.
+    #
+    def wait_until
+      until yield
+        wait
+      end
+    end
+
+    #
+    # Wakes up the first thread in line waiting for this lock.
+    #
+    def signal
+      @monitor.__send__(:mon_check_owner)
+      @cond.signal
+    end
+
+    #
+    # Wakes up all threads waiting for this lock.
+    #
+    def broadcast
+      @monitor.__send__(:mon_check_owner)
+      @cond.broadcast
+    end
+
+    private
+
+    def initialize(monitor)
+      @monitor = monitor
+      @cond = Thread::ConditionVariable.new
+    end
+  end
+
+  def self.extend_object(obj)
+    super(obj)
+    obj.__send__(:mon_initialize)
+  end
+
+  #
+  # Attempts to enter exclusive section.  Returns +false+ if lock fails.
+  #
+  def mon_try_enter
+    if @mon_owner != Thread.current
+      unless @mon_mutex.try_lock
+        return false
+      end
+      @mon_owner = Thread.current
+      @mon_count = 0
+    end
+    @mon_count += 1
+    return true
+  end
+  # For backward compatibility
+  alias try_mon_enter mon_try_enter
+
+  #
+  # Enters exclusive section.
+  #
+  def mon_enter
+    if @mon_owner != Thread.current
+      @mon_mutex.lock
+      @mon_owner = Thread.current
+      @mon_count = 0
+    end
+    @mon_count += 1
+  end
+
+  #
+  # Leaves exclusive section.
+  #
+  def mon_exit
+    mon_check_owner
+    @mon_count -=1
+    if @mon_count == 0
+      @mon_owner = nil
+      @mon_mutex.unlock
+    end
+  end
+
+  #
+  # Returns true if this monitor is locked by any thread
+  #
+  def mon_locked?
+    @mon_mutex.locked?
+  end
+
+  #
+  # Returns true if this monitor is locked by current thread.
+  #
+  def mon_owned?
+    @mon_mutex.locked? && @mon_owner == Thread.current
+  end
+
+  #
+  # Enters exclusive section and executes the block.  Leaves the exclusive
+  # section automatically when the block exits.  See example under
+  # +MonitorMixin+.
+  #
+  def mon_synchronize
+    mon_enter
+    begin
+      yield
+    ensure
+      mon_exit
+    end
+  end
+  alias synchronize mon_synchronize
+
+  #
+  # Creates a new MonitorMixin::ConditionVariable associated with the
+  # receiver.
+  #
+  def new_cond
+    return ConditionVariable.new(self)
+  end
+
+  private
+
+  # Use <tt>extend MonitorMixin</tt> or <tt>include MonitorMixin</tt> instead
+  # of this constructor.  Have look at the examples above to understand how to
+  # use this module.
+  def initialize(*args)
+    super
+    mon_initialize
+  end
+
+  # Initializes the MonitorMixin after being included in a class or when an
+  # object has been extended with the MonitorMixin
+  def mon_initialize
+    if defined?(@mon_mutex) && @mon_mutex_owner_object_id == object_id
+      raise ThreadError, "already initialized"
+    end
+    @mon_mutex = Thread::Mutex.new
+    @mon_mutex_owner_object_id = object_id
+    @mon_owner = nil
+    @mon_count = 0
+  end
+
+  def mon_check_owner
+    if @mon_owner != Thread.current
+      raise ThreadError, "current thread not owner"
+    end
+  end
+
+  def mon_enter_for_cond(count)
+    @mon_owner = Thread.current
+    @mon_count = count
+  end
+
+  def mon_exit_for_cond
+    count = @mon_count
+    @mon_owner = nil
+    @mon_count = 0
+    return count
+  end
+end
+
+# Use the Monitor class when you want to have a lock object for blocks with
+# mutual exclusion.
+#
+#   require 'monitor'
+#
+#   lock = Monitor.new
+#   lock.synchronize do
+#     # exclusive access
+#   end
+#
+class Monitor
+  include MonitorMixin
+  alias try_enter try_mon_enter
+  alias enter mon_enter
+  alias exit mon_exit
+end
+
+
+# Documentation comments:
+#  - All documentation comes from Nutshell.
+#  - MonitorMixin.new_cond appears in the example, but is not documented in
+#    Nutshell.
+#  - All the internals (internal modules Accessible and Initializable, class
+#    ConditionVariable) appear in RDoc.  It might be good to hide them, by
+#    making them private, or marking them :nodoc:, etc.
+#  - RDoc doesn't recognise aliases, so we have mon_synchronize documented, but
+#    not synchronize.
+#  - mon_owner is in Nutshell, but appears as an accessor in a separate module
+#    here, so is hard/impossible to RDoc.  Some other useful accessors
+#    (mon_count and some queue stuff) are also in this module, and don't appear
+#    directly in the RDoc output.
+#  - in short, it may be worth changing the code layout in this file to make the
+#    documentation easier
+
+# Local variables:
+# mode: Ruby
+# tab-width: 8
+# End:

--- a/mruby/src/extn/stdlib/monitor.rb
+++ b/mruby/src/extn/stdlib/monitor.rb
@@ -251,7 +251,7 @@ module MonitorMixin
   # Initializes the MonitorMixin after being included in a class or when an
   # object has been extended with the MonitorMixin
   def mon_initialize
-    raise ThreadError, 'already initialized' if defined?(@mon_mutex) && @mon_mutex_owner_object_id == object_id
+    raise ThreadError, 'already initialized' if !@mon_mutex.nil? && @mon_mutex_owner_object_id == object_id
 
     @mon_mutex = Thread::Mutex.new
     @mon_mutex_owner_object_id = object_id

--- a/mruby/src/extn/stdlib/monitor.rb
+++ b/mruby/src/extn/stdlib/monitor.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: false
+
 # = monitor.rb
 #
 # Copyright (C) 2001  Shugo Maeda <shugo@ruby-lang.org>
@@ -94,7 +95,7 @@ module MonitorMixin
   # above calls while_wait and signal, this class should be documented.
   #
   class ConditionVariable
-    class Timeout < Exception; end
+    class Timeout < Exception; end # rubocop:disable Lint/InheritException
 
     #
     # Releases the lock held in the associated monitor and waits; reacquires the lock on wakeup.
@@ -121,18 +122,14 @@ module MonitorMixin
     # Calls wait repeatedly while the given block yields a truthy value.
     #
     def wait_while
-      while yield
-        wait
-      end
+      wait while yield
     end
 
     #
     # Calls wait repeatedly until the given block yields a truthy value.
     #
     def wait_until
-      until yield
-        wait
-      end
+      wait until yield
     end
 
     #
@@ -169,14 +166,13 @@ module MonitorMixin
   #
   def mon_try_enter
     if @mon_owner != Thread.current
-      unless @mon_mutex.try_lock
-        return false
-      end
+      return false unless @mon_mutex.try_lock
+
       @mon_owner = Thread.current
       @mon_count = 0
     end
     @mon_count += 1
-    return true
+    true
   end
   # For backward compatibility
   alias try_mon_enter mon_try_enter
@@ -198,7 +194,7 @@ module MonitorMixin
   #
   def mon_exit
     mon_check_owner
-    @mon_count -=1
+    @mon_count -= 1
     if @mon_count == 0
       @mon_owner = nil
       @mon_mutex.unlock
@@ -239,7 +235,7 @@ module MonitorMixin
   # receiver.
   #
   def new_cond
-    return ConditionVariable.new(self)
+    ConditionVariable.new(self)
   end
 
   private
@@ -255,9 +251,8 @@ module MonitorMixin
   # Initializes the MonitorMixin after being included in a class or when an
   # object has been extended with the MonitorMixin
   def mon_initialize
-    if defined?(@mon_mutex) && @mon_mutex_owner_object_id == object_id
-      raise ThreadError, "already initialized"
-    end
+    raise ThreadError, 'already initialized' if defined?(@mon_mutex) && @mon_mutex_owner_object_id == object_id
+
     @mon_mutex = Thread::Mutex.new
     @mon_mutex_owner_object_id = object_id
     @mon_owner = nil
@@ -265,9 +260,7 @@ module MonitorMixin
   end
 
   def mon_check_owner
-    if @mon_owner != Thread.current
-      raise ThreadError, "current thread not owner"
-    end
+    raise ThreadError, 'current thread not owner' if @mon_owner != Thread.current
   end
 
   def mon_enter_for_cond(count)
@@ -279,7 +272,7 @@ module MonitorMixin
     count = @mon_count
     @mon_owner = nil
     @mon_count = 0
-    return count
+    count
   end
 end
 

--- a/mruby/src/extn/stdlib/monitor.rb
+++ b/mruby/src/extn/stdlib/monitor.rb
@@ -293,7 +293,6 @@ class Monitor
   alias exit mon_exit
 end
 
-
 # Documentation comments:
 #  - All documentation comes from Nutshell.
 #  - MonitorMixin.new_cond appears in the example, but is not documented in

--- a/mruby/src/extn/stdlib/monitor.rb
+++ b/mruby/src/extn/stdlib/monitor.rb
@@ -195,10 +195,10 @@ module MonitorMixin
   def mon_exit
     mon_check_owner
     @mon_count -= 1
-    if @mon_count == 0
-      @mon_owner = nil
-      @mon_mutex.unlock
-    end
+    return unless @mon_count.zero?
+
+    @mon_owner = nil
+    @mon_mutex.unlock
   end
 
   #

--- a/mruby/src/extn/stdlib/monitor.rs
+++ b/mruby/src/extn/stdlib/monitor.rs
@@ -2,8 +2,6 @@ use crate::interpreter::Mrb;
 use crate::load::MrbLoadSources;
 use crate::MrbError;
 
-const SRC: &str = include_str!("monitor.rb");
-
 pub fn init(interp: &Mrb) -> Result<(), MrbError> {
-    interp.def_rb_source_file("monitor.rb", SRC)
+    interp.def_rb_source_file("monitor.rb", include_str!("monitor.rb"))
 }

--- a/mruby/src/extn/stdlib/monitor.rs
+++ b/mruby/src/extn/stdlib/monitor.rs
@@ -10,3 +10,49 @@ pub fn init(interp: &Mrb) -> Result<(), MrbError> {
 }
 
 pub struct Monitor;
+
+// Monitor tests from ruby/spec
+// https://github.com/ruby/spec/tree/master/library/monitor
+#[cfg(test)]
+mod tests {
+    use crate::convert::TryFromMrb;
+    use crate::eval::MrbEval;
+    use crate::interpreter::Interpreter;
+
+    #[test]
+    fn mon_initialize() {
+        let spec = r#"
+cls = Class.new do
+  include MonitorMixin
+
+  def initialize(*array)
+    mon_initialize
+    @array = array
+  end
+
+  def to_a
+    synchronize { @array.dup }
+  end
+
+  def initialize_copy(other)
+    mon_initialize
+
+    synchronize do
+      @array = other.to_a
+    end
+  end
+end
+
+
+instance = cls.new(1, 2, 3)
+copy = instance.dup
+copy != instance
+# The below requires mspec
+# copy.should_not equal(instance)
+"#;
+        let interp = Interpreter::create().expect("mrb init");
+        interp.eval("require 'monitor'").expect("require");
+        let result = interp.eval(spec).expect("spec");
+        assert!(unsafe { bool::try_from_mrb(&interp, result) }.expect("convert"));
+    }
+}

--- a/mruby/src/extn/stdlib/monitor.rs
+++ b/mruby/src/extn/stdlib/monitor.rs
@@ -1,0 +1,9 @@
+use crate::interpreter::Mrb;
+use crate::load::MrbLoadSources;
+use crate::MrbError;
+
+const SRC: &str = include_str!("monitor.rb");
+
+pub fn init(interp: &Mrb) -> Result<(), MrbError> {
+    interp.def_rb_source_file("monitor.rb", SRC)
+}

--- a/mruby/src/extn/stdlib/monitor.rs
+++ b/mruby/src/extn/stdlib/monitor.rs
@@ -3,5 +3,10 @@ use crate::load::MrbLoadSources;
 use crate::MrbError;
 
 pub fn init(interp: &Mrb) -> Result<(), MrbError> {
+    interp
+        .borrow_mut()
+        .def_class::<Monitor>("Monitor", None, None);
     interp.def_rb_source_file("monitor.rb", include_str!("monitor.rb"))
 }
+
+pub struct Monitor;

--- a/mruby/src/extn/stdlib/thread.rb
+++ b/mruby/src/extn/stdlib/thread.rb
@@ -1,8 +1,206 @@
 # frozen_string_literal: true
 
+# Single-threaded implementation of Thread and Mutex.
+#
+# Threads are executed synchronously and support "spawning" new threads that
+# get pushed onto the stack and executed synchronously.
+#
+# A special "root" thread that never terminates is created on require.
+#
+# Mutex immediately acquires locks and yields since there is no possibility of
+# contention in a single-threaded environement.
+
 class Thread
+  attr_accessor :abort_on_exception
+  attr_accessor :name
+  attr_accessor :report_on_exception
+
   def self.current
-    @current ||= {}
+    @@current.last
+  end
+
+  # To simulate concurrent execution, Thread maintains a stack of Threads.
+  @@current = [] # rubocop:disable Style/ClassVars
+
+  def initialize(root = false)
+    @priority = 0
+    @priority = self.class.current.priority unless self.class.current.nil?
+
+    @@current.push(self)
+    @fiber_locals = {}
+    @thread_locals = {}
+    @abort_on_exception = false
+    @name = "thread-#{@@current.length}"
+    @report_on_exception = false
+    @terminated_with_exception = nil
+    # mruby is not multi-threaded. Threads are executed synchronously.
+    @alive = true
+    @value = yield if block_given?
+  rescue StandardError => e
+    @terminated_with_exception = true
+    @value = e
+  ensure
+    @alive = false unless root
+    @@current.pop unless root
+  end
+
+  def [](sym)
+    @fiber_locals[sym]
+  end
+
+  alias thr []
+
+  def []=(sym, obj)
+    @fiber_locals[sym] = obj
+  end
+
+  alias thr= []=
+
+  def add_trace_func(func)
+    # TODO: not implemented
+  end
+
+  def alive?
+    @alive
+  end
+
+  def backtrace
+    # TODO: implement this in Rust using the C API
+    []
+  end
+
+  def backtrace_locations(*_args)
+    # TODO: not implemented
+    nil
+  end
+
+  def exit
+    # Because mruby Thread instances are run synchronously on initialize, this
+    # method is a noop.
+    nil
+  end
+
+  alias kill exit
+  alias terminate exit
+
+  def fetch(*args)
+    Kernel.raise ArgumentError, 'Thread#fetch requires 1 or 2 arguments' unless [1, 2].include?(args.length)
+
+    key = args[0]
+    if @fiber_locals.key?(key)
+      @fiber_locals[key]
+    elsif block_given?
+      # block supersedes default argument
+      yield key
+    elsif args.length == 2
+      args[1]
+    else
+      Kernel.raise "key '#{key}' not found in Thread locals"
+    end
+  end
+
+  def group
+    nil
+  end
+
+  alias inspect to_s
+
+  def join(*_args)
+    # Because mruby Thread instances are run synchronously on initialize, this
+    # method is a noop.
+    self
+  end
+
+  def key?(sym)
+    @fiber_locals.key?(sym)
+  end
+
+  def keys
+    @fiber_locals.keys.map(&:to_sym)
+  end
+
+  def pending_interrupt?(_error = nil)
+    false
+  end
+
+  attr_reader :priority
+
+  def priority=(pri)
+    @priority = pri
+    self # rubocop:disable Lint/Void
+  end
+
+  def raise(*args)
+    exc, message, array = *args
+    case args.length
+    when 0 then Kernel.raise
+    when 1 then Kernel.raise(exc)
+    when 2 then Kernel.raise(exc, message)
+    when 3 then Kernel.raise(exc, message, array)
+    else Kernel.raise ArgumentError
+    end
+  end
+
+  def run(*_args)
+    # Because mruby Thread instances are run synchronously on initialize, this
+    # method is a noop.
+    self
+  end
+
+  def safe_level
+    # TODO: not implemented
+    0
+  end
+
+  def set_trace_fun(func) # rubocop:disable Naming/AccessorMethodName
+    # TODO: not implemented
+  end
+
+  def status
+    if alive?
+      'run'
+    elsif @terminated_with_exception
+      nil
+    else
+      false
+    end
+  end
+
+  def stop?
+    !alive?
+  end
+
+  def thread_variable?(key)
+    @thread_locals.key?(key)
+  end
+
+  def thread_variable_get(key)
+    @thread_locals[key]
+  end
+
+  def thread_variable_set(key, value)
+    @thread_locals[key] = value
+    nil
+  end
+
+  def thread_variables
+    @thread_locals.keys.map(&:to_sym)
+  end
+
+  def to_s
+    "#<Thread:#{name}:#{object_id} #{status}>"
+  end
+
+  def value
+    Kernel.raise @value if @terminated_with_exception
+
+    @value
+  end
+
+  def wakeup
+    # Because mruby Thread instances are run synchronously on initialize, this
+    # method is a noop.
+    self
   end
 end
 
@@ -56,3 +254,6 @@ class Mutex
     self
   end
 end
+
+# Spawn the special "root" thread that never terminates.
+Thread.new(true)

--- a/mruby/src/extn/stdlib/thread.rb
+++ b/mruby/src/extn/stdlib/thread.rb
@@ -32,6 +32,62 @@ class Thread
   # To simulate concurrent execution, Thread maintains a stack of Threads.
   @@current = [] # rubocop:disable Style/ClassVars
 
+  def self.exclusive
+    yield
+  end
+
+  def self.exit
+    # TODO: not implemented
+  end
+
+  singleton_class.send(:alias_method, :kill, :exit)
+
+  def self.fork(*args, &blk)
+    # TODO: handle subclassing behavior correctly.
+    new(*args, blk)
+  end
+
+  singleton_class.send(:alias_method, :start, :fork)
+
+  def self.handle_interrupt(_hash)
+    # https://ruby-doc.org/core-2.6.3/Thread.html#method-c-handle_interrupt
+    # Implemented as an immediate yield because interrupts are not a thing in
+    # the mruby interpreter. `Thread::exit` is not implemented.
+    yield
+  end
+
+  def self.list
+    # make sure to clone the list
+    @@current.map(&:itself)
+  end
+
+  def self.main
+    @@current.first
+  end
+
+  def self.pass
+    # noop since there is no scheduler
+    nil
+  end
+
+  def self.pending_interrupt?(_error = nil)
+    # See `Thread::handle_interrupt`.
+    false
+  end
+
+  def self.report_on_exception
+    @@report_on_exception ||= false # rubocop:disable Style/ClassVars
+  end
+
+  def self.report_on_exception=(report_on_exception)
+    @@report_on_exception = report_on_exception # rubocop:disable Style/ClassVars
+  end
+
+  def self.stop
+    # noop since there is no scheduler
+    nil
+  end
+
   def initialize(root = false)
     @priority = 0
     @priority = self.class.current.priority unless self.class.current.nil?

--- a/mruby/src/extn/stdlib/thread.rb
+++ b/mruby/src/extn/stdlib/thread.rb
@@ -15,6 +15,14 @@ class Thread
   attr_accessor :name
   attr_accessor :report_on_exception
 
+  def self.abort_on_exception
+    @@abort_on_exception ||= false # rubocop:disable Style/ClassVars
+  end
+
+  def self.abort_on_exception=(abort_on_exception)
+    @@abort_on_exception = abort_on_exception # rubocop:disable Style/ClassVars
+  end
+
   def self.current
     @@current.last
   end
@@ -39,6 +47,7 @@ class Thread
   rescue StandardError => e
     @terminated_with_exception = true
     @value = e
+    raise if self.class.abort_on_exception
   ensure
     @alive = false unless root
     @@current.pop unless root

--- a/mruby/src/extn/stdlib/thread.rb
+++ b/mruby/src/extn/stdlib/thread.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Thread
+  def self.current
+    @current ||= {}
+  end
+end
+
+class Mutex
+  # mruby interpreters are single threaded and are not `Send`. A `Mutex` can
+  # never be contended, so synchronize just immediately yields.
+  def synchronize
+    yield
+  end
+end

--- a/mruby/src/extn/stdlib/thread.rb
+++ b/mruby/src/extn/stdlib/thread.rb
@@ -6,10 +6,53 @@ class Thread
   end
 end
 
+class ThreadError < StandardError; end
+
 class Mutex
+  def initialize
+    @owner = nil
+  end
+
+  def lock
+    raise ThreadError, 'locked by current Thread' if owned?
+
+    @owner = Thread.current
+    self
+  end
+
+  def locked?
+    !@owner.nil?
+  end
+
+  def owned?
+    @owner == Thread.current
+  end
+
+  # This method does not actually sleep
+  def sleep(timeout = nil)
+    unlock
+    lock
+    timeout
+  end
+
   # mruby interpreters are single threaded and are not `Send`. A `Mutex` can
   # never be contended, so synchronize just immediately yields.
   def synchronize
+    lock
     yield
+  ensure
+    unlock
+  end
+
+  def try_lock
+    lock
+    locked? && owned?
+  end
+
+  def unlock
+    raise ThreadError, 'not locked by current Thread' unless owned?
+
+    @owner = nil
+    self
   end
 end

--- a/mruby/src/extn/stdlib/thread.rs
+++ b/mruby/src/extn/stdlib/thread.rs
@@ -1,0 +1,9 @@
+use crate::interpreter::Mrb;
+use crate::load::MrbLoadSources;
+use crate::MrbError;
+
+const SRC: &str = include_str!("thread.rb");
+
+pub fn init(interp: &Mrb) -> Result<(), MrbError> {
+    interp.def_rb_source_file("thread.rb", SRC)
+}

--- a/mruby/src/extn/stdlib/thread.rs
+++ b/mruby/src/extn/stdlib/thread.rs
@@ -104,4 +104,15 @@ Thread.current.thread_variable_get(:local) == 42
         let result = interp.eval(spec).expect("spec");
         assert!(unsafe { bool::try_from_mrb(&interp, result) }.expect("convert"));
     }
+
+    #[test]
+    fn thread_abort_on_exception() {
+        let interp = Interpreter::create().expect("mrb init");
+        let spec = r#"
+Thread.abort_on_exception = true
+Thread.new { raise 'failboat' }.join
+"#;
+        let result = interp.eval(spec);
+        assert!(result.is_err());
+    }
 }

--- a/mruby/src/extn/stdlib/thread.rs
+++ b/mruby/src/extn/stdlib/thread.rs
@@ -19,3 +19,17 @@ pub fn init(interp: &Mrb) -> Result<(), MrbError> {
 
 pub struct Thread;
 pub struct Mutex;
+
+#[cfg(test)]
+mod tests {
+    use crate::convert::TryFromMrb;
+    use crate::eval::MrbEval;
+    use crate::interpreter::Interpreter;
+
+    #[test]
+    fn thread_required_by_default() {
+        let interp = Interpreter::create().expect("mrb init");
+        let result = interp.eval("Object.const_defined?(:Thread)").expect("thread");
+        assert!(unsafe { bool::try_from_mrb(&interp, result) }.expect("convert"));
+    }
+}

--- a/mruby/src/extn/stdlib/thread.rs
+++ b/mruby/src/extn/stdlib/thread.rs
@@ -114,5 +114,17 @@ Thread.new { raise 'failboat' }.join
 "#;
         let result = interp.eval(spec);
         assert!(result.is_err());
+        let spec = r#"
+Thread.abort_on_exception = true
+Thread.new do
+  begin
+    Thread.new { raise 'failboat' }.join
+  rescue RuntimeError
+    # swallow errors
+  end
+end.join
+"#;
+        let result = interp.eval(spec);
+        assert!(result.is_err());
     }
 }

--- a/mruby/src/extn/stdlib/thread.rs
+++ b/mruby/src/extn/stdlib/thread.rs
@@ -3,5 +3,14 @@ use crate::load::MrbLoadSources;
 use crate::MrbError;
 
 pub fn init(interp: &Mrb) -> Result<(), MrbError> {
+    interp
+        .borrow_mut()
+        .def_class::<Thread>("Thread", None, None);
+    interp
+        .borrow_mut()
+        .def_class::<Mutex>("Mutex", None, None);
     interp.def_rb_source_file("thread.rb", include_str!("thread.rb"))
 }
+
+pub struct Thread;
+pub struct Mutex;

--- a/mruby/src/extn/stdlib/thread.rs
+++ b/mruby/src/extn/stdlib/thread.rs
@@ -7,9 +7,7 @@ pub fn init(interp: &Mrb) -> Result<(), MrbError> {
     interp
         .borrow_mut()
         .def_class::<Thread>("Thread", None, None);
-    interp
-        .borrow_mut()
-        .def_class::<Mutex>("Mutex", None, None);
+    interp.borrow_mut().def_class::<Mutex>("Mutex", None, None);
     interp.def_rb_source_file("thread.rb", include_str!("thread.rb"))?;
     // Thread is loaded by default, so require it on interpreter initialization
     // https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/UnneededRequireStatement
@@ -29,7 +27,9 @@ mod tests {
     #[test]
     fn thread_required_by_default() {
         let interp = Interpreter::create().expect("mrb init");
-        let result = interp.eval("Object.const_defined?(:Thread)").expect("thread");
+        let result = interp
+            .eval("Object.const_defined?(:Thread)")
+            .expect("thread");
         assert!(unsafe { bool::try_from_mrb(&interp, result) }.expect("convert"));
     }
 }

--- a/mruby/src/extn/stdlib/thread.rs
+++ b/mruby/src/extn/stdlib/thread.rs
@@ -2,8 +2,6 @@ use crate::interpreter::Mrb;
 use crate::load::MrbLoadSources;
 use crate::MrbError;
 
-const SRC: &str = include_str!("thread.rb");
-
 pub fn init(interp: &Mrb) -> Result<(), MrbError> {
-    interp.def_rb_source_file("thread.rb", SRC)
+    interp.def_rb_source_file("thread.rb", include_str!("thread.rb"))
 }

--- a/mruby/src/extn/stdlib/thread.rs
+++ b/mruby/src/extn/stdlib/thread.rs
@@ -36,6 +36,17 @@ mod tests {
     }
 
     #[test]
+    fn thread_current_is_main() {
+        let interp = Interpreter::create().expect("mrb init");
+        let spec = "Thread.current == Thread.main";
+        let result = interp.eval(spec).expect("spec");
+        assert!(unsafe { bool::try_from_mrb(&interp, result) }.expect("convert"));
+        let spec = "Thread.new { Thread.current == Thread.main }.join.value == false";
+        let result = interp.eval(spec).expect("spec");
+        assert!(unsafe { bool::try_from_mrb(&interp, result) }.expect("convert"));
+    }
+
+    #[test]
     fn thread_join_value() {
         let interp = Interpreter::create().expect("mrb init");
         let spec = "Thread.new { 2 + 3 }.join.value == 5";

--- a/mruby/src/extn/stdlib/thread.rs
+++ b/mruby/src/extn/stdlib/thread.rs
@@ -1,3 +1,4 @@
+use crate::eval::MrbEval;
 use crate::interpreter::Mrb;
 use crate::load::MrbLoadSources;
 use crate::MrbError;
@@ -9,7 +10,11 @@ pub fn init(interp: &Mrb) -> Result<(), MrbError> {
     interp
         .borrow_mut()
         .def_class::<Mutex>("Mutex", None, None);
-    interp.def_rb_source_file("thread.rb", include_str!("thread.rb"))
+    interp.def_rb_source_file("thread.rb", include_str!("thread.rb"))?;
+    // Thread is loaded by default, so require it on interpreter initialization
+    // https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/UnneededRequireStatement
+    interp.eval("require 'thread'")?;
+    Ok(())
 }
 
 pub struct Thread;

--- a/mruby/tests/leak_unbounded_arena_growth.rs
+++ b/mruby/tests/leak_unbounded_arena_growth.rs
@@ -31,9 +31,8 @@ const LEAK_TOLERANCE: i64 = 1024 * 1024 * 15;
 
 #[test]
 fn unbounded_arena_growth() {
-    let interp = Interpreter::create().expect("mrb init");
-
     // MrbApi::current_exception
+    let interp = Interpreter::create().expect("mrb init");
     let code = r#"
 def bad_code
   raise ArgumentError.new("n" * 1024 * 1024)
@@ -60,6 +59,7 @@ end
     });
 
     // Value::to_s
+    let interp = Interpreter::create().expect("mrb init");
     let code = "'a' * 1024 * 1024";
     let expected = "a".repeat(1024 * 1024);
     LeakDetector::new("to_s", ITERATIONS, LEAK_TOLERANCE).check_leaks_with_finalizer(
@@ -76,6 +76,7 @@ end
     );
 
     // Value::to_s_debug
+    let interp = Interpreter::create().expect("mrb init");
     let code = "'a' * 1024 * 1024";
     let expected = format!(r#"String<"{}">"#, "a".repeat(1024 * 1024));
     LeakDetector::new("to_s_debug", ITERATIONS, 3 * LEAK_TOLERANCE).check_leaks_with_finalizer(


### PR DESCRIPTION
Single threaded implementations that conform to the API.

TODO: implement class methods on `Thread`.

Split this out of GH-85 and fleshed out the `Thread` implementation.