### PR TITLE
Implement Regexp#match?

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,6 +410,7 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mruby-sys 2.0.1-sys.4.c078758",
  "mruby-vfs 0.5.0-alpha",
+ "onig 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck_macros 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -497,6 +498,26 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "onig"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "onig_sys 69.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "pear"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -524,6 +545,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "percent-encoding"
 version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1206,10 +1232,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 "checksum num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a23f0ed30a54abaa0c7e83b1d2d87ada7c3c23078d1d87815af3e3b6385fbba"
 "checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
+"checksum onig 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a646989adad8a19f49be2090374712931c3a59835cb5277b4530f48b417f26e7"
+"checksum onig_sys 69.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388410bf5fa341f10e58e6db3975f4bea1ac30247dd79d37a9e5ced3cb4cc3b0"
 "checksum pear 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c26d2b92e47063ffce70d3e3b1bd097af121a9e0db07ca38a6cc1cf0cc85ff25"
 "checksum pear_codegen 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "336db4a192cc7f54efeb0c4e11a9245394824cc3bcbd37ba3ff51240c35d7a6e"
 "checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
+"checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quickcheck 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8d467b6d7a927b98d31a9d726d84da692787ae8238da3bed081fa992b30cfa8a"

--- a/mruby/Cargo.toml
+++ b/mruby/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 log = "0.4.6"
+onig = "4.3.2"
 
 [dependencies.mruby-sys]
 path = "../mruby-sys"

--- a/mruby/src/convert/fixnum.rs
+++ b/mruby/src/convert/fixnum.rs
@@ -1,3 +1,5 @@
+use std::convert::TryFrom;
+
 use crate::convert::{Error, FromMrb, TryFromMrb};
 use crate::interpreter::Mrb;
 use crate::sys;
@@ -30,6 +32,26 @@ impl TryFromMrb<Value> for Int {
                 to: Rust::SignedInt,
             }),
         }
+    }
+}
+
+impl TryFromMrb<Value> for usize {
+    type From = Ruby;
+    type To = Rust;
+
+    unsafe fn try_from_mrb(
+        interp: &Mrb,
+        value: Value,
+    ) -> Result<Self, Error<Self::From, Self::To>> {
+        if let Ok(result) = Int::try_from_mrb(interp, value) {
+            if let Ok(result) = usize::try_from(result) {
+                return Ok(result);
+            }
+        }
+        Err(Error {
+            from: Ruby::Fixnum,
+            to: Rust::UnsignedInt,
+        })
     }
 }
 
@@ -92,5 +114,21 @@ mod tests {
             to: Rust::SignedInt,
         });
         value == expected
+    }
+
+    #[test]
+    fn fixnum_to_usize() {
+        let interp = Interpreter::create().expect("mrb init");
+        let value = Value::from_mrb(&interp, 100);
+        let value = unsafe { usize::try_from_mrb(&interp, value) };
+        let expected = Ok(100);
+        assert_eq!(value, expected);
+        let value = Value::from_mrb(&interp, -100);
+        let value = unsafe { usize::try_from_mrb(&interp, value) };
+        let expected = Err(Error {
+            from: Ruby::Fixnum,
+            to: Rust::UnsignedInt,
+        });
+        assert_eq!(value, expected);
     }
 }

--- a/mruby/src/convert/fixnum.rs
+++ b/mruby/src/convert/fixnum.rs
@@ -44,7 +44,7 @@ impl TryFromMrb<Value> for usize {
         value: Value,
     ) -> Result<Self, Error<Self::From, Self::To>> {
         if let Ok(result) = Int::try_from_mrb(interp, value) {
-            if let Ok(result) = usize::try_from(result) {
+            if let Ok(result) = Self::try_from(result) {
                 return Ok(result);
             }
         }

--- a/mruby/src/extn/core/regexp.rs
+++ b/mruby/src/extn/core/regexp.rs
@@ -42,7 +42,7 @@ struct Options {
 }
 
 impl Options {
-    fn flags(&self) -> RegexOptions {
+    fn flags(self) -> RegexOptions {
         let mut bits = RegexOptions::REGEX_OPTION_NONE;
         if self.ignore_case {
             bits |= RegexOptions::REGEX_OPTION_IGNORECASE;

--- a/mruby/src/extn/core/regexp.rs
+++ b/mruby/src/extn/core/regexp.rs
@@ -433,7 +433,7 @@ mod tests {
         let interp = Interpreter::create().expect("mrb init");
         regexp::init(&interp).expect("regexp init");
         let regexp = interp.eval("Regexp.new('foo.*bar')").expect("eval");
-        assert_eq!(regexp.ruby_type(), Ruby::Object);
+        assert_eq!(regexp.ruby_type(), Ruby::Data);
         let class = regexp
             .funcall::<Value, _, _>("class", &[])
             .expect("funcall");
@@ -446,14 +446,14 @@ mod tests {
         let interp = Interpreter::create().expect("mrb init");
         regexp::init(&interp).expect("regexp init");
         let regexp = interp.eval("/foo.*bar/").expect("eval");
-        assert_eq!(regexp.ruby_type(), Ruby::Object);
+        assert_eq!(regexp.ruby_type(), Ruby::Data);
         let class = regexp
             .funcall::<Value, _, _>("class", &[])
             .expect("funcall");
         let name = class.funcall::<String, _, _>("name", &[]).expect("funcall");
         assert_eq!(&name, "Regexp");
         let regexp = interp.eval("/foo.*bar/i").expect("eval");
-        assert_eq!(regexp.ruby_type(), Ruby::Object);
+        assert_eq!(regexp.ruby_type(), Ruby::Data);
     }
 
     #[test]
@@ -461,17 +461,17 @@ mod tests {
         let interp = Interpreter::create().expect("mrb init");
         regexp::init(&interp).expect("regexp init");
         let regexp = interp.eval("Regexp.new('foo.*bar', true)").expect("eval");
-        assert_eq!(regexp.ruby_type(), Ruby::Object);
+        assert_eq!(regexp.ruby_type(), Ruby::Data);
         let regexp = interp.eval("Regexp.new('foo.*bar', false)").expect("eval");
-        assert_eq!(regexp.ruby_type(), Ruby::Object);
+        assert_eq!(regexp.ruby_type(), Ruby::Data);
         let regexp = interp.eval("Regexp.new('foo.*bar', nil)").expect("eval");
-        assert_eq!(regexp.ruby_type(), Ruby::Object);
+        assert_eq!(regexp.ruby_type(), Ruby::Data);
         let regexp = interp
             .eval("Regexp.new('foo.*bar', 1 | 2 | 4)")
             .expect("eval");
-        assert_eq!(regexp.ruby_type(), Ruby::Object);
+        assert_eq!(regexp.ruby_type(), Ruby::Data);
         let regexp = interp.eval("Regexp.new('foo.*bar', 'ixm')").expect("eval");
-        assert_eq!(regexp.ruby_type(), Ruby::Object);
+        assert_eq!(regexp.ruby_type(), Ruby::Data);
     }
 
     #[test]
@@ -479,7 +479,7 @@ mod tests {
         let interp = Interpreter::create().expect("mrb init");
         regexp::init(&interp).expect("regexp init");
         let regexp = interp.eval("Regexp.new('foo.*bar', 'u')").expect("eval");
-        assert_eq!(regexp.ruby_type(), Ruby::Object);
+        assert_eq!(regexp.ruby_type(), Ruby::Data);
     }
 
     #[test]

--- a/mruby/src/extn/core/regexp.rs
+++ b/mruby/src/extn/core/regexp.rs
@@ -400,6 +400,10 @@ impl Regexp {
         let regex = Rc::clone(&data);
         mem::forget(data);
 
+        // onig will panic if pos is beyond the end of string
+        if args.pos.unwrap_or_default() > args.string.len() {
+            return Value::from_mrb(&interp, false).inner();
+        }
         let is_match = regex.borrow().regex.search_with_options(
             &args.string,
             args.pos.unwrap_or_default(),

--- a/mruby/src/value/types.rs
+++ b/mruby/src/value/types.rs
@@ -10,6 +10,7 @@ pub enum Rust {
     Map,
     SignedInt,
     String,
+    UnsignedInt,
     Vec,
 }
 
@@ -24,6 +25,7 @@ impl fmt::Display for Rust {
             Rust::SignedInt => write!(f, "i64"),
             Rust::String => write!(f, "String"),
             Rust::Vec => write!(f, "Vec"),
+            Rust::UnsignedInt => write!(f, "usize"),
         }
     }
 }


### PR DESCRIPTION
Use `onig` regex crate. Ruby uses the Oniguruma regular expressions library. Using it in our Rust implementation maps nicely to the Ruby API and implementation.