### PR TITLE
Add more infallible integer type converters

### DIFF
--- a/mruby/src/convert/fixnum.rs
+++ b/mruby/src/convert/fixnum.rs
@@ -17,6 +17,60 @@ impl FromMrb<Int> for Value {
     }
 }
 
+impl FromMrb<u8> for Value {
+    type From = Rust;
+    type To = Ruby;
+
+    fn from_mrb(interp: &Mrb, value: u8) -> Self {
+        Self::from_mrb(interp, Int::from(value))
+    }
+}
+
+impl FromMrb<u16> for Value {
+    type From = Rust;
+    type To = Ruby;
+
+    fn from_mrb(interp: &Mrb, value: u16) -> Self {
+        Self::from_mrb(interp, Int::from(value))
+    }
+}
+
+impl FromMrb<u32> for Value {
+    type From = Rust;
+    type To = Ruby;
+
+    fn from_mrb(interp: &Mrb, value: u32) -> Self {
+        Self::from_mrb(interp, Int::from(value))
+    }
+}
+
+impl FromMrb<i8> for Value {
+    type From = Rust;
+    type To = Ruby;
+
+    fn from_mrb(interp: &Mrb, value: i8) -> Self {
+        Self::from_mrb(interp, Int::from(value))
+    }
+}
+
+impl FromMrb<i16> for Value {
+    type From = Rust;
+    type To = Ruby;
+
+    fn from_mrb(interp: &Mrb, value: i16) -> Self {
+        Self::from_mrb(interp, Int::from(value))
+    }
+}
+
+impl FromMrb<i32> for Value {
+    type From = Rust;
+    type To = Ruby;
+
+    fn from_mrb(interp: &Mrb, value: i32) -> Self {
+        Self::from_mrb(interp, Int::from(value))
+    }
+}
+
 impl TryFromMrb<Value> for Int {
     type From = Ruby;
     type To = Rust;


### PR DESCRIPTION
- u8, u16, u32
- i8, i16, i32

Needed to facilitate passing around port numbers (`u16`) to Rack. While I was here, I added converters for every integer type except `isize`, `usize`, and `u64` because those are fallible.