### PR TITLE
Enable Rack::Builder.new_from_string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,6 +420,7 @@ name = "mruby-bin"
 version = "0.1.0"
 dependencies = [
  "mruby 0.1.0",
+ "mruby-gems 0.1.0",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustyline 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/foolsgold/ruby/config.ru
+++ b/foolsgold/ruby/config.ru
@@ -3,7 +3,7 @@
 require 'foolsgold'
 
 # Monkeypatch String to add String#strip_heredoc_indent
-class String
+String.class_eval do
   # mruby doesn't support Regexp natively, so use a fixed width
   # strip technique.
   def strip_indent(indent)

--- a/mruby-bin/Cargo.toml
+++ b/mruby-bin/Cargo.toml
@@ -10,3 +10,6 @@ rustyline = "4.1.0"
 
 [dependencies.mruby]
 path = "../mruby"
+
+[dependencies.mruby-gems]
+path = "../mruby-gems"

--- a/mruby-bin/src/repl.rs
+++ b/mruby-bin/src/repl.rs
@@ -84,6 +84,10 @@ pub fn run(
     writeln!(output, "{}", preamble()?).map_err(Error::Io)?;
     let config = config.unwrap_or_else(Default::default);
     let interp = Interpreter::create().map_err(Error::Ruby)?;
+
+    // load gems
+    mruby_gems::rubygems::rack::init(&interp).map_err(Error::Ruby)?;
+
     let parser = Parser::new(&interp).ok_or(Error::ReplInit)?;
     interp.push_context(EvalContext::new(REPL_FILENAME));
     unsafe {

--- a/mruby-gems/src/rubygems/rack.rs
+++ b/mruby-gems/src/rubygems/rack.rs
@@ -20,9 +20,19 @@ struct Rack;
 impl Rack {
     fn contents<T: AsRef<str>>(path: T) -> Result<Vec<u8>, MrbError> {
         let path = path.as_ref();
-        Self::get(path)
+        let contents = Self::get(path)
             .map(Cow::into_owned)
-            .ok_or_else(|| MrbError::SourceNotFound(path.to_owned()))
+            .ok_or_else(|| MrbError::SourceNotFound(path.to_owned()))?;
+        // patches
+        if path == "rack/builder.rb" {
+            let bad = "TOPLEVEL_BINDING";
+            let good = "nil";
+            let string = String::from_utf8(contents)
+                .map_err(|_| MrbError::SourceNotFound(path.to_owned()))?;
+            Ok(string.replace(bad, good).into_bytes())
+        } else {
+            Ok(contents)
+        }
     }
 }
 

--- a/mruby-sys/sys.gembox
+++ b/mruby-sys/sys.gembox
@@ -4,6 +4,9 @@ MRuby::GemBox.new do |conf|
   # Compiler, parser, and context
   conf.gem core: 'mruby-compiler'
 
+  # eval and instance eval
+  conf.gem core: 'mruby-eval'
+
   # mrb_protect
   conf.gem core: 'mruby-error'
 

--- a/mruby/src/value/types.rs
+++ b/mruby/src/value/types.rs
@@ -45,6 +45,7 @@ pub enum Ruby {
     Module,
     Nil,
     Object,
+    Proc,
     SingletonClass,
     String,
     Symbol,
@@ -67,6 +68,7 @@ impl Ruby {
             Ruby::Module => "Module",
             Ruby::Nil => "NilClass",
             Ruby::Object => "Object",
+            Ruby::Proc => "Proc",
             Ruby::SingletonClass => "Singleton (anonymous) class",
             Ruby::String => "String",
             Ruby::Symbol => "Symbol",
@@ -134,7 +136,7 @@ impl From<sys::mrb_value> for Ruby {
             // def obj.bar; 'bar'; end
             // ```
             sys::mrb_vtype::MRB_TT_SCLASS => Ruby::SingletonClass,
-            sys::mrb_vtype::MRB_TT_PROC => unimplemented!("mruby type proc"),
+            sys::mrb_vtype::MRB_TT_PROC => Ruby::Proc,
             sys::mrb_vtype::MRB_TT_ARRAY => Ruby::Array,
             sys::mrb_vtype::MRB_TT_HASH => Ruby::Hash,
             sys::mrb_vtype::MRB_TT_STRING => Ruby::String,


### PR DESCRIPTION
- Add eval gem to sys build.
- Patch rack/builder.rb to use a nil binding instead of `TOPLEVEL_BINDING` because mruby does not support `Binding`s.
- Ensure `String` is monkey patched even when config.ru is loaded in an enclosing scope.
- Load Rack into rirb REPL.
- Make `Proc` a supported `Ruby` type.