### PR TITLE
Implement prefork mode in nemesis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,6 +453,7 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mruby 0.1.0",
  "mruby-gems 0.1.0",
+ "ref_thread_local 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-embed 4.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -725,6 +726,11 @@ dependencies = [
  "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "ref_thread_local"
+version = "0.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex"
@@ -1253,6 +1259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)" = "12229c14a0f65c4f1cb046a3b52047cdd9da1f4b30f8a39c5063c8bae515e252"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum redox_users 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe5204c3a17e97dde73f285d49be585df59ed84b50a872baf416e73b62c3828"
+"checksum ref_thread_local 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d813022b2e00774a48eaf43caaa3c20b45f040ba8cbf398e2e8911a06668dbe6"
 "checksum regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8f0a0bcab2fd7d1d7c54fa9eae6f43eddeb9ce2e7352f8518a814a4f65d60c58"
 "checksum regex-syntax 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "dcfd8681eebe297b81d98498869d4aae052137651ad7b96822f09ceb690d0a96"
 "checksum ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2c4db68a2e35f3497146b7e4563df7d4773a2433230c5e4b448328e31740458a"

--- a/foolsgold/src/main.rs
+++ b/foolsgold/src/main.rs
@@ -38,6 +38,17 @@ pub fn spawn() -> Result<(), Error> {
                     // preload foolsgold sources
                     interp.eval("require 'foolsgold'")?;
                     Ok(())
+                })),
+        )
+        .add_mount(
+            Mount::from_rackup("foolsgold", foolsgold::RACKUP, "/fools-gold/prefork")
+                .with_init(Box::new(|interp| {
+                    foolsgold::init(interp)?;
+                    // preload foolsgold sources
+                    interp.eval("require 'foolsgold'")?;
+                    Ok(())
+                }))
+                .with_shared_interpreter(Some(150)),
         )
         .add_static_assets(Assets::all()?)
         .serve()

--- a/foolsgold/src/main.rs
+++ b/foolsgold/src/main.rs
@@ -32,14 +32,12 @@ pub fn main() -> Result<(), i32> {
 pub fn spawn() -> Result<(), Error> {
     Builder::default()
         .add_mount(
-            Mount::from_rackup("foolsgold", foolsgold::RACKUP, "/fools-gold").with_init(Box::new(
-                |interp| {
+            Mount::from_rackup("foolsgold", foolsgold::RACKUP, "/fools-gold/shared-nothing")
+                .with_init(Box::new(|interp| {
                     foolsgold::init(interp)?;
                     // preload foolsgold sources
                     interp.eval("require 'foolsgold'")?;
                     Ok(())
-                },
-            )),
         )
         .add_static_assets(Assets::all()?)
         .serve()

--- a/nemesis/Cargo.toml
+++ b/nemesis/Cargo.toml
@@ -14,6 +14,7 @@ doctest = false
 
 [dependencies]
 log = "0.4.6"
+ref_thread_local = "0.0.0"
 rocket = "0.4.1"
 
 [dependencies.mruby]

--- a/nemesis/src/adapter.rs
+++ b/nemesis/src/adapter.rs
@@ -16,13 +16,19 @@ pub struct RackApp {
     interp: Mrb,
     app: Value,
     name: String,
+    mount_path: String,
 }
 
 impl RackApp {
     /// Create a Rack app by wrapping the supplied rackup source in a
     /// `Rack::Builder`. The returned [`Value`] has a call method and is
     /// suitable for serving a [`Mount`](crate::server::Mount).
-    pub fn from_rackup(interp: &Mrb, builder_script: &str, name: &str) -> Result<Self, MrbError> {
+    pub fn from_rackup(
+        interp: &Mrb,
+        builder_script: &str,
+        name: &str,
+        mount_path: &str,
+    ) -> Result<Self, MrbError> {
         let builder = interp.eval("Rack::Builder")?;
         let app = builder.funcall::<Value, _, _>(
             "new_from_string",
@@ -32,6 +38,7 @@ impl RackApp {
             interp: Rc::clone(interp),
             app,
             name: name.to_owned(),
+            mount_path: mount_path.to_owned(),
         })
     }
 
@@ -44,6 +51,10 @@ impl RackApp {
 
     pub fn name(&self) -> &str {
         &self.name
+    }
+
+    pub fn mount_path(&self) -> &str {
+        &self.mount_path
     }
 }
 

--- a/nemesis/src/interpreter.rs
+++ b/nemesis/src/interpreter.rs
@@ -1,23 +1,35 @@
 //! Create or retrieve an interpreter for a request.
 
 use mruby::eval::MrbEval;
+use mruby::gc::GarbageCollection;
 use mruby::interpreter::{Interpreter, Mrb};
 use mruby::MrbError;
 use mruby_gems::rubygems::rack;
+use ref_thread_local::RefThreadLocal;
+use std::collections::HashMap;
+use std::rc::Rc;
 use std::sync::Arc;
 
+use crate::adapter::RackApp;
 use crate::rubygems::nemesis;
 use crate::Error;
 
 pub type InitFunc = Box<dyn Fn(&Mrb) -> Result<(), MrbError> + Send + Sync>;
 
+ref_thread_local! {
+    static managed STORAGE: HashMap<Key, (usize, Mrb)> = HashMap::default();
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+enum Key {
+    PerWorker { app: Option<String> },
+}
+
 /// Execution mode of an interpreter for a given mount.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExecMode {
-    /// A single interpreter will be used for a worker executing the mount.
-    #[allow(dead_code)]
-    // TODO: undeaden this code.
-    PerMountPerWorker {
+    /// A single interpreter will be used for a worker executing the rack app.
+    PerAppPerWorker {
         /// After `max_requests`, close the interpreter and lazily initialize a
         /// new one.
         ///
@@ -30,35 +42,106 @@ pub enum ExecMode {
 }
 
 impl ExecMode {
-    pub fn interpreter(&self, init: &Option<Arc<InitFunc>>) -> Result<Mrb, Error> {
-        if let ExecMode::SingleUse = self {
-            let interp = Interpreter::create()?;
-            rack::init(&interp)?;
-            nemesis::init(&interp)?;
-            // Preload required gem sources
-            interp.eval("require 'rack'")?;
-            interp.eval("require 'nemesis'")?;
-            interp.eval("require 'nemesis/response'")?;
-            if let Some(init) = init {
-                init(&interp)?;
+    pub fn interpreter(
+        &self,
+        mount_path: &str,
+        init: &Option<Arc<InitFunc>>,
+    ) -> Result<Mrb, Error> {
+        match self {
+            ExecMode::SingleUse => {
+                info!(
+                    "Initializing single use interpreter for app at {}",
+                    mount_path
+                );
+                let interp = Interpreter::create()?;
+                rack::init(&interp)?;
+                nemesis::init(&interp)?;
+                // Preload required gem sources
+                interp.eval("require 'rack'")?;
+                interp.eval("require 'nemesis'")?;
+                interp.eval("require 'nemesis/response'")?;
+                if let Some(init) = init {
+                    init(&interp)?;
+                }
+                Ok(interp)
             }
-            Ok(interp)
-        } else {
-            // TODO: implement support for all exec modes.
-            panic!("Exec mode not implemented {:?}", self);
+            ExecMode::PerAppPerWorker { .. } => {
+                let key = Key::PerWorker {
+                    app: Some(mount_path.to_owned()),
+                };
+                let interp = {
+                    let borrow = STORAGE.borrow();
+                    borrow.get(&key).map(|(_, interp)| Rc::clone(interp))
+                };
+                if let Some(interp) = interp {
+                    Ok(interp)
+                } else {
+                    info!(
+                        "Initializing thread local interpreter for app at {}",
+                        mount_path
+                    );
+                    let interp = Interpreter::create()?;
+                    rack::init(&interp)?;
+                    nemesis::init(&interp)?;
+                    // Preload required gem sources
+                    interp.eval("require 'rack'")?;
+                    interp.eval("require 'nemesis'")?;
+                    interp.eval("require 'nemesis/response'")?;
+                    if let Some(init) = init {
+                        init(&interp)?;
+                    };
+                    STORAGE.borrow_mut().insert(key, (0, Rc::clone(&interp)));
+                    Ok(interp)
+                }
+            }
         }
     }
 
-    /// Maybe execute a garbage collection on the interpreter.
+    /// Finalize a request on the interpeter for `app`.
     ///
-    /// Returns true if a GC was performed, false otherwise.
-    pub fn gc(&self, interp: &Mrb) -> bool {
-        if let ExecMode::SingleUse = self {
-            false
-        } else {
-            let _ = interp;
-            // TODO: implement support for all exec modes.
-            panic!("Exec mode not implemented {:?}", self);
+    /// Keep track of the request count for an interpreter and potentially tear
+    /// it down if it has served too many requests.
+    ///
+    /// Maybe execute a garbage collection on the interpreter. Returns true if
+    /// a GC was performed, false otherwise.
+    pub fn finalize(&self, interp: &Mrb, app: &RackApp) -> bool {
+        match self {
+            ExecMode::SingleUse => false,
+            ExecMode::PerAppPerWorker { max_requests } => {
+                let key = Key::PerWorker {
+                    app: Some(app.mount_path().to_owned()),
+                };
+                {
+                    let mut borrow = STORAGE.borrow_mut();
+                    let counter = borrow
+                        .get_mut(&key)
+                        .map(|record| {
+                            let counter = record.0;
+                            record.0 += 1;
+                            counter
+                        })
+                        .unwrap_or_default();
+                    info!(
+                        "Finalizing request {} for app at {}",
+                        counter,
+                        app.mount_path()
+                    );
+                    if *max_requests > 0 && counter > 0 && counter % max_requests == 0 {
+                        // Recycle the interpreter if it has been used for
+                        // `max_requests` app invocations.
+                        borrow.remove(&key);
+                        info!(
+                            "Recycling interpreter at {} after {} requests",
+                            app.mount_path(),
+                            counter
+                        );
+                        false
+                    } else {
+                        interp.incremental_gc();
+                        true
+                    }
+                }
+            }
         }
     }
 }

--- a/nemesis/src/lib.rs
+++ b/nemesis/src/lib.rs
@@ -6,6 +6,8 @@
 #[macro_use]
 extern crate log;
 #[macro_use]
+extern crate ref_thread_local;
+#[macro_use]
 extern crate rocket;
 #[macro_use]
 extern crate rust_embed;

--- a/nemesis/src/server/mod.rs
+++ b/nemesis/src/server/mod.rs
@@ -81,8 +81,11 @@ pub struct Mount {
 impl Mount {
     pub fn from_rackup(name: &str, rackup: &str, mount_path: &str) -> Self {
         let name = name.to_owned();
+        let path = mount_path.to_owned();
         let rackup = rackup.to_owned();
-        let app = move |interp: &Mrb| RackApp::from_rackup(interp, &rackup.clone(), &name.clone());
+        let app = move |interp: &Mrb| {
+            RackApp::from_rackup(interp, &rackup.clone(), &name.clone(), &path.clone())
+        };
         Self {
             path: mount_path.to_owned(),
             app: Arc::new(Box::new(app)),

--- a/nemesis/src/server/mod.rs
+++ b/nemesis/src/server/mod.rs
@@ -103,4 +103,15 @@ impl Mount {
             exec_mode: self.exec_mode,
         }
     }
+
+    pub fn with_shared_interpreter(self, max_requests: Option<usize>) -> Self {
+        Self {
+            path: self.path,
+            app: self.app,
+            interp_init: self.interp_init,
+            exec_mode: ExecMode::PerAppPerWorker {
+                max_requests: max_requests.unwrap_or_default(),
+            },
+        }
+    }
 }

--- a/nemesis/src/server/rocket/routes.rs
+++ b/nemesis/src/server/rocket/routes.rs
@@ -87,7 +87,9 @@ impl Handler for RackHandler {
 }
 
 fn app<'a>(req: &request::Request, mount: &Mount) -> Result<rocket::Response<'a>, Error> {
-    let interp = mount.exec_mode.interpreter(&mount.interp_init)?;
+    let interp = mount
+        .exec_mode
+        .interpreter(&mount.path, &mount.interp_init)?;
     let _arena = interp.create_arena_savepoint();
     let app = (mount.app)(&interp)?;
     debug!(
@@ -109,6 +111,6 @@ fn app<'a>(req: &request::Request, mount: &Mount) -> Result<rocket::Response<'a>
         }
         Err(error) => return Err(error),
     };
-    mount.exec_mode.gc(&interp);
+    mount.exec_mode.finalize(&interp, &app);
     Ok(response)
 }


### PR DESCRIPTION
GH-97 removed the prefork route in `foolsgold`. This PR restores that functionality by adding the ability to associate a `Mount` with a thread local interpreter that is isolated to the Rack app in the `Mount`.

Prefork mounts can specify a `max_requests` parameter which will cause the thread local interpreter to be recycled (torn down and reinitialized) after the worker serves `max_requests` requests. This parameter exists to mitigate memory leaks.

The prefork implementation, even with recycling every 150 requests, has similar performance to the previous benchmarks: p99 5ms. For comparison, the shared nothing mode has p99 69ms.

