### PR TITLE
Handle Exceptions that don't have a backtrace

### DIFF
--- a/mruby/src/eval.rs
+++ b/mruby/src/eval.rs
@@ -252,22 +252,22 @@ NestedEval.file
     }
 
     #[test]
-    fn unparseable_code_returns_err_undef() {
+    fn unparseable_code_returns_err_syntax_error() {
         let interp = Interpreter::create().expect("mrb init");
         let result = interp.eval("'a").map(|_| ());
         assert_eq!(
             result,
-            Err(MrbError::UnreachableValue(sys::mrb_vtype::MRB_TT_UNDEF))
+            Err(MrbError::Exec("SyntaxError: syntax error".to_owned()))
         );
     }
 
     #[test]
-    fn interpreter_is_usable_after_returning_undef() {
+    fn interpreter_is_usable_after_syntax_error() {
         let interp = Interpreter::create().expect("mrb init");
         let result = interp.eval("'a").map(|_| ());
         assert_eq!(
             result,
-            Err(MrbError::UnreachableValue(sys::mrb_vtype::MRB_TT_UNDEF))
+            Err(MrbError::Exec("SyntaxError: syntax error".to_owned()))
         );
         // Ensure interpreter is usable after evaling unparseable code
         let result = interp.eval("'a' * 10 ").expect("eval");

--- a/mruby/src/extn/core/regexp.rs
+++ b/mruby/src/extn/core/regexp.rs
@@ -414,7 +414,6 @@ mod tests {
     use crate::eval::MrbEval;
     use crate::extn::core::regexp;
     use crate::interpreter::Interpreter;
-    use crate::sys;
     use crate::value::types::Ruby;
     use crate::value::{Value, ValueLike};
     use crate::MrbError;
@@ -541,7 +540,7 @@ mod tests {
         let regexp = interp.eval("/foo.*bar/o").map(|_| ());
         assert_eq!(
             regexp,
-            Err(MrbError::UnreachableValue(sys::mrb_vtype::MRB_TT_UNDEF))
+            Err(MrbError::Exec("SyntaxError: syntax error".to_owned()))
         );
     }
 


### PR DESCRIPTION
Some exceptions generated by the mruby VM, like `SyntaxError`, do not have a backtrace associated with them. Calling the `backtrace` Ruby method on them returns `nil`.

Previously, the exception handler in `MrbApi::current_exception` would itself throw an exception when attempting to marshal such an exception.

This PR only attempts to attach backtrace information to the `MrbError::Exec` if the backtrace is an `Array`.