### PR TITLE
Converter enhancements

### DIFF
--- a/mruby/src/convert/array/string.rs
+++ b/mruby/src/convert/array/string.rs
@@ -15,6 +15,18 @@ impl FromMrb<Vec<String>> for Value {
     }
 }
 
+impl FromMrb<Vec<&str>> for Value {
+    type From = Rust;
+    type To = Ruby;
+
+    fn from_mrb(interp: &Mrb, value: Vec<&str>) -> Self {
+        Self::from_mrb(
+            interp,
+            value.into_iter().map(str::as_bytes).collect::<Vec<_>>(),
+        )
+    }
+}
+
 #[allow(clippy::use_self)]
 // https://github.com/rust-lang/rust-clippy/issues/4143
 impl TryFromMrb<Value> for Vec<String> {
@@ -48,6 +60,21 @@ impl FromMrb<Vec<Option<String>>> for Value {
             value
                 .into_iter()
                 .map(|item| item.map(String::into_bytes))
+                .collect::<Vec<_>>(),
+        )
+    }
+}
+
+impl FromMrb<Vec<Option<&str>>> for Value {
+    type From = Rust;
+    type To = Ruby;
+
+    fn from_mrb(interp: &Mrb, value: Vec<Option<&str>>) -> Self {
+        Self::from_mrb(
+            interp,
+            value
+                .into_iter()
+                .map(|item| item.map(str::as_bytes))
                 .collect::<Vec<_>>(),
         )
     }

--- a/mruby/src/value/mod.rs
+++ b/mruby/src/value/mod.rs
@@ -10,14 +10,16 @@ use crate::MrbError;
 
 pub mod types;
 
+/// Max argument count for function calls including initialize.
+///
+/// Defined in `vm.c`.
+pub const MRB_FUNCALL_ARGC_MAX: usize = 16;
+
 #[allow(clippy::module_name_repetitions)]
 pub trait ValueLike
 where
     Self: Sized,
 {
-    // defined in vm.c
-    const MRB_FUNCALL_ARGC_MAX: usize = 16;
-
     fn inner(&self) -> sys::mrb_value;
 
     fn interp(&self) -> &Mrb;
@@ -35,15 +37,15 @@ where
         let arena = interp.create_arena_savepoint();
 
         let args = args.as_ref().iter().map(Value::inner).collect::<Vec<_>>();
-        if args.len() > Self::MRB_FUNCALL_ARGC_MAX {
+        if args.len() > MRB_FUNCALL_ARGC_MAX {
             warn!(
                 "Too many args supplied to funcall: given {}, max {}.",
                 args.len(),
-                Self::MRB_FUNCALL_ARGC_MAX
+                MRB_FUNCALL_ARGC_MAX
             );
             return Err(MrbError::TooManyArgs {
                 given: args.len(),
-                max: Self::MRB_FUNCALL_ARGC_MAX,
+                max: MRB_FUNCALL_ARGC_MAX,
             });
         }
         let method = method.as_ref();


### PR DESCRIPTION
- Allow `RustBackedValue`s to supply args to initialize the derived Ruby object.
- Simplify the implementation of `RustBackedValue` by returning `MrbError`.
- Add converters for `Vec` of `&str` and `Option<&str>`.
- Add converter from Ruby `Symbol` to Rust `String`.