### PR TITLE
Exception handler cleanup

### DIFF
--- a/mruby/src/convert/nilable.rs
+++ b/mruby/src/convert/nilable.rs
@@ -7,12 +7,14 @@ use crate::sys;
 use crate::value::types::{Ruby, Rust};
 use crate::value::Value;
 
+mod array;
 mod boolean;
 mod bytes;
 mod fixnum;
 mod float;
 mod string;
 
+pub use self::array::*;
 pub use self::boolean::*;
 pub use self::bytes::*;
 pub use self::fixnum::*;

--- a/mruby/src/convert/nilable/array.rs
+++ b/mruby/src/convert/nilable/array.rs
@@ -200,6 +200,7 @@ mod tests {
     }
 
     #[quickcheck]
+    #[allow(clippy::needless_pass_by_value)]
     fn convert_to_value(v: Option<Vec<Int>>) -> bool {
         let interp = Interpreter::create().expect("mrb init");
         let value = Value::from_mrb(&interp, v.clone());
@@ -212,6 +213,7 @@ mod tests {
     }
 
     #[quickcheck]
+    #[allow(clippy::needless_pass_by_value)]
     fn roundtrip(v: Option<Vec<Int>>) -> bool {
         let interp = Interpreter::create().expect("mrb init");
         let value = Value::from_mrb(&interp, v.clone());

--- a/mruby/src/convert/nilable/array.rs
+++ b/mruby/src/convert/nilable/array.rs
@@ -1,0 +1,221 @@
+use crate::convert::fixnum::Int;
+use crate::convert::float::Float;
+use crate::convert::{Error, FromMrb, TryFromMrb};
+use crate::interpreter::Mrb;
+use crate::value::types::{Ruby, Rust};
+use crate::value::Value;
+
+impl FromMrb<Option<Vec<bool>>> for Value {
+    type From = Rust;
+    type To = Ruby;
+
+    fn from_mrb(interp: &Mrb, value: Option<Vec<bool>>) -> Self {
+        if let Some(value) = value {
+            Self::from_mrb(interp, value)
+        } else {
+            Self::from_mrb(interp, None::<Self>)
+        }
+    }
+}
+
+#[allow(clippy::use_self)]
+// https://github.com/rust-lang/rust-clippy/issues/4143
+impl TryFromMrb<Value> for Option<Vec<bool>> {
+    type From = Ruby;
+    type To = Rust;
+
+    unsafe fn try_from_mrb(
+        interp: &Mrb,
+        value: Value,
+    ) -> Result<Self, Error<Self::From, Self::To>> {
+        let value = <Option<Value>>::try_from_mrb(interp, value)?;
+        if let Some(item) = value {
+            Ok(Some(<Vec<bool>>::try_from_mrb(interp, item)?))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+impl FromMrb<Option<Vec<Vec<u8>>>> for Value {
+    type From = Rust;
+    type To = Ruby;
+
+    fn from_mrb(interp: &Mrb, value: Option<Vec<Vec<u8>>>) -> Self {
+        if let Some(value) = value {
+            Self::from_mrb(interp, value)
+        } else {
+            Self::from_mrb(interp, None::<Self>)
+        }
+    }
+}
+
+#[allow(clippy::use_self)]
+// https://github.com/rust-lang/rust-clippy/issues/4143
+impl TryFromMrb<Value> for Option<Vec<Vec<u8>>> {
+    type From = Ruby;
+    type To = Rust;
+
+    unsafe fn try_from_mrb(
+        interp: &Mrb,
+        value: Value,
+    ) -> Result<Self, Error<Self::From, Self::To>> {
+        let value = <Option<Value>>::try_from_mrb(interp, value)?;
+        if let Some(item) = value {
+            Ok(Some(<Vec<Vec<u8>>>::try_from_mrb(interp, item)?))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+impl FromMrb<Option<Vec<Int>>> for Value {
+    type From = Rust;
+    type To = Ruby;
+
+    fn from_mrb(interp: &Mrb, value: Option<Vec<Int>>) -> Self {
+        if let Some(value) = value {
+            Self::from_mrb(interp, value)
+        } else {
+            Self::from_mrb(interp, None::<Self>)
+        }
+    }
+}
+
+#[allow(clippy::use_self)]
+// https://github.com/rust-lang/rust-clippy/issues/4143
+impl TryFromMrb<Value> for Option<Vec<Int>> {
+    type From = Ruby;
+    type To = Rust;
+
+    unsafe fn try_from_mrb(
+        interp: &Mrb,
+        value: Value,
+    ) -> Result<Self, Error<Self::From, Self::To>> {
+        let value = <Option<Value>>::try_from_mrb(interp, value)?;
+        if let Some(item) = value {
+            Ok(Some(<Vec<Int>>::try_from_mrb(interp, item)?))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+impl FromMrb<Option<Vec<Float>>> for Value {
+    type From = Rust;
+    type To = Ruby;
+
+    fn from_mrb(interp: &Mrb, value: Option<Vec<Float>>) -> Self {
+        if let Some(value) = value {
+            Self::from_mrb(interp, value)
+        } else {
+            Self::from_mrb(interp, None::<Self>)
+        }
+    }
+}
+
+#[allow(clippy::use_self)]
+// https://github.com/rust-lang/rust-clippy/issues/4143
+impl TryFromMrb<Value> for Option<Vec<Float>> {
+    type From = Ruby;
+    type To = Rust;
+
+    unsafe fn try_from_mrb(
+        interp: &Mrb,
+        value: Value,
+    ) -> Result<Self, Error<Self::From, Self::To>> {
+        let value = <Option<Value>>::try_from_mrb(interp, value)?;
+        if let Some(item) = value {
+            Ok(Some(<Vec<Float>>::try_from_mrb(interp, item)?))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+impl FromMrb<Option<Vec<String>>> for Value {
+    type From = Rust;
+    type To = Ruby;
+
+    fn from_mrb(interp: &Mrb, value: Option<Vec<String>>) -> Self {
+        if let Some(value) = value {
+            Self::from_mrb(interp, value)
+        } else {
+            Self::from_mrb(interp, None::<Self>)
+        }
+    }
+}
+
+#[allow(clippy::use_self)]
+// https://github.com/rust-lang/rust-clippy/issues/4143
+impl TryFromMrb<Value> for Option<Vec<String>> {
+    type From = Ruby;
+    type To = Rust;
+
+    unsafe fn try_from_mrb(
+        interp: &Mrb,
+        value: Value,
+    ) -> Result<Self, Error<Self::From, Self::To>> {
+        let value = <Option<Value>>::try_from_mrb(interp, value)?;
+        if let Some(item) = value {
+            Ok(Some(<Vec<String>>::try_from_mrb(interp, item)?))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+impl FromMrb<Option<Vec<&str>>> for Value {
+    type From = Rust;
+    type To = Ruby;
+
+    fn from_mrb(interp: &Mrb, value: Option<Vec<&str>>) -> Self {
+        if let Some(value) = value {
+            Self::from_mrb(interp, value)
+        } else {
+            Self::from_mrb(interp, None::<Self>)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use quickcheck_macros::quickcheck;
+
+    use crate::convert::fixnum::Int;
+    use crate::convert::{FromMrb, TryFromMrb};
+    use crate::eval::MrbEval;
+    use crate::interpreter::Interpreter;
+    use crate::sys;
+    use crate::value::types::Ruby;
+    use crate::value::Value;
+
+    #[test]
+    fn fail_convert() {
+        let interp = Interpreter::create().expect("mrb init");
+        // get a mrb_value that can't be converted to a primitive type.
+        let value = interp.eval("Object.new").expect("eval");
+        let result = unsafe { <Option<Vec<Int>>>::try_from_mrb(&interp, value) }.map(|_| ());
+        assert_eq!(result.map_err(|e| e.from), Err(Ruby::Object));
+    }
+
+    #[quickcheck]
+    fn convert_to_value(v: Option<Vec<Int>>) -> bool {
+        let interp = Interpreter::create().expect("mrb init");
+        let value = Value::from_mrb(&interp, v.clone());
+        if let Some(v) = v {
+            let value = unsafe { <Vec<Int>>::try_from_mrb(&interp, value) }.expect("convert");
+            value == v
+        } else {
+            unsafe { sys::mrb_sys_value_is_nil(value.inner()) }
+        }
+    }
+
+    #[quickcheck]
+    fn roundtrip(v: Option<Vec<Int>>) -> bool {
+        let interp = Interpreter::create().expect("mrb init");
+        let value = Value::from_mrb(&interp, v.clone());
+        let value = unsafe { <Option<Vec<Int>>>::try_from_mrb(&interp, value) }.expect("convert");
+        value == v
+    }
+}

--- a/mruby/src/exception.rs
+++ b/mruby/src/exception.rs
@@ -1,0 +1,156 @@
+use log::{debug, trace};
+use std::ffi::c_void;
+use std::fmt;
+
+use crate::gc::GarbageCollection;
+use crate::interpreter::Mrb;
+use crate::sys;
+use crate::value::{Value, ValueLike};
+use crate::MrbError;
+
+/// Metadata about a Ruby exception.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Exception {
+    /// The result of calling `exception.class.name`.
+    pub class: String,
+    /// The result of calling `exception.message`.
+    pub message: String,
+    /// The result of calling `exception.backtrace`.
+    ///
+    /// Some exceptions, like `SyntaxError` which is thrown directly by the
+    /// mruby VM, do not have backtraces, so this field is optional.
+    pub backtrace: Option<Vec<String>>,
+    /// The result of calling `exception.inspect`.
+    pub inspect: String,
+}
+
+impl Exception {
+    pub fn new(class: &str, message: &str, backtrace: Option<Vec<String>>, inspect: &str) -> Self {
+        Self {
+            class: class.to_owned(),
+            message: message.to_owned(),
+            backtrace,
+            inspect: inspect.to_owned(),
+        }
+    }
+}
+
+impl fmt::Display for Exception {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.inspect)?;
+        if let Some(ref backtrace) = self.backtrace {
+            for frame in backtrace {
+                write!(f, "\n{}", frame)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+pub enum LastError {
+    Some(Exception),
+    None,
+    UnableToExtract(MrbError),
+}
+
+/// Extract the last exception thrown on the interpreter.
+#[allow(clippy::module_name_repetitions)]
+pub trait MrbExceptionHandler {
+    /// Extract the last thrown exception on the mruby interpreter if there is
+    /// one.
+    ///
+    /// If there is an error, return [`LastError::Some`], which contains the
+    /// exception class name, message, and optional backtrace.
+    fn last_error(&self) -> LastError;
+}
+
+impl MrbExceptionHandler for Mrb {
+    fn last_error(&self) -> LastError {
+        let _arena = self.create_arena_savepoint();
+        let mrb = { self.borrow().mrb };
+        let exc = unsafe {
+            let exc = (*mrb).exc;
+            // Clear the current exception from the mruby interpreter so
+            // subsequent calls to the mruby VM are not tainted by an error they
+            // did not generate.
+            //
+            // We must do this at the beginning of `current_exception` so we can
+            // use the mruby VM to inspect the exception once we turn it into an
+            // `mrb_value`. `ValueLike::funcall` handles errors by calling this
+            // function, so not clearing the exception results in a stack
+            // overflow.
+            (*mrb).exc = std::ptr::null_mut();
+            exc
+        };
+        if exc.is_null() {
+            trace!("No last error present");
+            return LastError::None;
+        }
+        // Generate exception metadata in by executing the following Ruby code:
+        //
+        // ```ruby
+        // clazz = exception.class.name
+        // message = exception.message
+        // backtrace = exception.backtrace
+        // ```
+        let exception = Value::new(self, unsafe { sys::mrb_sys_obj_value(exc as *mut c_void) });
+        let class = exception
+            .funcall::<Value, _, _>("class", &[])
+            .and_then(|exception| exception.funcall::<String, _, _>("name", &[]));
+        let class = match class {
+            Ok(class) => class,
+            Err(err) => return LastError::UnableToExtract(err),
+        };
+        let message = match exception.funcall::<String, _, _>("message", &[]) {
+            Ok(message) => message,
+            Err(err) => return LastError::UnableToExtract(err),
+        };
+        let backtrace = match exception.funcall::<Option<Vec<String>>, _, _>("backtrace", &[]) {
+            Ok(backtrace) => backtrace,
+            Err(err) => return LastError::UnableToExtract(err),
+        };
+        let inspect = match exception.funcall::<String, _, _>("inspect", &[]) {
+            Ok(inspect) => inspect,
+            Err(err) => return LastError::UnableToExtract(err),
+        };
+        let exception = Exception {
+            class,
+            message,
+            backtrace,
+            inspect,
+        };
+        debug!("Extracted exception from interpreter: {}", exception);
+        LastError::Some(exception)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::eval::MrbEval;
+    use crate::exception::Exception;
+    use crate::interpreter::Interpreter;
+    use crate::MrbError;
+
+    #[test]
+    fn return_exception() {
+        let interp = Interpreter::create().expect("mrb init");
+        let result = interp
+            .eval("raise ArgumentError.new('waffles')")
+            .map(|_| ());
+        let expected = Exception::new(
+            "ArgumentError",
+            "waffles",
+            Some(vec!["(eval):1".to_owned()]),
+            "(eval):1: waffles (ArgumentError)",
+        );
+        assert_eq!(result, Err(MrbError::Exec(expected.to_string())));
+    }
+
+    #[test]
+    fn return_exception_with_no_backtrace() {
+        let interp = Interpreter::create().expect("mrb init");
+        let result = interp.eval("def bad; /./o; end").map(|_| ());
+        let expected = Exception::new("SyntaxError", "waffles", None, "SyntaxError: syntax error");
+        assert_eq!(result, Err(MrbError::Exec(expected.to_string())));
+    }
+}

--- a/mruby/src/lib.rs
+++ b/mruby/src/lib.rs
@@ -12,6 +12,7 @@ pub mod class;
 pub mod convert;
 pub mod def;
 pub mod eval;
+pub mod exception;
 pub mod extn;
 pub mod file;
 pub mod gc;
@@ -29,6 +30,7 @@ pub enum MrbError {
     ArgSpec,
     ConvertToRuby(convert::Error<value::types::Rust, value::types::Ruby>),
     ConvertToRust(convert::Error<value::types::Ruby, value::types::Rust>),
+    // TODO: this should really be an `Exception` instead of a `String`.
     Exec(String),
     New,
     NotDefined(String),


### PR DESCRIPTION
Refactor exception handling

- Break exception handler out of MrbApi into its own trait
- Introduce an exception struct that contains class name, message, backtrace,
  and inspect string
- Properly propagate MrbError from exception handler

This PR also adds converters for nilable Array of {Boolean, Bytes, Int, Float, String} to `Option<Vec<_>>`.