### PR TITLE
Add forwardable impl to stdlib

### DIFF
--- a/mruby/src/extn/stdlib/forwardable.rb
+++ b/mruby/src/extn/stdlib/forwardable.rb
@@ -1,0 +1,309 @@
+# frozen_string_literal: false
+#
+#   forwardable.rb -
+#       $Release Version: 1.1$
+#       $Revision$
+#       by Keiju ISHITSUKA(keiju@ishitsuka.com)
+#       original definition by delegator.rb
+#       Revised by Daniel J. Berger with suggestions from Florian Gross.
+#
+#       Documentation by James Edward Gray II and Gavin Sinclair
+
+
+
+# The Forwardable module provides delegation of specified
+# methods to a designated object, using the methods #def_delegator
+# and #def_delegators.
+#
+# For example, say you have a class RecordCollection which
+# contains an array <tt>@records</tt>.  You could provide the lookup method
+# #record_number(), which simply calls #[] on the <tt>@records</tt>
+# array, like this:
+#
+#   require 'forwardable'
+#
+#   class RecordCollection
+#     attr_accessor :records
+#     extend Forwardable
+#     def_delegator :@records, :[], :record_number
+#   end
+#
+# We can use the lookup method like so:
+#
+#   r = RecordCollection.new
+#   r.records = [4,5,6]
+#   r.record_number(0)  # => 4
+#
+# Further, if you wish to provide the methods #size, #<<, and #map,
+# all of which delegate to @records, this is how you can do it:
+#
+#   class RecordCollection # re-open RecordCollection class
+#     def_delegators :@records, :size, :<<, :map
+#   end
+#
+#   r = RecordCollection.new
+#   r.records = [1,2,3]
+#   r.record_number(0)   # => 1
+#   r.size               # => 3
+#   r << 4               # => [1, 2, 3, 4]
+#   r.map { |x| x * 2 }  # => [2, 4, 6, 8]
+#
+# You can even extend regular objects with Forwardable.
+#
+#   my_hash = Hash.new
+#   my_hash.extend Forwardable              # prepare object for delegation
+#   my_hash.def_delegator "STDOUT", "puts"  # add delegation for STDOUT.puts()
+#   my_hash.puts "Howdy!"
+#
+# == Another example
+#
+# We want to rely on what has come before obviously, but with delegation we can
+# take just the methods we need and even rename them as appropriate.  In many
+# cases this is preferable to inheritance, which gives us the entire old
+# interface, even if much of it isn't needed.
+#
+#   class Queue
+#     extend Forwardable
+#
+#     def initialize
+#       @q = [ ]    # prepare delegate object
+#     end
+#
+#     # setup preferred interface, enq() and deq()...
+#     def_delegator :@q, :push, :enq
+#     def_delegator :@q, :shift, :deq
+#
+#     # support some general Array methods that fit Queues well
+#     def_delegators :@q, :clear, :first, :push, :shift, :size
+#   end
+#
+#   q = Queue.new
+#   q.enq 1, 2, 3, 4, 5
+#   q.push 6
+#
+#   q.shift    # => 1
+#   while q.size > 0
+#     puts q.deq
+#   end
+#
+#   q.enq "Ruby", "Perl", "Python"
+#   puts q.first
+#   q.clear
+#   puts q.first
+#
+# This should output:
+#
+#   2
+#   3
+#   4
+#   5
+#   6
+#   Ruby
+#   nil
+#
+# == Notes
+#
+# Be advised, RDoc will not detect delegated methods.
+#
+# +forwardable.rb+ provides single-method delegation via the def_delegator and
+# def_delegators methods. For full-class delegation via DelegateClass, see
+# +delegate.rb+.
+#
+module Forwardable
+  require 'forwardable/impl'
+
+  # Version of +forwardable.rb+
+  VERSION = "1.2.0"
+  FORWARDABLE_VERSION = VERSION
+
+  @debug = nil
+  class << self
+    # ignored
+    attr_accessor :debug
+  end
+
+  # Takes a hash as its argument.  The key is a symbol or an array of
+  # symbols.  These symbols correspond to method names.  The value is
+  # the accessor to which the methods will be delegated.
+  #
+  # :call-seq:
+  #    delegate method => accessor
+  #    delegate [method, method, ...] => accessor
+  #
+  def instance_delegate(hash)
+    hash.each do |methods, accessor|
+      unless defined?(methods.each)
+        def_instance_delegator(accessor, methods)
+      else
+        methods.each {|method| def_instance_delegator(accessor, method)}
+      end
+    end
+  end
+
+  #
+  # Shortcut for defining multiple delegator methods, but with no
+  # provision for using a different name.  The following two code
+  # samples have the same effect:
+  #
+  #   def_delegators :@records, :size, :<<, :map
+  #
+  #   def_delegator :@records, :size
+  #   def_delegator :@records, :<<
+  #   def_delegator :@records, :map
+  #
+  def def_instance_delegators(accessor, *methods)
+    methods.delete("__send__")
+    methods.delete("__id__")
+    for method in methods
+      def_instance_delegator(accessor, method)
+    end
+  end
+
+  # Define +method+ as delegator instance method with an optional
+  # alias name +ali+. Method calls to +ali+ will be delegated to
+  # +accessor.method+.
+  #
+  #   class MyQueue
+  #     extend Forwardable
+  #     attr_reader :queue
+  #     def initialize
+  #       @queue = []
+  #     end
+  #
+  #     def_delegator :@queue, :push, :mypush
+  #   end
+  #
+  #   q = MyQueue.new
+  #   q.mypush 42
+  #   q.queue    #=> [42]
+  #   q.push 23  #=> NoMethodError
+  #
+  def def_instance_delegator(accessor, method, ali = method)
+    gen = Forwardable._delegator_method(self, accessor, method, ali)
+
+    # If it's not a class or module, it's an instance
+    (Module === self ? self : singleton_class).module_eval(&gen)
+  end
+
+  alias delegate instance_delegate
+  alias def_delegators def_instance_delegators
+  alias def_delegator def_instance_delegator
+
+  # :nodoc:
+  def self._delegator_method(obj, accessor, method, ali)
+    accessor = accessor.to_s unless Symbol === accessor
+
+    if Module === obj ?
+         obj.method_defined?(accessor) || obj.private_method_defined?(accessor) :
+         obj.respond_to?(accessor, true)
+      accessor = "#{accessor}()"
+    end
+
+    method_call = ".__send__(:#{method}, *args, &block)"
+    if _valid_method?(method)
+      loc, = caller_locations(2,1)
+      pre = "_ ="
+      mesg = "#{Module === obj ? obj : obj.class}\##{ali} at #{loc.path}:#{loc.lineno} forwarding to private method "
+      method_call = "#{<<-"begin;"}\n#{<<-"end;".chomp}"
+        begin;
+          unless defined? _.#{method}
+            ::Kernel.warn #{mesg.dump}"\#{_.class}"'##{method}', uplevel: 1
+            _#{method_call}
+          else
+            _.#{method}(*args, &block)
+          end
+        end;
+    end
+
+    _compile_method("#{<<-"begin;"}\n#{<<-"end;"}", __FILE__, __LINE__+1)
+    begin;
+      proc do
+        def #{ali}(*args, &block)
+          #{pre}
+          begin
+            #{accessor}
+          end#{method_call}
+        end
+      end
+    end;
+  end
+end
+
+# SingleForwardable can be used to setup delegation at the object level as well.
+#
+#    printer = String.new
+#    printer.extend SingleForwardable        # prepare object for delegation
+#    printer.def_delegator "STDOUT", "puts"  # add delegation for STDOUT.puts()
+#    printer.puts "Howdy!"
+#
+# Also, SingleForwardable can be used to set up delegation for a Class or Module.
+#
+#   class Implementation
+#     def self.service
+#       puts "serviced!"
+#     end
+#   end
+#
+#   module Facade
+#     extend SingleForwardable
+#     def_delegator :Implementation, :service
+#   end
+#
+#   Facade.service #=> serviced!
+#
+# If you want to use both Forwardable and SingleForwardable, you can
+# use methods def_instance_delegator and def_single_delegator, etc.
+module SingleForwardable
+  # Takes a hash as its argument.  The key is a symbol or an array of
+  # symbols.  These symbols correspond to method names.  The value is
+  # the accessor to which the methods will be delegated.
+  #
+  # :call-seq:
+  #    delegate method => accessor
+  #    delegate [method, method, ...] => accessor
+  #
+  def single_delegate(hash)
+    hash.each do |methods, accessor|
+      unless defined?(methods.each)
+        def_single_delegator(accessor, methods)
+      else
+        methods.each {|method| def_single_delegator(accessor, method)}
+      end
+    end
+  end
+
+  #
+  # Shortcut for defining multiple delegator methods, but with no
+  # provision for using a different name.  The following two code
+  # samples have the same effect:
+  #
+  #   def_delegators :@records, :size, :<<, :map
+  #
+  #   def_delegator :@records, :size
+  #   def_delegator :@records, :<<
+  #   def_delegator :@records, :map
+  #
+  def def_single_delegators(accessor, *methods)
+    methods.delete("__send__")
+    methods.delete("__id__")
+    for method in methods
+      def_single_delegator(accessor, method)
+    end
+  end
+
+  # :call-seq:
+  #   def_single_delegator(accessor, method, new_name=method)
+  #
+  # Defines a method _method_ which delegates to _accessor_ (i.e. it calls
+  # the method of the same name in _accessor_).  If _new_name_ is
+  # provided, it is used as the name for the delegate method.
+  def def_single_delegator(accessor, method, ali = method)
+    gen = Forwardable._delegator_method(self, accessor, method, ali)
+
+    instance_eval(&gen)
+  end
+
+  alias delegate single_delegate
+  alias def_delegators def_single_delegators
+  alias def_delegator def_single_delegator
+end

--- a/mruby/src/extn/stdlib/forwardable.rb
+++ b/mruby/src/extn/stdlib/forwardable.rb
@@ -192,7 +192,7 @@ module Forwardable
   def self._delegator_method(obj, accessor, method, ali)
     accessor = accessor.to_s unless accessor.is_a?(Symbol)
 
-    if obj.is_a?(Module) && (obj.method_defined?(accessor) || obj.private_method_defined?(accessor))
+    if obj.is_a?(Module) && obj.method_defined?(accessor)
       accessor = "#{accessor}()"
     elsif obj.respond_to?(accessor, true)
       accessor = "#{accessor}()"

--- a/mruby/src/extn/stdlib/forwardable.rb
+++ b/mruby/src/extn/stdlib/forwardable.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: false
+
 #
 #   forwardable.rb -
 #       $Release Version: 1.1$
@@ -8,8 +9,6 @@
 #       Revised by Daniel J. Berger with suggestions from Florian Gross.
 #
 #       Documentation by James Edward Gray II and Gavin Sinclair
-
-
 
 # The Forwardable module provides delegation of specified
 # methods to a designated object, using the methods #def_delegator
@@ -113,7 +112,7 @@ module Forwardable
   require 'forwardable/impl'
 
   # Version of +forwardable.rb+
-  VERSION = "1.2.0"
+  VERSION = '1.2.0'.freeze
   FORWARDABLE_VERSION = VERSION
 
   @debug = nil
@@ -132,10 +131,10 @@ module Forwardable
   #
   def instance_delegate(hash)
     hash.each do |methods, accessor|
-      unless defined?(methods.each)
-        def_instance_delegator(accessor, methods)
+      if defined?(methods.each)
+        methods.each { |method| def_instance_delegator(accessor, method) }
       else
-        methods.each {|method| def_instance_delegator(accessor, method)}
+        def_instance_delegator(accessor, methods)
       end
     end
   end
@@ -152,9 +151,9 @@ module Forwardable
   #   def_delegator :@records, :map
   #
   def def_instance_delegators(accessor, *methods)
-    methods.delete("__send__")
-    methods.delete("__id__")
-    for method in methods
+    methods.delete('__send__')
+    methods.delete('__id__')
+    methods.each do |method|
       def_instance_delegator(accessor, method)
     end
   end
@@ -201,21 +200,21 @@ module Forwardable
 
     method_call = ".__send__(:#{method}, *args, &block)"
     if _valid_method?(method)
-      loc, = caller_locations(2,1)
-      pre = "_ ="
+      loc, = caller_locations(2, 1)
+      pre = '_ ='
       mesg = "#{Module === obj ? obj : obj.class}\##{ali} at #{loc.path}:#{loc.lineno} forwarding to private method "
       method_call = "#{<<-"begin;"}\n#{<<-"end;".chomp}"
-        begin;
+      begin;
           unless defined? _.#{method}
             ::Kernel.warn #{mesg.dump}"\#{_.class}"'##{method}', uplevel: 1
             _#{method_call}
           else
             _.#{method}(*args, &block)
           end
-        end;
+      end;
     end
 
-    _compile_method("#{<<-"begin;"}\n#{<<-"end;"}", __FILE__, __LINE__+1)
+    _compile_method("#{<<-"begin;"}\n#{<<-"end;"}", __FILE__, __LINE__ + 1)
     begin;
       proc do
         def #{ali}(*args, &block)
@@ -264,10 +263,10 @@ module SingleForwardable
   #
   def single_delegate(hash)
     hash.each do |methods, accessor|
-      unless defined?(methods.each)
-        def_single_delegator(accessor, methods)
+      if defined?(methods.each)
+        methods.each { |method| def_single_delegator(accessor, method) }
       else
-        methods.each {|method| def_single_delegator(accessor, method)}
+        def_single_delegator(accessor, methods)
       end
     end
   end
@@ -284,9 +283,9 @@ module SingleForwardable
   #   def_delegator :@records, :map
   #
   def def_single_delegators(accessor, *methods)
-    methods.delete("__send__")
-    methods.delete("__id__")
-    for method in methods
+    methods.delete('__send__')
+    methods.delete('__id__')
+    methods.each do |method|
       def_single_delegator(accessor, method)
     end
   end

--- a/mruby/src/extn/stdlib/forwardable.rs
+++ b/mruby/src/extn/stdlib/forwardable.rs
@@ -1,0 +1,187 @@
+use crate::interpreter::Mrb;
+use crate::load::MrbLoadSources;
+use crate::MrbError;
+
+pub fn init(interp: &Mrb) -> Result<(), MrbError> {
+    interp
+        .borrow_mut()
+        .def_module::<Forwardable>("Forwardable", None);
+    interp.def_rb_source_file("forwardable.rb", include_str!("forwardable.rb"))?;
+    interp.def_rb_source_file("forwardable/impl.rb", include_str!("forwardable/impl.rb"))?;
+    Ok(())
+}
+
+pub struct Forwardable;
+
+// Monitor tests from ruby/spec
+// https://github.com/ruby/spec/tree/master/library/monitor
+#[cfg(test)]
+mod tests {
+    use crate::eval::MrbEval;
+    use crate::interpreter::Interpreter;
+    use crate::value::ValueLike;
+
+    #[test]
+    #[allow(clippy::shadow_unrelated)]
+    fn forwardable() {
+        let interp = Interpreter::create().expect("mrb init");
+        interp
+            .eval(
+                r#"
+require 'forwardable'
+
+class RecordCollection
+  attr_accessor :records
+  extend Forwardable
+  def_delegator :@records, :[], :record_number
+end
+                "#,
+            )
+            .unwrap();
+        let result = interp
+            .eval(
+                r#"
+r = RecordCollection.new
+r.records = [4,5,6]
+r.record_number(0)
+                "#,
+            )
+            .unwrap()
+            .funcall::<i64, _, _>("itself", &[])
+            .unwrap();
+        assert_eq!(result, 4);
+        interp
+            .eval(
+                r#"
+class RecordCollection # re-open RecordCollection class
+  def_delegators :@records, :size, :<<, :map
+end
+                "#,
+            )
+            .unwrap();
+        let result = interp
+            .eval(
+                r#"
+r = RecordCollection.new
+r.records = [1,2,3]
+r.record_number(0)
+                "#,
+            )
+            .unwrap()
+            .funcall::<i64, _, _>("itself", &[])
+            .unwrap();
+        assert_eq!(result, 1);
+        let result = interp
+            .eval("r.size")
+            .unwrap()
+            .funcall::<i64, _, _>("itself", &[])
+            .unwrap();
+        assert_eq!(result, 3);
+        let result = interp
+            .eval("r << 4")
+            .unwrap()
+            .funcall::<Vec<i64>, _, _>("itself", &[])
+            .unwrap();
+        assert_eq!(result, vec![1, 2, 3, 4]);
+        let result = interp
+            .eval("r.map { |x| x * 2 }")
+            .unwrap()
+            .funcall::<Vec<i64>, _, _>("itself", &[])
+            .unwrap();
+        assert_eq!(result, vec![2, 4, 6, 8]);
+    }
+
+    #[test]
+    fn forwardable_another_example() {
+        let interp = Interpreter::create().expect("mrb init");
+        let result = interp
+            .eval(
+                r#"
+require 'forwardable'
+
+class Queue
+  extend Forwardable
+
+  def initialize
+    @q = [ ]    # prepare delegate object
+  end
+
+  # setup preferred interface, enq() and deq()...
+  def_delegator :@q, :push, :enq
+  def_delegator :@q, :shift, :deq
+
+  # support some general Array methods that fit Queues well
+  def_delegators :@q, :clear, :first, :push, :shift, :size
+end
+
+out = []
+
+q = Queue.new
+q.enq 1, 2, 3, 4, 5
+q.push 6
+
+q.shift    # => 1
+while q.size > 0
+  out << q.deq.to_s
+end
+
+q.enq "Ruby", "Perl", "Python"
+out << q.first
+q.clear
+out << q.first
+                "#,
+            )
+            .unwrap()
+            .funcall::<Vec<Option<String>>, _, _>("itself", &[])
+            .unwrap();
+        assert_eq!(
+            result,
+            vec![
+                Some("2".to_owned()),
+                Some("3".to_owned()),
+                Some("4".to_owned()),
+                Some("5".to_owned()),
+                Some("6".to_owned()),
+                Some("Ruby".to_owned()),
+                None
+            ]
+        );
+    }
+
+    #[test]
+    fn forwardable_def_instance_delegator() {
+        let interp = Interpreter::create().expect("mrb init");
+        let result = interp
+            .eval(
+                r#"
+require 'forwardable'
+
+class MyQueue
+  extend Forwardable
+  attr_reader :queue
+  def initialize
+    @queue = []
+  end
+
+  def_delegator :@queue, :push, :mypush
+end
+
+q = MyQueue.new
+q.mypush 42
+# q.queue    #=> [42]
+raise 'fail' unless q.queue == [42]
+# q.push 23  #=> NoMethodError
+begin
+  q.push 23
+  false
+rescue NoMethodError
+  true
+end
+                "#,
+            )
+            .unwrap()
+            .funcall::<bool, _, _>("itself", &[])
+            .unwrap();
+        assert!(result);
+    }
+}

--- a/mruby/src/extn/stdlib/forwardable/forwardable.gemspec
+++ b/mruby/src/extn/stdlib/forwardable/forwardable.gemspec
@@ -1,0 +1,26 @@
+begin
+  require_relative "lib/forwardable"
+rescue LoadError
+  # for Ruby core repository
+  require_relative "../forwardable"
+end
+
+Gem::Specification.new do |spec|
+  spec.name          = "forwardable"
+  spec.version       = Forwardable::VERSION
+  spec.authors       = ["Keiju ISHITSUKA"]
+  spec.email         = ["keiju@ruby-lang.org"]
+
+  spec.summary       = %q{Provides delegation of specified methods to a designated object.}
+  spec.description   = %q{Provides delegation of specified methods to a designated object.}
+  spec.homepage      = "https://github.com/ruby/forwardable"
+  spec.license       = "BSD-2-Clause"
+
+  spec.files         = [".gitignore", ".travis.yml", "Gemfile", "LICENSE.txt", "README.md", "Rakefile", "bin/console", "bin/setup", "forwardable.gemspec", "lib/forwardable.rb", "lib/forwardable/impl.rb"]
+  spec.bindir        = "exe"
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.require_paths = ["lib"]
+
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
+end

--- a/mruby/src/extn/stdlib/forwardable/forwardable.gemspec
+++ b/mruby/src/extn/stdlib/forwardable/forwardable.gemspec
@@ -1,26 +1,28 @@
+# frozen_string_literal: true
+
 begin
-  require_relative "lib/forwardable"
+  require_relative 'lib/forwardable'
 rescue LoadError
   # for Ruby core repository
-  require_relative "../forwardable"
+  require_relative '../forwardable'
 end
 
 Gem::Specification.new do |spec|
-  spec.name          = "forwardable"
+  spec.name          = 'forwardable'
   spec.version       = Forwardable::VERSION
-  spec.authors       = ["Keiju ISHITSUKA"]
-  spec.email         = ["keiju@ruby-lang.org"]
+  spec.authors       = ['Keiju ISHITSUKA']
+  spec.email         = ['keiju@ruby-lang.org']
 
-  spec.summary       = %q{Provides delegation of specified methods to a designated object.}
-  spec.description   = %q{Provides delegation of specified methods to a designated object.}
-  spec.homepage      = "https://github.com/ruby/forwardable"
-  spec.license       = "BSD-2-Clause"
+  spec.summary       = 'Provides delegation of specified methods to a designated object.'
+  spec.description   = 'Provides delegation of specified methods to a designated object.'
+  spec.homepage      = 'https://github.com/ruby/forwardable'
+  spec.license       = 'BSD-2-Clause'
 
-  spec.files         = [".gitignore", ".travis.yml", "Gemfile", "LICENSE.txt", "README.md", "Rakefile", "bin/console", "bin/setup", "forwardable.gemspec", "lib/forwardable.rb", "lib/forwardable/impl.rb"]
-  spec.bindir        = "exe"
+  spec.files         = ['.gitignore', '.travis.yml', 'Gemfile', 'LICENSE.txt', 'README.md', 'Rakefile', 'bin/console', 'bin/setup', 'forwardable.gemspec', 'lib/forwardable.rb', 'lib/forwardable/impl.rb']
+  spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_development_dependency "bundler"
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'rake'
 end

--- a/mruby/src/extn/stdlib/forwardable/impl.rb
+++ b/mruby/src/extn/stdlib/forwardable/impl.rb
@@ -1,0 +1,16 @@
+# :stopdoc:
+module Forwardable
+  def self._valid_method?(method)
+    catch {|tag|
+      eval("BEGIN{throw tag}; ().#{method}", binding, __FILE__, __LINE__)
+    }
+  rescue SyntaxError
+    false
+  else
+    true
+  end
+
+  def self._compile_method(src, file, line)
+    eval(src, nil, file, line)
+  end
+end

--- a/mruby/src/extn/stdlib/forwardable/impl.rb
+++ b/mruby/src/extn/stdlib/forwardable/impl.rb
@@ -3,8 +3,8 @@
 # :stopdoc:
 module Forwardable
   def self._valid_method?(method)
-    catch do |tag|
-      eval("BEGIN{throw tag}; ().#{method}", binding, __FILE__, __LINE__) # rubocop:disable Security/Eval
+    catch(1) do |_tag|
+      eval("throw 1; ().#{method}", nil, __FILE__, __LINE__) # rubocop:disable Security/Eval
     end
   rescue SyntaxError
     false

--- a/mruby/src/extn/stdlib/forwardable/impl.rb
+++ b/mruby/src/extn/stdlib/forwardable/impl.rb
@@ -4,7 +4,7 @@
 module Forwardable
   def self._valid_method?(method)
     catch do |tag|
-      eval("BEGIN{throw tag}; ().#{method}", binding, __FILE__, __LINE__)
+      eval("BEGIN{throw tag}; ().#{method}", binding, __FILE__, __LINE__) # rubocop:disable Security/Eval
     end
   rescue SyntaxError
     false
@@ -13,6 +13,6 @@ module Forwardable
   end
 
   def self._compile_method(src, file, line)
-    eval(src, nil, file, line)
+    eval(src, nil, file, line) # rubocop:disable Security/Eval
   end
 end

--- a/mruby/src/extn/stdlib/forwardable/impl.rb
+++ b/mruby/src/extn/stdlib/forwardable/impl.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 # :stopdoc:
 module Forwardable
   def self._valid_method?(method)
-    catch {|tag|
+    catch do |tag|
       eval("BEGIN{throw tag}; ().#{method}", binding, __FILE__, __LINE__)
-    }
+    end
   rescue SyntaxError
     false
   else

--- a/mruby/src/extn/stdlib/mod.rs
+++ b/mruby/src/extn/stdlib/mod.rs
@@ -1,9 +1,11 @@
 use crate::interpreter::Mrb;
 use crate::MrbError;
 
+pub mod forwardable;
 pub mod monitor;
 
 pub fn patch(interp: &Mrb) -> Result<(), MrbError> {
+    forwardable::init(interp)?;
     monitor::init(interp)?;
     Ok(())
 }

--- a/mruby/src/extn/stdlib/monitor.rs
+++ b/mruby/src/extn/stdlib/monitor.rs
@@ -6,7 +6,8 @@ pub fn init(interp: &Mrb) -> Result<(), MrbError> {
     interp
         .borrow_mut()
         .def_class::<Monitor>("Monitor", None, None);
-    interp.def_rb_source_file("monitor.rb", include_str!("monitor.rb"))
+    interp.def_rb_source_file("monitor.rb", include_str!("monitor.rb"))?;
+    Ok(())
 }
 
 pub struct Monitor;


### PR DESCRIPTION
Imported from Ruby 2.6.3, rubocoped, and modified to work with mruby.