### PR TITLE
Nemesis cleanup

### DIFF
--- a/mruby/src/convert/object.rs
+++ b/mruby/src/convert/object.rs
@@ -70,9 +70,9 @@ where
                     max: value::MRB_FUNCALL_ARGC_MAX,
                 });
             }
-            // This will never unwrap because we've already checked that we have
-            // fewer than `MRB_FUNCALL_ARGC_MAX` args, wich is less than i64 max
-            // value.
+            // This will always unwrap because we've already checked that we
+            // have fewer than `MRB_FUNCALL_ARGC_MAX` args, which is less than
+            // i64 max value.
             let len = args.len().try_into().unwrap_or_default();
             sys::mrb_obj_new(
                 interp.borrow().mrb,

--- a/mruby/src/eval.rs
+++ b/mruby/src/eval.rs
@@ -1,4 +1,4 @@
-use log::{debug, error, warn};
+use log::{error, trace, warn};
 use std::ffi::CString;
 
 use crate::exception::{LastError, MrbExceptionHandler};
@@ -109,7 +109,7 @@ impl MrbEval for Mrb {
         }
 
         let code = code.as_ref();
-        debug!("Evaling code on {}", mrb.debug());
+        trace!("Evaling code on {}", mrb.debug());
         let result = unsafe {
             // Execute arbitrary ruby code, which may generate objects with C
             // APIs if backed by Rust functions.

--- a/mruby/src/value/mod.rs
+++ b/mruby/src/value/mod.rs
@@ -1,5 +1,6 @@
 use log::{error, trace, warn};
 use std::convert::TryFrom;
+use std::fmt;
 use std::rc::Rc;
 
 use crate::convert::{FromMrb, TryFromMrb};
@@ -149,12 +150,6 @@ where
     }
 }
 
-// TODO: The below comment is no longer true since inspect is implemented on
-// `Value`.
-//
-// We can't impl `fmt::Debug` because `mrb_sys_value_debug_str` requires a
-// `mrb_state` interpreter, which we can't store on the `Value` because we
-// construct it from Rust native types.
 pub struct Value {
     interp: Mrb,
     value: sys::mrb_value,
@@ -224,6 +219,18 @@ impl FromMrb<Value> for Value {
 
     fn from_mrb(_interp: &Mrb, value: Self) -> Self {
         value
+    }
+}
+
+impl fmt::Display for Value {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.to_s())
+    }
+}
+
+impl fmt::Debug for Value {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.to_s_debug())
     }
 }
 

--- a/nemesis/src/response.rs
+++ b/nemesis/src/response.rs
@@ -30,10 +30,7 @@ impl Response {
     /// `Nemesis::Response`.
     pub fn from_rack_tuple(interp: &Mrb, response: Vec<Value>) -> Result<Self, Error> {
         if response.len() != Self::RACK_RESPONSE_TUPLE_LEN {
-            warn!(
-                "malformed rack response: {:?}",
-                response.iter().map(Value::to_s_debug).collect::<Vec<_>>()
-            );
+            warn!("malformed rack response: {:?}", response);
             return Err(Error::RackResponse);
         }
         let class = interp

--- a/nemesis/src/server/mod.rs
+++ b/nemesis/src/server/mod.rs
@@ -46,11 +46,10 @@ impl Builder {
         self
     }
 
-    pub fn add_static_asset<S: AsRef<str>, T: AsRef<[u8]>>(mut self, path: S, asset: T) -> Self {
-        self.assets
-            .0
-            .insert(path.as_ref().to_owned(), asset.as_ref().to_owned());
-        self
+    pub fn add_static_asset(self, path: String, asset: Vec<u8>) -> Self {
+        let mut assets = HashMap::default();
+        assets.insert(path, asset);
+        self.add_static_assets(assets)
     }
 
     pub fn add_static_assets(mut self, assets: HashMap<String, Vec<u8>>) -> Self {

--- a/nemesis/src/server/mod.rs
+++ b/nemesis/src/server/mod.rs
@@ -17,10 +17,19 @@ pub enum Backend {
     Rocket,
 }
 
+impl Default for Backend {
+    fn default() -> Self {
+        Backend::Rocket
+    }
+}
+
+#[derive(Default, Debug, Clone)]
 struct AssetRegistry(HashMap<String, Vec<u8>>);
 
+#[derive(Default, Clone)]
 struct MountRegistry(HashMap<String, Mount>);
 
+#[derive(Default, Clone)]
 pub struct Builder {
     assets: AssetRegistry,
     mounts: MountRegistry,
@@ -60,16 +69,6 @@ impl Builder {
     }
 }
 
-impl Default for Builder {
-    fn default() -> Self {
-        Self {
-            assets: AssetRegistry(HashMap::default()),
-            mounts: MountRegistry(HashMap::default()),
-            backend: Backend::Rocket,
-        }
-    }
-}
-
 #[derive(Clone)]
 pub struct Mount {
     path: String,
@@ -90,7 +89,6 @@ impl Mount {
             path: mount_path.to_owned(),
             app: Arc::new(Box::new(app)),
             interp_init: None,
-            // TODO: expose a setter for exec mode.
             exec_mode: ExecMode::default(),
         }
     }


### PR DESCRIPTION
- Ensure that `Mount`s are finalized for every request in Rocket impl, even if they end in `Err`.
- Properly support Rack spec for headers and body – they only respond to `#each`.

To get there:

- Add `Display` and `Debug` impls for `Value`.
- Implement `ValueLike::funcall_with_block`.
- Fix comments around `MRB_FUNCALL_ARGC_MAX`.
- Adjust logging levels to trace for voluminous eval and funcall logs.