### PR TITLE
Add delegate impl to stdlib

### DIFF
--- a/mruby/src/extn/core/mod.rs
+++ b/mruby/src/extn/core/mod.rs
@@ -5,6 +5,7 @@ pub mod error;
 pub mod kernel;
 pub mod module;
 pub mod regexp;
+pub mod string;
 pub mod thread;
 
 pub fn patch(interp: &Mrb) -> Result<(), MrbError> {
@@ -12,6 +13,7 @@ pub fn patch(interp: &Mrb) -> Result<(), MrbError> {
     kernel::patch(interp)?;
     module::patch(interp)?;
     regexp::init(interp)?;
+    string::patch(interp)?;
     thread::init(interp)?;
     Ok(())
 }

--- a/mruby/src/extn/core/regexp.rs
+++ b/mruby/src/extn/core/regexp.rs
@@ -372,8 +372,8 @@ impl Regexp {
         unwrap_value_or_raise!(interp, data.try_into_ruby(&interp, None))
     }
 
-    // Support for extracting named captures and assigning to local variables is
-    // not implemented.
+    // TODO: Implement support for extracting named captures and assigning to
+    // local variables.
     // See: https://ruby-doc.org/core-2.6.3/Regexp.html#method-i-3D-7E
     unsafe extern "C" fn equal_squiggle(
         mrb: *mut sys::mrb_state,

--- a/mruby/src/extn/core/string.rb
+++ b/mruby/src/extn/core/string.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+String.class_eval do
+  # https://ruby-doc.org/core-2.6.3/String.html#method-i-3D-7E
+  def =~(other)
+    return other.match(self).begin(0) if other.is_a?(Regexp)
+    return other =~ self if other.respond_to?(:=~)
+
+    nil
+  end
+end

--- a/mruby/src/extn/core/string.rs
+++ b/mruby/src/extn/core/string.rs
@@ -1,0 +1,42 @@
+use crate::def::Define;
+use crate::eval::MrbEval;
+use crate::interpreter::Mrb;
+use crate::MrbError;
+use log::trace;
+
+pub fn patch(interp: &Mrb) -> Result<(), MrbError> {
+    let string = interp
+        .borrow_mut()
+        .def_class::<RString>("String", None, None);
+    string.borrow().define(interp).map_err(|_| MrbError::New)?;
+    interp.eval(include_str!("string.rb"))?;
+    trace!("Patched String onto interpreter");
+    Ok(())
+}
+
+#[allow(clippy::module_name_repetitions)]
+pub struct RString;
+
+// Tests from String core docs in Ruby 2.6.3
+// https://ruby-doc.org/core-2.6.3/String.html
+#[cfg(test)]
+mod tests {
+    use crate::eval::MrbEval;
+    use crate::extn::core::string;
+    use crate::interpreter::Interpreter;
+    use crate::value::ValueLike;
+
+    #[test]
+    fn string_equal_squiggle() {
+        let interp = Interpreter::create().expect("mrb init");
+        string::patch(&interp).expect("string init");
+
+        let value = interp.eval(r#""cat o' 9 tails" =~ /\d/"#).unwrap();
+        assert_eq!(
+            value.funcall::<Option<i64>, _, _>("itself", &[]),
+            Ok(Some(7))
+        );
+        let value = interp.eval(r#""cat o' 9 tails" =~ 9"#).unwrap();
+        assert_eq!(value.funcall::<Option<i64>, _, _>("itself", &[]), Ok(None));
+    }
+}

--- a/mruby/src/extn/core/thread.rb
+++ b/mruby/src/extn/core/thread.rb
@@ -11,6 +11,8 @@
 # contention in a single-threaded environement.
 
 class Thread
+  alias __raise__ raise
+
   attr_accessor :abort_on_exception
   attr_accessor :name
   attr_accessor :report_on_exception
@@ -103,7 +105,7 @@ class Thread
   end
 
   def initialize(root = false)
-    raise ThreadError, 'must be called with a block' unless block_given?
+    __raise__ ThreadError, 'must be called with a block' unless block_given?
 
     @priority = 0
     @priority = self.class.current.priority unless self.class.current.nil?
@@ -127,7 +129,7 @@ class Thread
   ensure
     @alive = false unless root
     self.class.__pop_stack unless root
-    raise @__unwind_with_exception if self.class.current == self.class.main && !@__unwind_with_exception.nil?
+    __raise__ @__unwind_with_exception if self.class.current == self.class.main && !@__unwind_with_exception.nil?
   end
 
   def [](sym)
@@ -170,7 +172,7 @@ class Thread
   alias terminate exit
 
   def fetch(*args)
-    Kernel.raise ArgumentError, 'Thread#fetch requires 1 or 2 arguments' unless [1, 2].include?(args.length)
+    __raise__ ArgumentError, 'Thread#fetch requires 1 or 2 arguments' unless [1, 2].include?(args.length)
 
     key = args[0]
     if @fiber_locals.key?(key)
@@ -181,7 +183,7 @@ class Thread
     elsif args.length == 2
       args[1]
     else
-      Kernel.raise "key '#{key}' not found in Thread locals"
+      __raise__ "key '#{key}' not found in Thread locals"
     end
   end
 
@@ -219,11 +221,11 @@ class Thread
   def raise(*args)
     exc, message, array = *args
     case args.length
-    when 0 then Kernel.raise
-    when 1 then Kernel.raise(exc)
-    when 2 then Kernel.raise(exc, message)
-    when 3 then Kernel.raise(exc, message, array)
-    else Kernel.raise ArgumentError
+    when 0 then __raise__
+    when 1 then __raise__(exc)
+    when 2 then __raise__(exc, message)
+    when 3 then __raise__(exc, message, array)
+    else __raise__ ArgumentError
     end
   end
 
@@ -278,7 +280,7 @@ class Thread
   end
 
   def value
-    Kernel.raise @value if @terminated_with_exception
+    __raise__ @value if @terminated_with_exception
 
     @value
   end

--- a/mruby/src/extn/core/thread.rs
+++ b/mruby/src/extn/core/thread.rs
@@ -178,11 +178,11 @@ end.join
         let expected_backtrace = r#"
 (eval):8: inner (RuntimeError)
 (eval):8:in call
-/src/lib/thread.rb:120:in initialize
+/src/lib/thread.rb:122:in initialize
 (eval):6:in call
-/src/lib/thread.rb:120:in initialize
+/src/lib/thread.rb:122:in initialize
 (eval):4:in call
-/src/lib/thread.rb:120:in initialize
+/src/lib/thread.rb:122:in initialize
 (eval):2
 "#;
         assert_eq!(

--- a/mruby/src/extn/stdlib/delegate.rb
+++ b/mruby/src/extn/stdlib/delegate.rb
@@ -1,0 +1,414 @@
+# frozen_string_literal: true
+# = delegate -- Support for the Delegation Pattern
+#
+# Documentation by James Edward Gray II and Gavin Sinclair
+
+##
+# This library provides three different ways to delegate method calls to an
+# object.  The easiest to use is SimpleDelegator.  Pass an object to the
+# constructor and all methods supported by the object will be delegated.  This
+# object can be changed later.
+#
+# Going a step further, the top level DelegateClass method allows you to easily
+# setup delegation through class inheritance.  This is considerably more
+# flexible and thus probably the most common use for this library.
+#
+# Finally, if you need full control over the delegation scheme, you can inherit
+# from the abstract class Delegator and customize as needed.  (If you find
+# yourself needing this control, have a look at Forwardable which is also in
+# the standard library.  It may suit your needs better.)
+#
+# SimpleDelegator's implementation serves as a nice example of the use of
+# Delegator:
+#
+#   class SimpleDelegator < Delegator
+#     def __getobj__
+#       @delegate_sd_obj # return object we are delegating to, required
+#     end
+#
+#     def __setobj__(obj)
+#       @delegate_sd_obj = obj # change delegation object,
+#                              # a feature we're providing
+#     end
+#   end
+#
+# == Notes
+#
+# Be advised, RDoc will not detect delegated methods.
+#
+class Delegator < BasicObject
+  kernel = ::Kernel.dup
+  kernel.class_eval do
+    alias __raise__ raise
+    [:to_s, :inspect, :=~, :!~, :===, :<=>, :hash].each do |m|
+      undef_method m
+    end
+    private_instance_methods.each do |m|
+      if /\Ablock_given\?\z|iterator\?\z|\A__.*__\z/ =~ m
+        next
+      end
+      undef_method m
+    end
+  end
+  include kernel
+
+  # :stopdoc:
+  def self.const_missing(n)
+    ::Object.const_get(n)
+  end
+  # :startdoc:
+
+  ##
+  # :method: raise
+  # Use __raise__ if your Delegator does not have a object to delegate the
+  # raise method call.
+  #
+
+  #
+  # Pass in the _obj_ to delegate method calls to.  All methods supported by
+  # _obj_ will be delegated to.
+  #
+  def initialize(obj)
+    __setobj__(obj)
+  end
+
+  #
+  # Handles the magic of delegation through \_\_getobj\_\_.
+  #
+  def method_missing(m, *args, &block)
+    r = true
+    target = self.__getobj__ {r = false}
+
+    if r && target.respond_to?(m)
+      target.__send__(m, *args, &block)
+    elsif ::Kernel.respond_to?(m, true)
+      ::Kernel.instance_method(m).bind(self).(*args, &block)
+    else
+      super(m, *args, &block)
+    end
+  end
+
+  #
+  # Checks for a method provided by this the delegate object by forwarding the
+  # call through \_\_getobj\_\_.
+  #
+  def respond_to_missing?(m, include_private)
+    r = true
+    target = self.__getobj__ {r = false}
+    r &&= target.respond_to?(m, include_private)
+    if r && include_private && !target.respond_to?(m, false)
+      warn "delegator does not forward private method \##{m}", uplevel: 3
+      return false
+    end
+    r
+  end
+
+  #
+  # Returns the methods available to this delegate object as the union
+  # of this object's and \_\_getobj\_\_ methods.
+  #
+  def methods(all=true)
+    __getobj__.methods(all) | super
+  end
+
+  #
+  # Returns the methods available to this delegate object as the union
+  # of this object's and \_\_getobj\_\_ public methods.
+  #
+  def public_methods(all=true)
+    __getobj__.public_methods(all) | super
+  end
+
+  #
+  # Returns the methods available to this delegate object as the union
+  # of this object's and \_\_getobj\_\_ protected methods.
+  #
+  def protected_methods(all=true)
+    __getobj__.protected_methods(all) | super
+  end
+
+  # Note: no need to specialize private_methods, since they are not forwarded
+
+  #
+  # Returns true if two objects are considered of equal value.
+  #
+  def ==(obj)
+    return true if obj.equal?(self)
+    self.__getobj__ == obj
+  end
+
+  #
+  # Returns true if two objects are not considered of equal value.
+  #
+  def !=(obj)
+    return false if obj.equal?(self)
+    __getobj__ != obj
+  end
+
+  #
+  # Returns true if two objects are considered of equal value.
+  #
+  def eql?(obj)
+    return true if obj.equal?(self)
+    obj.eql?(__getobj__)
+  end
+
+  #
+  # Delegates ! to the \_\_getobj\_\_
+  #
+  def !
+    !__getobj__
+  end
+
+  #
+  # This method must be overridden by subclasses and should return the object
+  # method calls are being delegated to.
+  #
+  def __getobj__
+    __raise__ ::NotImplementedError, "need to define `__getobj__'"
+  end
+
+  #
+  # This method must be overridden by subclasses and change the object delegate
+  # to _obj_.
+  #
+  def __setobj__(obj)
+    __raise__ ::NotImplementedError, "need to define `__setobj__'"
+  end
+
+  #
+  # Serialization support for the object returned by \_\_getobj\_\_.
+  #
+  def marshal_dump
+    ivars = instance_variables.reject {|var| /\A@delegate_/ =~ var}
+    [
+      :__v2__,
+      ivars, ivars.map {|var| instance_variable_get(var)},
+      __getobj__
+    ]
+  end
+
+  #
+  # Reinitializes delegation from a serialized object.
+  #
+  def marshal_load(data)
+    version, vars, values, obj = data
+    if version == :__v2__
+      vars.each_with_index {|var, i| instance_variable_set(var, values[i])}
+      __setobj__(obj)
+    else
+      __setobj__(data)
+    end
+  end
+
+  def initialize_clone(obj) # :nodoc:
+    self.__setobj__(obj.__getobj__.clone)
+  end
+  def initialize_dup(obj) # :nodoc:
+    self.__setobj__(obj.__getobj__.dup)
+  end
+  private :initialize_clone, :initialize_dup
+
+  ##
+  # :method: trust
+  # Trust both the object returned by \_\_getobj\_\_ and self.
+  #
+
+  ##
+  # :method: untrust
+  # Untrust both the object returned by \_\_getobj\_\_ and self.
+  #
+
+  ##
+  # :method: taint
+  # Taint both the object returned by \_\_getobj\_\_ and self.
+  #
+
+  ##
+  # :method: untaint
+  # Untaint both the object returned by \_\_getobj\_\_ and self.
+  #
+
+  ##
+  # :method: freeze
+  # Freeze both the object returned by \_\_getobj\_\_ and self.
+  #
+
+  [:trust, :untrust, :taint, :untaint, :freeze].each do |method|
+    define_method method do
+      __getobj__.send(method)
+      super()
+    end
+  end
+
+  @delegator_api = self.public_instance_methods
+  def self.public_api # :nodoc:
+    @delegator_api
+  end
+end
+
+##
+# A concrete implementation of Delegator, this class provides the means to
+# delegate all supported method calls to the object passed into the constructor
+# and even to change the object being delegated to at a later time with
+# #__setobj__.
+#
+#   class User
+#     def born_on
+#       Date.new(1989, 9, 10)
+#     end
+#   end
+#
+#   class UserDecorator < SimpleDelegator
+#     def birth_year
+#       born_on.year
+#     end
+#   end
+#
+#   decorated_user = UserDecorator.new(User.new)
+#   decorated_user.birth_year  #=> 1989
+#   decorated_user.__getobj__  #=> #<User: ...>
+#
+# A SimpleDelegator instance can take advantage of the fact that SimpleDelegator
+# is a subclass of +Delegator+ to call <tt>super</tt> to have methods called on
+# the object being delegated to.
+#
+#   class SuperArray < SimpleDelegator
+#     def [](*args)
+#       super + 1
+#     end
+#   end
+#
+#   SuperArray.new([1])[0]  #=> 2
+#
+# Here's a simple example that takes advantage of the fact that
+# SimpleDelegator's delegation object can be changed at any time.
+#
+#   class Stats
+#     def initialize
+#       @source = SimpleDelegator.new([])
+#     end
+#
+#     def stats(records)
+#       @source.__setobj__(records)
+#
+#       "Elements:  #{@source.size}\n" +
+#       " Non-Nil:  #{@source.compact.size}\n" +
+#       "  Unique:  #{@source.uniq.size}\n"
+#     end
+#   end
+#
+#   s = Stats.new
+#   puts s.stats(%w{James Edward Gray II})
+#   puts
+#   puts s.stats([1, 2, 3, nil, 4, 5, 1, 2])
+#
+# Prints:
+#
+#   Elements:  4
+#    Non-Nil:  4
+#     Unique:  4
+#
+#   Elements:  8
+#    Non-Nil:  7
+#     Unique:  6
+#
+class SimpleDelegator < Delegator
+  # Returns the current object method calls are being delegated to.
+  def __getobj__
+    unless defined?(@delegate_sd_obj)
+      return yield if block_given?
+      __raise__ ::ArgumentError, "not delegated"
+    end
+    @delegate_sd_obj
+  end
+
+  #
+  # Changes the delegate object to _obj_.
+  #
+  # It's important to note that this does *not* cause SimpleDelegator's methods
+  # to change.  Because of this, you probably only want to change delegation
+  # to objects of the same type as the original delegate.
+  #
+  # Here's an example of changing the delegation object.
+  #
+  #   names = SimpleDelegator.new(%w{James Edward Gray II})
+  #   puts names[1]    # => Edward
+  #   names.__setobj__(%w{Gavin Sinclair})
+  #   puts names[1]    # => Sinclair
+  #
+  def __setobj__(obj)
+    __raise__ ::ArgumentError, "cannot delegate to self" if self.equal?(obj)
+    @delegate_sd_obj = obj
+  end
+end
+
+def Delegator.delegating_block(mid) # :nodoc:
+  lambda do |*args, &block|
+    target = self.__getobj__
+    target.__send__(mid, *args, &block)
+  end
+end
+
+#
+# The primary interface to this library.  Use to setup delegation when defining
+# your class.
+#
+#   class MyClass < DelegateClass(ClassToDelegateTo) # Step 1
+#     def initialize
+#       super(obj_of_ClassToDelegateTo)              # Step 2
+#     end
+#   end
+#
+# Here's a sample of use from Tempfile which is really a File object with a
+# few special rules about storage location and when the File should be
+# deleted.  That makes for an almost textbook perfect example of how to use
+# delegation.
+#
+#   class Tempfile < DelegateClass(File)
+#     # constant and class member data initialization...
+#
+#     def initialize(basename, tmpdir=Dir::tmpdir)
+#       # build up file path/name in var tmpname...
+#
+#       @tmpfile = File.open(tmpname, File::RDWR|File::CREAT|File::EXCL, 0600)
+#
+#       # ...
+#
+#       super(@tmpfile)
+#
+#       # below this point, all methods of File are supported...
+#     end
+#
+#     # ...
+#   end
+#
+def DelegateClass(superclass)
+  klass = Class.new(Delegator)
+  methods = superclass.instance_methods
+  methods -= ::Delegator.public_api
+  methods -= [:to_s, :inspect, :=~, :!~, :===]
+  klass.module_eval do
+    def __getobj__ # :nodoc:
+      unless defined?(@delegate_dc_obj)
+        return yield if block_given?
+        __raise__ ::ArgumentError, "not delegated"
+      end
+      @delegate_dc_obj
+    end
+    def __setobj__(obj)  # :nodoc:
+      __raise__ ::ArgumentError, "cannot delegate to self" if self.equal?(obj)
+      @delegate_dc_obj = obj
+    end
+    methods.each do |method|
+      define_method(method, Delegator.delegating_block(method))
+    end
+  end
+  klass.define_singleton_method :public_instance_methods do |all=true|
+    super(all) - superclass.protected_instance_methods
+  end
+  klass.define_singleton_method :protected_instance_methods do |all=true|
+    super(all) | superclass.protected_instance_methods
+  end
+  return klass
+end

--- a/mruby/src/extn/stdlib/delegate.rb
+++ b/mruby/src/extn/stdlib/delegate.rb
@@ -406,11 +406,5 @@ def DelegateClass(superclass) # rubocop:disable Naming/MethodName
       define_method(method, Delegator.delegating_block(method))
     end
   end
-  klass.define_singleton_method :public_instance_methods do |all = true|
-    super(all) - superclass.protected_instance_methods
-  end
-  klass.define_singleton_method :protected_instance_methods do |all = true|
-    super(all) | superclass.protected_instance_methods
-  end
   klass
 end

--- a/mruby/src/extn/stdlib/delegate.rb
+++ b/mruby/src/extn/stdlib/delegate.rb
@@ -41,14 +41,7 @@ class Delegator < BasicObject
   kernel = ::Kernel.dup
   kernel.class_eval do
     alias_method :__raise__, :raise
-    %i[to_s inspect =~ !~ === <=> hash].each do |m|
-      undef_method m
-    end
-    private_instance_methods.each do |m|
-      if /\Ablock_given\?\z|iterator\?\z|\A__.*__\z/ =~ m
-        next
-      end
-
+    %i[to_s inspect !~ === hash].each do |m|
       undef_method m
     end
   end
@@ -247,7 +240,7 @@ class Delegator < BasicObject
     end
   end
 
-  @delegator_api = public_instance_methods
+  @delegator_api = instance_methods
   def self.public_api # :nodoc:
     @delegator_api
   end
@@ -322,7 +315,7 @@ end
 class SimpleDelegator < Delegator
   # Returns the current object method calls are being delegated to.
   def __getobj__
-    unless defined?(@delegate_sd_obj)
+    if @delegate_sd_obj.nil?
       return yield if block_given?
 
       __raise__ ::ArgumentError, 'not delegated'

--- a/mruby/src/extn/stdlib/delegate.rs
+++ b/mruby/src/extn/stdlib/delegate.rs
@@ -141,4 +141,23 @@ s = Stats.new
             Ok(vec![8, 7, 6])
         );
     }
+
+    #[test]
+    fn delegate_class() {
+        let interp = Interpreter::create().expect("mrb init");
+        interp.eval("require 'delegate'").expect("require");
+        let value = interp.eval(
+            r#"
+class MyClass < DelegateClass(Array) # Step 1
+  def initialize
+    super([])                        # Step 2
+  end
+end
+
+MyClass.instance_methods
+MyClass.new
+                "#,
+        );
+        assert!(value.is_ok());
+    }
 }

--- a/mruby/src/extn/stdlib/delegate.rs
+++ b/mruby/src/extn/stdlib/delegate.rs
@@ -5,7 +5,6 @@ use crate::MrbError;
 pub fn init(interp: &Mrb) -> Result<(), MrbError> {
     interp.borrow_mut().def_module::<Delegate>("Delegate", None);
     interp.def_rb_source_file("delegate.rb", include_str!("delegate.rb"))?;
-    interp.def_rb_source_file("forwardable/impl.rb", include_str!("forwardable/impl.rb"))?;
     Ok(())
 }
 

--- a/mruby/src/extn/stdlib/delegate.rs
+++ b/mruby/src/extn/stdlib/delegate.rs
@@ -1,0 +1,144 @@
+use crate::interpreter::Mrb;
+use crate::load::MrbLoadSources;
+use crate::MrbError;
+
+pub fn init(interp: &Mrb) -> Result<(), MrbError> {
+    interp.borrow_mut().def_module::<Delegate>("Delegate", None);
+    interp.def_rb_source_file("delegate.rb", include_str!("delegate.rb"))?;
+    interp.def_rb_source_file("forwardable/impl.rb", include_str!("forwardable/impl.rb"))?;
+    Ok(())
+}
+
+pub struct Delegate;
+
+// Delegate tests from Ruby stdlib docs
+// https://ruby-doc.org/stdlib-2.6.3/libdoc/delegate/rdoc/Delegator.html
+// https://ruby-doc.org/stdlib-2.6.3/libdoc/delegate/rdoc/Object.html
+// https://ruby-doc.org/stdlib-2.6.3/libdoc/delegate/rdoc/SimpleDelegator.html
+#[cfg(test)]
+mod tests {
+    use crate::convert::FromMrb;
+    use crate::eval::MrbEval;
+    use crate::interpreter::{Interpreter, MrbApi};
+    use crate::value::{Value, ValueLike};
+
+    #[test]
+    fn simple_delegator() {
+        let interp = Interpreter::create().expect("mrb init");
+        interp.eval("require 'delegate'").expect("require");
+        // Hack because Date is not yet implemented
+        interp
+            .eval("Date = Struct.new(:year, :month, :day)")
+            .expect("date");
+        let value = interp
+            .eval(
+                r#"
+class User
+  def born_on
+    Date.new(1989, 9, 10)
+  end
+end
+
+class UserDecorator < SimpleDelegator
+  def birth_year
+    born_on.year
+  end
+end
+
+decorated_user = UserDecorator.new(User.new)
+                "#,
+            )
+            .unwrap();
+        assert_eq!(value.funcall::<i64, _, _>("birth_year", &[]), Ok(1989));
+        let user = value.funcall::<Value, _, _>("__getobj__", &[]).unwrap();
+        let class = user.funcall::<Value, _, _>("class", &[]).unwrap();
+        assert_eq!(&class.funcall::<String, _, _>("name", &[]).unwrap(), "User");
+    }
+
+    #[test]
+    fn simple_delegator_super() {
+        let interp = Interpreter::create().expect("mrb init");
+        interp.eval("require 'delegate'").expect("require");
+        let value = interp
+            .eval(
+                r#"
+class SuperArray < SimpleDelegator
+  def [](*args)
+    super + 1
+  end
+end
+
+SuperArray.new([1])
+                "#,
+            )
+            .unwrap();
+        assert_eq!(value.funcall::<i64, _, _>("[]", &[interp.fixnum(0)]), Ok(2));
+    }
+
+    #[test]
+    fn simple_delegator_change_delegation_obj() {
+        let interp = Interpreter::create().expect("mrb init");
+        interp.eval("require 'delegate'").expect("require");
+        // Hack because Date is not yet implemented
+        interp
+            .eval("Date = Struct.new(:year, :month, :day)")
+            .expect("date");
+        let value = interp
+            .eval(
+                r#"
+class Stats
+  def initialize
+    @source = SimpleDelegator.new([])
+  end
+
+  def stats(records)
+    @source.__setobj__(records)
+
+    # [elements, non-nil, unique]
+    [@source.size, @source.compact.size, @source.uniq.size]
+  end
+end
+
+s = Stats.new
+# puts s.stats(%w{James Edward Gray II})
+# puts
+# puts s.stats([1, 2, 3, nil, 4, 5, 1, 2])
+                "#,
+            )
+            .unwrap();
+        assert_eq!(
+            value.funcall::<Vec<i64>, _, _>(
+                "stats",
+                &[Value::from_mrb(
+                    &interp,
+                    vec![
+                        interp.string("James"),
+                        interp.string("Edward"),
+                        interp.string("Gray"),
+                        interp.string("II")
+                    ]
+                )]
+            ),
+            Ok(vec![4, 4, 4])
+        );
+        assert_eq!(
+            value.funcall::<Vec<i64>, _, _>(
+                "stats",
+                &[Value::from_mrb(
+                    &interp,
+                    vec![
+                        interp.fixnum(1),
+                        interp.fixnum(2),
+                        interp.fixnum(3),
+                        interp.nil(),
+                        interp.fixnum(4),
+                        interp.fixnum(5),
+                        interp.fixnum(1),
+                        interp.fixnum(2),
+                    ]
+                )]
+            ),
+            Ok(vec![8, 7, 6])
+        );
+    }
+}

--- a/mruby/src/extn/stdlib/delegate.rs
+++ b/mruby/src/extn/stdlib/delegate.rs
@@ -3,12 +3,18 @@ use crate::load::MrbLoadSources;
 use crate::MrbError;
 
 pub fn init(interp: &Mrb) -> Result<(), MrbError> {
-    interp.borrow_mut().def_module::<Delegate>("Delegate", None);
+    interp
+        .borrow_mut()
+        .def_class::<Delegator>("Delegator", None, None);
+    interp
+        .borrow_mut()
+        .def_class::<SimpleDelegator>("SimpleDelegator", None, None);
     interp.def_rb_source_file("delegate.rb", include_str!("delegate.rb"))?;
     Ok(())
 }
 
-pub struct Delegate;
+pub struct Delegator;
+pub struct SimpleDelegator;
 
 // Delegate tests from Ruby stdlib docs
 // https://ruby-doc.org/stdlib-2.6.3/libdoc/delegate/rdoc/Delegator.html

--- a/mruby/src/extn/stdlib/forwardable.rs
+++ b/mruby/src/extn/stdlib/forwardable.rs
@@ -13,8 +13,8 @@ pub fn init(interp: &Mrb) -> Result<(), MrbError> {
 
 pub struct Forwardable;
 
-// Monitor tests from ruby/spec
-// https://github.com/ruby/spec/tree/master/library/monitor
+// Forwardable tests from Ruby stdlib docs
+// https://ruby-doc.org/stdlib-2.6.3/libdoc/forwardable/rdoc/Forwardable.html
 #[cfg(test)]
 mod tests {
     use crate::eval::MrbEval;

--- a/mruby/src/extn/stdlib/mod.rs
+++ b/mruby/src/extn/stdlib/mod.rs
@@ -1,10 +1,12 @@
 use crate::interpreter::Mrb;
 use crate::MrbError;
 
+pub mod delegate;
 pub mod forwardable;
 pub mod monitor;
 
 pub fn patch(interp: &Mrb) -> Result<(), MrbError> {
+    delegate::init(interp)?;
     forwardable::init(interp)?;
     monitor::init(interp)?;
     Ok(())


### PR DESCRIPTION
Imported from Ruby 2.6.3, rubocoped, and modified to work with mruby.

Delegate required implementing other parts of core:

- `Regexp#=~` and `String#=~`
- `MatchData#begin` and `MatchData#end`

Applied some fixups to `thread.rb` and `forwardable` Rust source.