### PR TITLE
Add functions on Value for casting to Rust types

### DIFF
--- a/mruby/src/extn/core/kernel.rs
+++ b/mruby/src/extn/core/kernel.rs
@@ -140,7 +140,6 @@ mod tests {
     use crate::file::MrbFile;
     use crate::interpreter::{Interpreter, Mrb};
     use crate::load::MrbLoadSources;
-    use crate::value::ValueLike;
     use crate::MrbError;
 
     // Integration test for `Kernel::require`:
@@ -266,25 +265,25 @@ mod tests {
         let result = interp
             .eval("catch(1) { 123 }")
             .unwrap()
-            .funcall::<i64, _, _>("itself", &[])
+            .try_into::<i64>()
             .unwrap();
         assert_eq!(result, 123);
         let result = interp
             .eval("catch(1) { throw(1, 456) }")
             .unwrap()
-            .funcall::<i64, _, _>("itself", &[])
+            .try_into::<i64>()
             .unwrap();
         assert_eq!(result, 456);
         let result = interp
             .eval("catch(1) { throw(1) }")
             .unwrap()
-            .funcall::<Option<i64>, _, _>("itself", &[])
+            .try_into::<Option<i64>>()
             .unwrap();
         assert_eq!(result, None);
         let result = interp
             .eval("catch(1) {|x| x + 2 }")
             .unwrap()
-            .funcall::<i64, _, _>("itself", &[])
+            .try_into::<i64>()
             .unwrap();
         assert_eq!(result, 3);
 
@@ -303,7 +302,7 @@ end
             "#,
             )
             .unwrap()
-            .funcall::<i64, _, _>("itself", &[])
+            .try_into::<i64>()
             .unwrap();
         assert_eq!(result, 456);
         let result = interp
@@ -321,7 +320,7 @@ end
             "#,
             )
             .unwrap()
-            .funcall::<i64, _, _>("itself", &[])
+            .try_into::<i64>()
             .unwrap();
         assert_eq!(result, 123);
     }

--- a/mruby/src/extn/core/regexp.rs
+++ b/mruby/src/extn/core/regexp.rs
@@ -278,7 +278,7 @@ impl Regexp {
             // `__regexp_source` accessor.
             args.pattern.funcall::<String, _, _>("__regexp_source", &[])
         } else {
-            args.pattern.funcall::<String, _, _>("itself", &[])
+            args.pattern.try_into()
         };
         let options = args.options.unwrap_or_default();
         let pattern = unwrap_or_raise!(interp, pattern, interp.nil().inner());

--- a/mruby/src/extn/core/string.rs
+++ b/mruby/src/extn/core/string.rs
@@ -24,7 +24,6 @@ mod tests {
     use crate::eval::MrbEval;
     use crate::extn::core::string;
     use crate::interpreter::Interpreter;
-    use crate::value::ValueLike;
 
     #[test]
     fn string_equal_squiggle() {
@@ -32,12 +31,9 @@ mod tests {
         string::patch(&interp).expect("string init");
 
         let value = interp.eval(r#""cat o' 9 tails" =~ /\d/"#).unwrap();
-        assert_eq!(
-            value.funcall::<Option<i64>, _, _>("itself", &[]),
-            Ok(Some(7))
-        );
+        assert_eq!(value.try_into::<Option<i64>>(), Ok(Some(7)));
         let value = interp.eval(r#""cat o' 9 tails" =~ 9"#).unwrap();
-        assert_eq!(value.funcall::<Option<i64>, _, _>("itself", &[]), Ok(None));
+        assert_eq!(value.try_into::<Option<i64>>(), Ok(None));
     }
 
     #[test]
@@ -49,7 +45,7 @@ mod tests {
             &interp
                 .eval(r"'hello there'[/[aeiou](.)\1/]")
                 .unwrap()
-                .funcall::<String, _, _>("itself", &[])
+                .try_into::<String>()
                 .unwrap(),
             "ell"
         );
@@ -57,7 +53,7 @@ mod tests {
             &interp
                 .eval(r"'hello there'[/[aeiou](.)\1/, 0]")
                 .unwrap()
-                .funcall::<String, _, _>("itself", &[])
+                .try_into::<String>()
                 .unwrap(),
             "ell"
         );
@@ -65,7 +61,7 @@ mod tests {
             &interp
                 .eval(r"'hello there'[/[aeiou](.)\1/, 1]")
                 .unwrap()
-                .funcall::<String, _, _>("itself", &[])
+                .try_into::<String>()
                 .unwrap(),
             "l"
         );
@@ -73,7 +69,7 @@ mod tests {
             interp
                 .eval(r"'hello there'[/[aeiou](.)\1/, 2]")
                 .unwrap()
-                .funcall::<Option<String>, _, _>("itself", &[])
+                .try_into::<Option<String>>()
                 .unwrap(),
             None
         );
@@ -81,7 +77,7 @@ mod tests {
             &interp
                 .eval(r"'hello there'[/(?<vowel>[aeiou])(?<non_vowel>[^aeiou])/, 'non_vowel']")
                 .unwrap()
-                .funcall::<String, _, _>("itself", &[])
+                .try_into::<String>()
                 .unwrap(),
             "l"
         );
@@ -89,7 +85,7 @@ mod tests {
             &interp
                 .eval(r"'hello there'[/(?<vowel>[aeiou])(?<non_vowel>[^aeiou])/, 'vowel']")
                 .unwrap()
-                .funcall::<String, _, _>("itself", &[])
+                .try_into::<String>()
                 .unwrap(),
             "e"
         );

--- a/mruby/src/extn/stdlib/forwardable.rs
+++ b/mruby/src/extn/stdlib/forwardable.rs
@@ -19,7 +19,6 @@ pub struct Forwardable;
 mod tests {
     use crate::eval::MrbEval;
     use crate::interpreter::Interpreter;
-    use crate::value::ValueLike;
 
     #[test]
     #[allow(clippy::shadow_unrelated)]
@@ -47,7 +46,7 @@ r.record_number(0)
                 "#,
             )
             .unwrap()
-            .funcall::<i64, _, _>("itself", &[])
+            .try_into::<i64>()
             .unwrap();
         assert_eq!(result, 4);
         interp
@@ -68,25 +67,21 @@ r.record_number(0)
                 "#,
             )
             .unwrap()
-            .funcall::<i64, _, _>("itself", &[])
+            .try_into::<i64>()
             .unwrap();
         assert_eq!(result, 1);
-        let result = interp
-            .eval("r.size")
-            .unwrap()
-            .funcall::<i64, _, _>("itself", &[])
-            .unwrap();
+        let result = interp.eval("r.size").unwrap().try_into::<i64>().unwrap();
         assert_eq!(result, 3);
         let result = interp
             .eval("r << 4")
             .unwrap()
-            .funcall::<Vec<i64>, _, _>("itself", &[])
+            .try_into::<Vec<i64>>()
             .unwrap();
         assert_eq!(result, vec![1, 2, 3, 4]);
         let result = interp
             .eval("r.map { |x| x * 2 }")
             .unwrap()
-            .funcall::<Vec<i64>, _, _>("itself", &[])
+            .try_into::<Vec<i64>>()
             .unwrap();
         assert_eq!(result, vec![2, 4, 6, 8]);
     }
@@ -132,7 +127,7 @@ out << q.first
                 "#,
             )
             .unwrap()
-            .funcall::<Vec<Option<String>>, _, _>("itself", &[])
+            .try_into::<Vec<Option<String>>>()
             .unwrap();
         assert_eq!(
             result,
@@ -180,7 +175,7 @@ end
                 "#,
             )
             .unwrap()
-            .funcall::<bool, _, _>("itself", &[])
+            .try_into::<bool>()
             .unwrap();
         assert!(result);
     }

--- a/mruby/src/extn/stdlib/set.rs
+++ b/mruby/src/extn/stdlib/set.rs
@@ -69,7 +69,7 @@ end
                 ",
             )
             .unwrap();
-        let result = result.funcall::<Vec<i64>, _, _>("itself", &[]);
+        let result = result.try_into::<Vec<i64>>();
         assert_eq!(result, Ok(vec![1, 2, 3, 4, 5, 6]));
     }
 }

--- a/mruby/src/value/mod.rs
+++ b/mruby/src/value/mod.rs
@@ -201,6 +201,28 @@ impl Value {
         self.funcall::<String, _, _>("inspect", &[])
             .unwrap_or_else(|_| "<unknown>".to_owned())
     }
+
+    /// Consume `self` and try to convert `self` to type `T`.
+    ///
+    /// If you do not want to consume this [`Value`], use [`Value::itself`].
+    pub fn try_into<T>(self) -> Result<T, MrbError>
+    where
+        T: TryFromMrb<Self, From = types::Ruby, To = types::Rust>,
+    {
+        let interp = Rc::clone(&self.interp);
+        unsafe { T::try_from_mrb(&interp, self) }.map_err(MrbError::ConvertToRust)
+    }
+
+    /// Call `#itself` on this [`Value`] and try to convert the result to type
+    /// `T`.
+    ///
+    /// If you want to consume this [`Value`], use [`Value::try_into`].
+    pub fn itself<T>(self) -> Result<T, MrbError>
+    where
+        T: TryFromMrb<Self, From = types::Ruby, To = types::Rust>,
+    {
+        self.funcall::<T, _, _>("itself", &[])
+    }
 }
 
 impl ValueLike for Value {


### PR DESCRIPTION
`Value::try_into` consumes `self` and attempts to convert with a `TryFromMrb` converter.

`Value::itself` calls `#itself` with the funcall interface and converts to `T` via `ValueLike::funcall`.

This PR converts all usage of funcall("itself") to use the new interfaces.