### PR TITLE
Improve mruby crate README

### DIFF
--- a/mruby/README.md
+++ b/mruby/README.md
@@ -1,170 +1,191 @@
 # mruby
 
-Crate mruby provides a safe interface over the raw bindings in
-[mruby-sys](/mruby-sys).
+mruby crate provides a safe interface over the raw mruby bindings in
+[`mruby-sys`](/mruby-sys). mruby crate aims to expose as much of the mruby API
+as possible.
 
-## Features
+## Execute Ruby Code
 
-### Embed Rust Objects in `mrb_value`
-
-`mrb_value`s can own a pointer to a Rust object via an `Rc<RefCell<_>>`. The
-interpreter supports extracting Rust values from an mruby value, which can be
-used to implement Ruby functions by delegating to Rust code.
-
-### Converters between Ruby and Rust Types
-
-The [convert module](src/convert) provides implementations for `TryFromMrb`
-which can convert between Ruby `mrb_value`s and native Rust types using an `Mrb`
+mruby crate exposes several mechanisms for executing Ruby code on the
 interpreter.
 
-The converters support converting `nil`able Ruby types to `Option<_>` and
-converting Array to `Vec`.
+### Evaling Source Code
 
-The converters are `unsafe`.
-
-### Virtual Filesystem and `Kernel#require`
-
-The mruby [State](src/state.rs) embeds an
-[in-memory virtual Unix filesystem](/mruby-vfs). Both pure Ruby source files and
-Rust-implemented `MrbFile`s are stored in the VFS and exposed to Ruby code in
-the interpreter via a Rust implementation of `Kernel#require`.
-
-`MrbFile::require` methods are stored as custom metadata on File nodes in the
-VFS.
-
-## API Examples
-
-### Evaling code
+mruby crate exposes eval on the `mrb_state` with the [`MrbEval`](src/eval.rs)
+trait. Side effects from eval are persisted across invocations.
 
 ```rust
-use mruby::convert::TryFromMrb;
 use mruby::eval::MrbEval;
 use mruby::interpreter::Interpreter;
 
-let interp = Interpreter::create().expect("mrb init");
-let result = interp.eval("10 * 10").expect("eval");
-let result = unsafe { i64::try_from_mrb(&interp, result) }.expect("convert");
-assert_eq!(result, 100);
+let interp = Interpreter::create().unwrap();
+let result = interp.eval("10 * 10").unwrap();
+let result = result.try_into::<i64>();
+assert_eq!(result, Ok(100));
 ```
 
-### Defining Ruby Sources
+### Calling Ruby Functions from Rust
+
+The [`ValueLike`](src/value/mod.rs) trait exposes a _funcall interface_ which
+can call Ruby functions on a [`Value`](src/value/mod.rs) using a `String`
+function name and a `Vec<Value>` or arguments. funcall takes a type parameter
+bound by `TryFromMrb` and converts the result of the function call to a Rust
+type (which may be `Value` or another "native" type).
+
+mruby limits functions to a maximum of 16 arguments.
+
+## Virtual Filesystem and `Kernel#require`
+
+The mruby [`State`](src/state.rs) embeds an
+[in-memory virtual Unix filesystem](/mruby-vfs). The VFS stores Ruby sources
+that are either pure Ruby, implemented with a Rust [`MrbFile`](src/file.rs), or
+both.
+
+mruby crate implements
+[`Kernel#require` and `Kernel#relative_require`](src/extn/core/kernel.rs) which
+loads sources from the VFS. For Ruby sources, the source is loaded from the VFS
+as a `Vec<u8>` and evaled with [`MrbEval::eval_with_context`](src/eval.rs). For
+Rust sources, [`MrbFile::require`](src/file.rs) methods are stored as custom
+metadata on File nodes in the VFS.
 
 ```rust
-use mruby::convert::TryFromMrb;
 use mruby::eval::MrbEval;
 use mruby::interpreter::Interpreter;
 use mruby::load::MrbLoadSources;
 
-let mut interp = Interpreter::create().expect("mrb init");
-let code = "def source_file; __FILE__; end";
-interp.def_rb_source_file("source.rb", code).expect("def file");
-interp.eval("require 'source'").expect("eval");
-let result = interp.eval("source_file").expect("eval");
-let result = unsafe { String::try_from_mrb(&interp, result) }.expect("convert");
+let mut interp = Interpreter::create().unwrap();
+let code = "
+def source_location
+  __FILE__
+end
+";
+interp.def_rb_source_file("source.rb", code).unwrap();
+interp.eval("require 'source'").unwrap();
+let result = interp.eval("source_location").unwrap();
+let result = result.try_into::<String>().unwrap();
 assert_eq!(&result, "/src/lib/source.rb");
 ```
 
-### Defining Rust-Backed Ruby Types
+## Embed Rust Objects in `mrb_value`
+
+The `mrb_value` struct is a data type that represents a Ruby object. The
+concrete type of an `mrb_value` is specified by its type tag, an `mrb_vtype`
+enum value.
+
+One `mrb_vtype` is `MRB_TT_DATA`, which allows an `mrb_value` to store an owned
+`c_void` pointer. mruby crate leverages this to store an owned copy of an
+`Rc<RefCell<T>>` for any `T` that implements `RustBackedValue`.
+
+[`RustBackedValue`](src/convert/object.rs) provides two methods for working with
+`MRB_TT_DATA`:
+
+- `RustBackedValue::try_into_ruby` consumes `self` and returns a live
+  `mrb_value` that wraps `T`.
+- `RustBackedValue::try_from_ruby` extracts an `Rc<RefCell<T>>` from an
+  `mrb_value` and manages the strong count of the `Rc` smart pointer to ensure
+  that the `mrb_value` continues to point to valid memory.
+
+These `mrb_value`s with type tag `MRB_TT_DATA` can be used to implement Ruby
+`Class`es and `Module`s with Rust structs. An example of this is the
+[`Regexp`](src/extn/core/regexp.rs) class which wraps an Oniguruma regex
+provided by the [`onig`](https://docs.rs/onig/) crate.
 
 ```rust
-use mruby::convert::TryFromMrb;
-use mruby::def::{ClassLike, Define};
+use mruby::convert::{RustBackedValue, TryFromMrb};
+use mruby::def::{rust_data_free, ClassLike, Define};
 use mruby::eval::MrbEval;
 use mruby::file::MrbFile;
-use mruby::interpreter::{Interpreter, Mrb};
-use mruby::interpreter_or_raise;
+use mruby::interpreter::{Interpreter, Mrb, MrbApi};
 use mruby::load::MrbLoadSources;
 use mruby::sys;
-use mruby::unwrap_value_or_raise;
 use mruby::value::Value;
-use std::cell::RefCell;
-use std::ffi::{c_void, CString};
+use mruby::{interpreter_or_raise, unwrap_or_raise, unwrap_value_or_raise};
+use mruby::MrbError;
+use std::io::Write;
 use std::mem;
-use std::rc::Rc;
 
 struct Container { inner: i64 }
 
-impl MrbFile for Container {
-  fn require(interp: Mrb) {
-        extern "C" fn free(_mrb: *mut sys::mrb_state, data: *mut c_void) {
-            unsafe {
-                let _ = mem::transmute::<*mut c_void, Rc<RefCell<Container>>>(data);
-            }
-        }
-
-        extern "C" fn initialize(
-            mrb: *mut sys::mrb_state,
-            mut slf: sys::mrb_value,
-        ) -> sys::mrb_value {
-            unsafe {
-                let interp = interpreter_or_raise!(mrb);
-                let api = interp.borrow();
-                let int = mem::uninitialized::<sys::mrb_int>();
-                let argspec = CString::new(sys::specifiers::INTEGER).expect("argspec");
-                sys::mrb_get_args(mrb, argspec.as_ptr(), &int);
-                let cont = Container { inner: int };
-                let data = Rc::new(RefCell::new(cont));
-                let ptr = mem::transmute::<Rc<RefCell<Container>>, *mut c_void>(data);
-                let spec = api.class_spec::<Container>();
-                sys::mrb_sys_data_init(&mut slf, ptr, spec.data_type());
-                slf
-            }
-        }
-
-        extern "C" fn value(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-            unsafe {
-                let interp = interpreter_or_raise!(mrb);
-                let api = interp.borrow();
-                let spec = api.class_spec::<Container>();
-                let ptr = sys::mrb_data_get_ptr(mrb, slf, spec.data_type());
-                let data = mem::transmute::<*mut c_void, Rc<RefCell<Container>>>(ptr);
-                let clone = Rc::clone(&data);
-                let cont = clone.borrow();
-                let value = unwrap_value_or_raise!(interp, Value::try_from_mrb(&interp, cont.inner));
-                mem::forget(data);
-                value
-            }
-        }
-
-        {
-            let mut api = interp.borrow_mut();
-            api.def_class::<Self>("Container", None, Some(free));
-            let spec = api.class_spec_mut::<Self>();
-            spec.add_method("initialize", initialize, sys::mrb_args_req(1));
-            spec.add_method("value", value, sys::mrb_args_none());
-            spec.mrb_value_is_rust_backed(true);
-        }
+impl Container {
+    unsafe extern "C" fn initialize(mrb: *mut sys::mrb_state, mut slf: sys::mrb_value) -> sys::mrb_value {
+        let interp = interpreter_or_raise!(mrb);
         let api = interp.borrow();
-        let spec = api.class_spec::<Self>();
-        spec.define(&interp).expect("class install");
+        let int = mem::uninitialized::<sys::mrb_int>();
+        let mut argspec = vec![];
+        argspec.write_all(format!("{}\0", sys::specifiers::INTEGER).as_bytes()).unwrap();
+        sys::mrb_get_args(mrb, argspec.as_ptr() as *const i8, &int);
+        let cont = Self { inner: int };
+        unwrap_value_or_raise!(interp, cont.try_into_ruby(&interp, Some(slf)))
+    }
+
+    unsafe extern "C" fn value(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+        let interp = interpreter_or_raise!(mrb);
+        let cont = unwrap_or_raise!(
+            interp,
+            Self::try_from_ruby(&interp, &Value::new(&interp, slf)),
+            interp.nil().inner()
+        );
+        let borrow = cont.borrow();
+        interp.fixnum(borrow.inner).inner()
     }
 }
 
-let mut interp = Interpreter::create().expect("mrb init");
-interp.def_file_for_type::<_, Container>("source.rb").expect("def file");
-interp.eval("require 'source'").expect("eval");
-let result = interp.eval("Container.new(15).value * 24").expect("eval");
-let result = unsafe { i64::try_from_mrb(&interp, result) }.expect("convert");
-assert_eq!(result, 360);
+impl RustBackedValue for Container {}
+
+impl MrbFile for Container {
+  fn require(interp: Mrb) -> Result<(), MrbError> {
+        let spec = interp.borrow_mut().def_class::<Self>("Container", None, Some(rust_data_free::<Self>));
+        spec.borrow_mut().add_method("initialize", Self::initialize, sys::mrb_args_req(1));
+        spec.borrow_mut().add_method("value", Self::value, sys::mrb_args_none());
+        spec.borrow_mut().mrb_value_is_rust_backed(true);
+        spec.borrow().define(&interp)?;
+        Ok(())
+    }
+}
+
+let mut interp = Interpreter::create().unwrap();
+interp.def_file_for_type::<_, Container>("container.rb").unwrap();
+interp.eval("require 'container'").unwrap();
+let result = interp.eval("Container.new(15).value * 24").unwrap();
+assert_eq!(result.try_into::<i64>(), Ok(360));
 ```
 
-### Garbage Collection
+## Converters Between Ruby and Rust Types
 
-```rust
-use mruby::convert::TryFromMrb;
-use mruby::eval::MrbEval;
-use mruby::gc::GarbageCollection;
-use mruby::interpreter::Interpreter;
-use mruby::load::MrbLoadSources;
+The [`convert` module](src/convert) provides implementations for conversions
+between `mrb_value` Ruby types and native Rust types like `i64` and
+`HashMap<String, Option<Vec<u8>>>` using an `Mrb` interpreter.
 
-let interp = Interpreter::create().expect("mrb init");
-interp.disable_gc();
-let code = "def spray_heap; 1024.times { '1234567890' }; nil; end";
-interp.eval(code).expect("eval");
-let live_objects = interp.live_object_count();
-interp.eval("spray_heap").expect("eval");
-assert_eq!(interp.live_object_count(), live_objects + 1024 + 3);
-interp.enable_gc();
-interp.full_gc();
-assert_eq!(interp.live_object_count(), live_objects - 1);
-```
+There are two converter traits:
+
+- [`FromMrb`](src/convert.rs) provides infallible conversions that return
+  `Self`. Converting from a Rust native type to a Ruby `mrb_value` is usually an
+  infallible conversion.
+- [`TryFromMrb`](src/convert.rs) provides fallible conversions that return
+  `Result<Self, Error>`. Converting from a Ruby `mrb_value` to a Rust native
+  type is always an fallible conversion because an `mrb_value` may be any type
+  tag.
+
+Supported conversions:
+
+- Ruby _primitive types_ to Rust types. Primitive Ruby types are `TrueClass`,
+  `FalseClass`, `String` (both UTF-8 and binary), `Fixnum` (`i64`), `Float`
+  (`f64`).
+- Rust types to Ruby types. Supported Rust types are `bool`, `Vec<u8>`, `&[u8]`,
+  integer types that losslessly convert to `i64` (`i64`, `i32`, `i16`, `i8`,
+  `u32`, `u16`, `u8`), `f64`, `String`, `&str`.
+- Ruby `nil`able types to Rust `Option<T>`.
+- Rust `Option<T>` types to Ruby `nil` or an `mrb_value` converted from `T`.
+- Ruby `Array` to Rust `Vec<T>` where `T` corresponds to a Ruby _primitive
+  type_.
+- Rust `Vec<T>` to Ruby `Array` where `T` corresponds to a Ruby _primitive
+  type_.
+- Ruby `Hash` to Rust `Vec<(Key, Value)>` or `HashMap<Key, Value>` where `Key`
+  and `Value` correspond to Ruby _primitive types_.
+- Rust `Vec<(Key, Value)>` or `HashMap<Key, Value>` to Ruby `Hash` where `Key`
+  and `Value` correspond to Ruby _primitive types_.
+- Identity conversion from `Value` to `Value`, which is useful when working with
+  collection types.
+
+The infallible converters are safe Rust functions. The fallibile converters are
+`unsafe` Rust functions.

--- a/mruby/src/lib.rs
+++ b/mruby/src/lib.rs
@@ -1,5 +1,198 @@
 #![deny(clippy::all, clippy::pedantic)]
 #![deny(warnings, intra_doc_link_resolution_failure)]
+#![doc(deny(warnings))]
+
+//! # mruby
+//!
+//! mruby crate provides a safe interface over the raw mruby bindings in
+//! [`mruby-sys`](mruby_sys). mruby crate aims to expose as much of the mruby API
+//! as possible.
+//!
+//! ## Execute Ruby Code
+//!
+//! mruby crate exposes several mechanisms for executing Ruby code on the
+//! interpreter.
+//!
+//! ### Evaling Source Code
+//!
+//! mruby crate exposes eval on the `mrb_state` with the [`MrbEval`](eval::MrbEval)
+//! trait. Side effects from eval are persisted across invocations.
+//!
+//! ```rust
+//! use mruby::eval::MrbEval;
+//! use mruby::interpreter::Interpreter;
+//!
+//! let interp = Interpreter::create().unwrap();
+//! let result = interp.eval("10 * 10").unwrap();
+//! let result = result.try_into::<i64>();
+//! assert_eq!(result, Ok(100));
+//! ```
+//!
+//! ### Calling Ruby Functions from Rust
+//!
+//! The [`ValueLike`](value::ValueLike) trait exposes a _funcall interface_ which
+//! can call Ruby functions on a [`Value`](value::Value) using a `String`
+//! function name and a `Vec<Value>` or arguments. funcall takes a type parameter
+//! bound by [`TryFromMrb`](convert::TryFromMrb) and converts the result of the function call to a Rust
+//! type (which may be `Value` or another "native" type).
+//!
+//! mruby limits functions to a maximum of 16 arguments.
+//!
+//! ## Virtual Filesystem and `Kernel#require`
+//!
+//! The mruby [`State`](state::State) embeds an
+//! [in-memory virtual Unix filesystem](mruby_vfs). The VFS stores Ruby sources
+//! that are either pure Ruby, implemented with a Rust [`MrbFile`](file::MrbFile), or
+//! both.
+//!
+//! mruby crate implements
+//! [`Kernel#require` and `Kernel#relative_require`](extn::core::kernel::Kernel) which
+//! loads sources from the VFS. For Ruby sources, the source is loaded from the VFS
+//! as a `Vec<u8>` and evaled with [`MrbEval::eval_with_context`](eval::MrbEval::eval_with_context). For
+//! Rust sources, [`MrbFile::require`](file::MrbFile::require) methods are stored as custom
+//! metadata on [`File`](mruby_vfs::FakeFileSystem) nodes in the VFS.
+//!
+//! ```rust
+//! use mruby::eval::MrbEval;
+//! use mruby::interpreter::Interpreter;
+//! use mruby::load::MrbLoadSources;
+//!
+//! let mut interp = Interpreter::create().unwrap();
+//! let code = "
+//! def source_location
+//!   __FILE__
+//! end
+//! ";
+//! interp.def_rb_source_file("source.rb", code).unwrap();
+//! interp.eval("require 'source'").unwrap();
+//! let result = interp.eval("source_location").unwrap();
+//! let result = result.try_into::<String>().unwrap();
+//! assert_eq!(&result, "/src/lib/source.rb");
+//! ```
+//!
+//! ## Embed Rust Objects in `mrb_value`
+//!
+//! The [`mrb_value`](sys::mrb_value) struct is a data type that represents a Ruby object. The
+//! concrete type of an `mrb_value` is specified by its type tag, an [`mrb_vtype`](sys::mrb_vtype)
+//! enum value.
+//!
+//! One `mrb_vtype` is `MRB_TT_DATA`, which allows an `mrb_value` to store an owned
+//! `c_void` pointer. mruby crate leverages this to store an owned copy of an
+//! `Rc<RefCell<T>>` for any `T` that implements [`RustBackedValue`](convert::RustBackedValue).
+//!
+//! [`RustBackedValue`](convert::RustBackedValue) provides two methods for working with
+//! `MRB_TT_DATA`:
+//!
+//! - [`RustBackedValue::try_into_ruby`](convert::RustBackedValue::try_into_ruby) consumes `self` and returns a live
+//!   `mrb_value` that wraps `T`.
+//! - [`RustBackedValue::try_from_ruby`](convert::RustBackedValue::try_from_ruby) extracts an `Rc<RefCell<T>>` from an
+//!   `mrb_value` and manages the strong count of the `Rc` smart pointer to ensure
+//!   that the `mrb_value` continues to point to valid memory.
+//!
+//! These `mrb_value`s with type tag `MRB_TT_DATA` can be used to implement Ruby
+//! `Class`es and `Module`s with Rust structs. An example of this is the
+//! [`Regexp`](extn::core::regexp::Regexp) class which wraps an Oniguruma regex
+//! provided by the [`onig`] crate.
+//!
+//! ```rust
+//! use mruby::convert::{RustBackedValue, TryFromMrb};
+//! use mruby::def::{rust_data_free, ClassLike, Define};
+//! use mruby::eval::MrbEval;
+//! use mruby::file::MrbFile;
+//! use mruby::interpreter::{Interpreter, Mrb, MrbApi};
+//! use mruby::load::MrbLoadSources;
+//! use mruby::sys;
+//! use mruby::value::Value;
+//! use mruby::{interpreter_or_raise, unwrap_or_raise, unwrap_value_or_raise};
+//! use mruby::MrbError;
+//! use std::io::Write;
+//! use std::mem;
+//!
+//! struct Container { inner: i64 }
+//!
+//! impl Container {
+//!     unsafe extern "C" fn initialize(mrb: *mut sys::mrb_state, mut slf: sys::mrb_value) -> sys::mrb_value {
+//!         let interp = interpreter_or_raise!(mrb);
+//!         let api = interp.borrow();
+//!         let int = mem::uninitialized::<sys::mrb_int>();
+//!         let mut argspec = vec![];
+//!         argspec.write_all(format!("{}\0", sys::specifiers::INTEGER).as_bytes()).unwrap();
+//!         sys::mrb_get_args(mrb, argspec.as_ptr() as *const i8, &int);
+//!         let cont = Self { inner: int };
+//!         unwrap_value_or_raise!(interp, cont.try_into_ruby(&interp, Some(slf)))
+//!     }
+//!
+//!     unsafe extern "C" fn value(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+//!         let interp = interpreter_or_raise!(mrb);
+//!         let cont = unwrap_or_raise!(
+//!             interp,
+//!             Self::try_from_ruby(&interp, &Value::new(&interp, slf)),
+//!             interp.nil().inner()
+//!         );
+//!         let borrow = cont.borrow();
+//!         interp.fixnum(borrow.inner).inner()
+//!     }
+//! }
+//!
+//! impl RustBackedValue for Container {}
+//!
+//! impl MrbFile for Container {
+//!   fn require(interp: Mrb) -> Result<(), MrbError> {
+//!         let spec = interp.borrow_mut().def_class::<Self>("Container", None, Some(rust_data_free::<Self>));
+//!         spec.borrow_mut().add_method("initialize", Self::initialize, sys::mrb_args_req(1));
+//!         spec.borrow_mut().add_method("value", Self::value, sys::mrb_args_none());
+//!         spec.borrow_mut().mrb_value_is_rust_backed(true);
+//!         spec.borrow().define(&interp)?;
+//!         Ok(())
+//!     }
+//! }
+//!
+//! let mut interp = Interpreter::create().unwrap();
+//! interp.def_file_for_type::<_, Container>("container.rb").unwrap();
+//! interp.eval("require 'container'").unwrap();
+//! let result = interp.eval("Container.new(15).value * 24").unwrap();
+//! assert_eq!(result.try_into::<i64>(), Ok(360));
+//! ```
+//!
+//! ## Converters Between Ruby and Rust Types
+//!
+//! The [`convert` module](convert) provides implementations for conversions
+//! between `mrb_value` Ruby types and native Rust types like `i64` and
+//! `HashMap<String, Option<Vec<u8>>>` using an [`Mrb`](interpreter::Mrb) interpreter.
+//!
+//! There are two converter traits:
+//!
+//! - [`FromMrb`](convert::FromMrb) provides infallible conversions that return
+//!   `Self`. Converting from a Rust native type to a Ruby `mrb_value` is usually an
+//!   infallible conversion.
+//! - [`TryFromMrb`](convert::TryFromMrb) provides fallible conversions that return
+//!   `Result<Self, Error>`. Converting from a Ruby `mrb_value` to a Rust native
+//!   type is always an fallible conversion because an `mrb_value` may be any type
+//!   tag.
+//!
+//! Supported conversions:
+//!
+//! - Ruby _primitive types_ to Rust types. Primitive Ruby types are `TrueClass`,
+//!   `FalseClass`, `String` (both UTF-8 and binary), `Fixnum` (`i64`), `Float`
+//!   (`f64`).
+//! - Rust types to Ruby types. Supported Rust types are `bool`, `Vec<u8>`, `&[u8]`,
+//!   integer types that losslessly convert to `i64` (`i64`, `i32`, `i16`, `i8`,
+//!   `u32`, `u16`, `u8`), `f64`, `String`, `&str`.
+//! - Ruby `nil`able types to Rust `Option<T>`.
+//! - Rust `Option<T>` types to Ruby `nil` or an `mrb_value` converted from `T`.
+//! - Ruby `Array` to Rust `Vec<T>` where `T` corresponds to a Ruby _primitive
+//!   type_.
+//! - Rust `Vec<T>` to Ruby `Array` where `T` corresponds to a Ruby _primitive
+//!   type_.
+//! - Ruby `Hash` to Rust `Vec<(Key, Value)>` or `HashMap<Key, Value>` where `Key`
+//!   and `Value` correspond to Ruby _primitive types_.
+//! - Rust `Vec<(Key, Value)>` or `HashMap<Key, Value>` to Ruby `Hash` where `Key`
+//!   and `Value` correspond to Ruby _primitive types_.
+//! - Identity conversion from `Value` to `Value`, which is useful when working with
+//!   collection types.
+//!
+//! The infallible converters are safe Rust functions. The fallibile converters are
+//! `unsafe` Rust functions.
 
 use std::error;
 use std::fmt;


### PR DESCRIPTION
- Author README in markdown but also store in lib.rs to ensure code samples work.
- Fix broken code samples.
- Sync code samples with latest patterns.
- Group examples with sections.
- Expand explanations for features.
- Nuke section on GC.
- Mention funcall interface

Relates to GH-57.