### PR TITLE
Protect against stack splits when raising from Rust code

### DIFF
--- a/mruby-sys/mruby-sys/include/mruby-sys/ext.h
+++ b/mruby-sys/mruby-sys/include/mruby-sys/ext.h
@@ -71,7 +71,7 @@ mrb_value mrb_sys_fixnum_value(mrb_int value);
 
 mrb_value mrb_sys_float_value(struct mrb_state *mrb, mrb_float value);
 
-mrb_value mrb_sys_cptr_value(struct mrb_state* mrb, void* ptr);
+mrb_value mrb_sys_cptr_value(struct mrb_state *mrb, void *ptr);
 
 mrb_value mrb_sys_obj_value(void *p);
 

--- a/mruby-sys/mruby-sys/include/mruby-sys/ext.h
+++ b/mruby-sys/mruby-sys/include/mruby-sys/ext.h
@@ -45,6 +45,8 @@ mrb_int mrb_sys_fixnum_to_cint(mrb_value value);
 
 mrb_float mrb_sys_float_to_cdouble(mrb_value value);
 
+void *mrb_sys_cptr_ptr(mrb_value value);
+
 struct RBasic *mrb_sys_basic_ptr(mrb_value value);
 
 struct RObject *mrb_sys_obj_ptr(mrb_value value);
@@ -68,6 +70,8 @@ mrb_value mrb_sys_true_value(void);
 mrb_value mrb_sys_fixnum_value(mrb_int value);
 
 mrb_value mrb_sys_float_value(struct mrb_state *mrb, mrb_float value);
+
+mrb_value mrb_sys_cptr_value(struct mrb_state* mrb, void* ptr);
 
 mrb_value mrb_sys_obj_value(void *p);
 

--- a/mruby-sys/mruby-sys/src/mruby-sys/ext.c
+++ b/mruby-sys/mruby-sys/src/mruby-sys/ext.c
@@ -30,9 +30,7 @@ mrb_int mrb_sys_fixnum_to_cint(mrb_value value) { return mrb_fixnum(value); }
 
 mrb_float mrb_sys_float_to_cdouble(mrb_value value) { return mrb_float(value); }
 
-void *mrb_sys_cptr_ptr(mrb_value value) {
-  return mrb_cptr(value);
-}
+void *mrb_sys_cptr_ptr(mrb_value value) { return mrb_cptr(value); }
 
 struct RBasic *mrb_sys_basic_ptr(mrb_value value) {
   return mrb_basic_ptr(value);
@@ -74,13 +72,13 @@ mrb_value mrb_sys_float_value(struct mrb_state *mrb, mrb_float value) {
   return mrb_float_value(mrb, value);
 }
 
-mrb_value mrb_sys_cptr_value(struct mrb_state* mrb, void* ptr) {
-    mrb_value value;
-    (void)(mrb);
+mrb_value mrb_sys_cptr_value(struct mrb_state *mrb, void *ptr) {
+  mrb_value value;
+  (void)(mrb);
 
-    SET_CPTR_VALUE(mrb, value, ptr);
+  SET_CPTR_VALUE(mrb, value, ptr);
 
-    return value;
+  return value;
 }
 
 mrb_value mrb_sys_obj_value(void *p) { return mrb_obj_value(p); }

--- a/mruby-sys/mruby-sys/src/mruby-sys/ext.c
+++ b/mruby-sys/mruby-sys/src/mruby-sys/ext.c
@@ -30,6 +30,10 @@ mrb_int mrb_sys_fixnum_to_cint(mrb_value value) { return mrb_fixnum(value); }
 
 mrb_float mrb_sys_float_to_cdouble(mrb_value value) { return mrb_float(value); }
 
+void *mrb_sys_cptr_ptr(mrb_value value) {
+  return mrb_cptr(value);
+}
+
 struct RBasic *mrb_sys_basic_ptr(mrb_value value) {
   return mrb_basic_ptr(value);
 }
@@ -68,6 +72,15 @@ mrb_value mrb_sys_fixnum_value(mrb_int value) {
 
 mrb_value mrb_sys_float_value(struct mrb_state *mrb, mrb_float value) {
   return mrb_float_value(mrb, value);
+}
+
+mrb_value mrb_sys_cptr_value(struct mrb_state* mrb, void* ptr) {
+    mrb_value value;
+    (void)(mrb);
+
+    SET_CPTR_VALUE(mrb, value, ptr);
+
+    return value;
 }
 
 mrb_value mrb_sys_obj_value(void *p) { return mrb_obj_value(p); }

--- a/mruby-sys/src/ffi.rs
+++ b/mruby-sys/src/ffi.rs
@@ -3309,6 +3309,9 @@ extern "C" {
     pub fn mrb_sys_float_to_cdouble(value: mrb_value) -> mrb_float;
 }
 extern "C" {
+    pub fn mrb_sys_cptr_ptr(value: mrb_value) -> *mut ::std::os::raw::c_void;
+}
+extern "C" {
     pub fn mrb_sys_basic_ptr(value: mrb_value) -> *mut RBasic;
 }
 extern "C" {
@@ -3340,6 +3343,9 @@ extern "C" {
 }
 extern "C" {
     pub fn mrb_sys_float_value(mrb: *mut mrb_state, value: mrb_float) -> mrb_value;
+}
+extern "C" {
+    pub fn mrb_sys_cptr_value(mrb: *mut mrb_state, ptr: *mut ::std::os::raw::c_void) -> mrb_value;
 }
 extern "C" {
     pub fn mrb_sys_obj_value(p: *mut ::std::os::raw::c_void) -> mrb_value;

--- a/mruby/src/eval.rs
+++ b/mruby/src/eval.rs
@@ -1,5 +1,7 @@
 use log::{error, trace, warn};
-use std::ffi::CString;
+use std::ffi::{c_void, CString};
+use std::mem;
+use std::rc::Rc;
 
 use crate::exception::{LastError, MrbExceptionHandler};
 use crate::interpreter::Mrb;
@@ -8,6 +10,20 @@ use crate::value::Value;
 use crate::MrbError;
 
 const TOP_FILENAME: &str = "(eval)";
+
+struct ProtectArgs {
+    ctx: *mut sys::mrbc_context,
+    code: Vec<u8>,
+}
+
+impl ProtectArgs {
+    fn new(interp: &Mrb, code: &[u8]) -> Self {
+        Self {
+            ctx: interp.borrow().ctx,
+            code: code.to_vec(),
+        }
+    }
+}
 
 /// `EvalContext` is used to manipulate the state of a wrapped
 /// [`sys::mrb_state`]. [`Mrb`] maintains a stack of `EvalContext`s and
@@ -81,6 +97,35 @@ impl MrbEval for Mrb {
     where
         T: AsRef<[u8]>,
     {
+        unsafe extern "C" fn run_protected(
+            mrb: *mut sys::mrb_state,
+            data: sys::mrb_value,
+        ) -> sys::mrb_value {
+            let ptr = sys::mrb_sys_cptr_ptr(data);
+            let args = mem::transmute::<*const c_void, *const ProtectArgs>(ptr);
+            let args = Rc::from_raw(args);
+
+            // Execute arbitrary ruby code, which may generate objects with C
+            // APIs if backed by Rust functions.
+            //
+            // `mrb_load_nstring_ctx` sets the "stack keep" field on the context
+            // which means the most recent value returned by eval will always be
+            // considered live by the GC.
+            sys::mrb_load_nstring_cxt(
+                mrb,
+                args.code.as_ptr() as *const i8,
+                args.code.len(),
+                args.ctx,
+            )
+        }
+        // Ensure the borrow is out of scope by the time we eval code since
+        // Rust-backed files and types may need to mutably borrow the `Mrb` to
+        // get access to the underlying `MrbState`.
+        let (mrb, ctx) = {
+            let borrow = self.borrow();
+            (borrow.mrb, borrow.ctx)
+        };
+
         // Grab the persistent `EvalContext` from the context on the `State` or
         // the root context if the stack is empty.
         let context = {
@@ -92,14 +137,6 @@ impl MrbEval for Mrb {
             }
         };
 
-        // Ensure the borrow is out of scope by the time we eval code since
-        // Rust-backed files and types may need to mutably borrow the `Mrb` to
-        // get access to the underlying `MrbState`.
-        let (mrb, ctx) = {
-            let borrow = self.borrow();
-            (borrow.mrb, borrow.ctx)
-        };
-
         if let Ok(cfilename) = CString::new(context.filename.to_owned()) {
             unsafe {
                 sys::mrbc_filename(mrb, ctx, cfilename.as_ptr() as *const i8);
@@ -108,18 +145,20 @@ impl MrbEval for Mrb {
             warn!("Could not set {} as mrc context filename", context.filename);
         }
 
-        let code = code.as_ref();
+        let args = Rc::new(ProtectArgs::new(self, code.as_ref()));
         trace!("Evaling code on {}", mrb.debug());
-        let result = unsafe {
-            // Execute arbitrary ruby code, which may generate objects with C
-            // APIs if backed by Rust functions.
-            //
-            // `mrb_load_nstring_ctx` sets the "stack keep" field on the context
-            // which means the most recent value returned by eval will always be
-            // considered live by the GC.
-            sys::mrb_load_nstring_cxt(mrb, code.as_ptr() as *const i8, code.len(), ctx)
+        let value = unsafe {
+            let data = sys::mrb_sys_cptr_value(mrb, Rc::into_raw(args) as *mut c_void);
+            let mut state = mem::uninitialized::<u8>();
+
+            let value = sys::mrb_protect(mrb, Some(run_protected), data, &mut state as *mut u8);
+            if state != 0 {
+                (*mrb).exc = sys::mrb_sys_obj_ptr(value);
+                sys::mrb_sys_raise_current_exception(mrb);
+            }
+            value
         };
-        let value = Value::new(self, result);
+        let value = Value::new(self, value);
 
         match self.last_error() {
             LastError::Some(exception) => {

--- a/mruby/src/eval.rs
+++ b/mruby/src/eval.rs
@@ -102,8 +102,7 @@ impl MrbEval for Mrb {
             data: sys::mrb_value,
         ) -> sys::mrb_value {
             let ptr = sys::mrb_sys_cptr_ptr(data);
-            let args = mem::transmute::<*const c_void, *const ProtectArgs>(ptr);
-            let args = Rc::from_raw(args);
+            let args = Rc::from_raw(ptr as *const ProtectArgs);
 
             // Execute arbitrary ruby code, which may generate objects with C
             // APIs if backed by Rust functions.

--- a/mruby/src/extn/core/error.rs
+++ b/mruby/src/extn/core/error.rs
@@ -1,6 +1,5 @@
 use log::warn;
 use std::ffi::{c_void, CString};
-use std::mem;
 use std::rc::Rc;
 
 use crate::def::{ClassLike, Define};
@@ -74,8 +73,7 @@ pub trait RubyException: 'static + Sized {
             data: sys::mrb_value,
         ) -> sys::mrb_value {
             let ptr = sys::mrb_sys_cptr_ptr(data);
-            let args = mem::transmute::<*const c_void, *const ProtectArgs>(ptr);
-            let args = Rc::from_raw(args);
+            let args = Rc::from_raw(ptr as *const ProtectArgs);
 
             let e_class_cstring = CString::new(args.e_class.as_str());
             let e_class = if let Ok(e_class) = e_class_cstring {

--- a/mruby/src/value/mod.rs
+++ b/mruby/src/value/mod.rs
@@ -46,7 +46,7 @@ impl ProtectArgs {
             slf: self.slf,
             func: self.func,
             args: self.args,
-            block: block,
+            block,
         }
     }
 }
@@ -71,8 +71,7 @@ where
             data: sys::mrb_value,
         ) -> sys::mrb_value {
             let ptr = sys::mrb_sys_cptr_ptr(data);
-            let args = mem::transmute::<*const c_void, *const ProtectArgs>(ptr);
-            let args = Rc::from_raw(args);
+            let args = Rc::from_raw(ptr as *const ProtectArgs);
 
             let sym = sys::mrb_intern(mrb, args.func.as_ptr() as *const i8, args.func.len());
             let value = sys::mrb_funcall_argv(
@@ -163,8 +162,7 @@ where
             data: sys::mrb_value,
         ) -> sys::mrb_value {
             let ptr = sys::mrb_sys_cptr_ptr(data);
-            let args = mem::transmute::<*const c_void, *const ProtectArgsWithBlock>(ptr);
-            let args = Rc::from_raw(args);
+            let args = Rc::from_raw(ptr as *const ProtectArgsWithBlock);
 
             let sym = sys::mrb_intern(mrb, args.func.as_ptr() as *const i8, args.func.len());
             let value = sys::mrb_funcall_with_block(


### PR DESCRIPTION
sys::mrb_raise is implemented with longjmp, which modifies the stack.
Rust callers do not expect this and it was causing mutable borrow
errors on Mrb. To fix this, wrap calls to raising C APIs (eval, raise)
with sys::mrb_protect and sys::mrb_ensure.

With this fix, nested calls to eval and raise, such as 'eval raise',
do not cause a panic.

This commit also re-syncs the implementation of mruby VM interactions
across funcall, eval, and raise.