### PR TITLE
Add more Regexp, MatchData, and String APIs

### DIFF
--- a/mruby/src/extn/core/regexp/args.rs
+++ b/mruby/src/extn/core/regexp/args.rs
@@ -64,6 +64,24 @@ impl RegexpNew {
     }
 }
 
+pub struct Pattern {
+    pub pattern: String,
+}
+
+impl Pattern {
+    pub unsafe fn extract(interp: &Mrb) -> Result<Self, MrbError> {
+        let pattern = mem::uninitialized::<sys::mrb_value>();
+        let mut argspec = vec![];
+        argspec
+            .write_all(format!("{}\0", sys::specifiers::OBJECT,).as_bytes())
+            .map_err(|_| MrbError::ArgSpec)?;
+        sys::mrb_get_args(interp.borrow().mrb, argspec.as_ptr() as *const i8, &pattern);
+        let pattern = String::try_from_mrb(&interp, Value::new(&interp, pattern))
+            .map_err(MrbError::ConvertToRust)?;
+        Ok(Self { pattern })
+    }
+}
+
 pub struct Rest {
     pub rest: Vec<Value>,
 }

--- a/mruby/src/extn/core/regexp/syntax.rs
+++ b/mruby/src/extn/core/regexp/syntax.rs
@@ -1,0 +1,46 @@
+// This module is forked from Rust regex crate @ 172898a.
+//
+// https://github.com/rust-lang/regex/blob/172898a4fda4fd6a2d1be9fc7b8a0ea971c84ca6/regex-syntax/src/lib.rs
+//
+// MIT Licence
+// Copyright (c) 2014 The Rust Project Developers
+
+/// Escapes all regular expression meta characters in `text`.
+///
+/// The string returned may be safely used as a literal in a regular
+/// expression.
+pub fn escape(text: &str) -> String {
+    let mut quoted = String::with_capacity(text.len());
+    escape_into(text, &mut quoted);
+    quoted
+}
+
+/// Escapes all meta characters in `text` and writes the result into `buf`.
+///
+/// This will append escape characters into the given buffer. The characters
+/// that are appended are safe to use as a literal in a regular expression.
+pub fn escape_into(text: &str, buf: &mut String) {
+    for c in text.chars() {
+        if is_meta_character(c) {
+            buf.push('\\');
+        }
+        buf.push(c);
+    }
+}
+
+/// Returns true if the give character has significance in a regex.
+///
+/// These are the only characters that are allowed to be escaped, with one
+/// exception: an ASCII space character may be escaped when extended mode (with
+/// the `x` flag) is enabld. In particular, `is_meta_character(' ')` returns
+/// `false`.
+///
+/// Note that the set of characters for which this function returns `true` or
+/// `false` is fixed and won't change in a semver compatible release.
+pub fn is_meta_character(c: char) -> bool {
+    match c {
+        '\\' | '.' | '+' | '*' | '?' | '(' | ')' | '|' | '[' | ']' | '{' | '}' | '^' | '$'
+        | '#' | '&' | '-' | '~' => true,
+        _ => false,
+    }
+}

--- a/mruby/src/extn/core/string.rb
+++ b/mruby/src/extn/core/string.rb
@@ -14,9 +14,103 @@ class String
 
   # https://ruby-doc.org/core-2.6.3/String.html#method-i-3D-7E
   def =~(other)
-    return other.match(self).begin(0) if other.is_a?(Regexp)
+    return other.match(self)&.begin(0) if other.is_a?(Regexp)
     return other =~ self if other.respond_to?(:=~)
 
     nil
+  end
+
+  # TODO: handle block
+  def split(pattern, limit = nil)
+    if pattern == ''
+      parts = []
+      length.times do |i|
+        parts << self[i]
+      end
+      return parts
+    end
+
+    pattern = Regexp.compile(Regexp.escape(pattern)) if pattern.is_a?(String)
+
+    parts = []
+    remainder = self
+    match = pattern.match(remainder)
+    until match.nil? || (limit && parts.length >= limit)
+      parts <<
+        if match.begin(0).positive?
+          remainder[0..match.begin(0) - 1]
+        else
+          ''
+        end
+      remainder = remainder[match.end(0)..-1]
+      remainder = remainder[1..-1] if match.begin(0) == match.end(0)
+      match = nil
+      pattern.match(remainder) unless remainder.nil?
+    end
+    return parts if remainder.nil? || remainder.empty?
+
+    parts << remainder if limit.nil? || parts.length < limit
+    parts
+  end
+
+  def sub(pattern, replacement = nil)
+    return to_enum(:sub, pattern) if replacement.nil? && !block_given?
+
+    replace =
+      if replacement.nil?
+        ->(old) { (yield old).to_s }
+      elsif replacement.is_a?(Hash)
+        ->(old) { replacement[old].to_s }
+      else
+        ->(_old) { replacement.to_s }
+      end
+    pattern = Regexp.compile(Regexp.escape(pattern)) if pattern.is_a?(String)
+    match = pattern.match(self)
+    return dup if match.nil?
+
+    buf = ''
+    remainder = self
+    buf << remainder[0..match.begin(0) - 1] if match.begin(0).positive?
+    buf << replace.call(match[0])
+    remainder = remainder[match.end(0)..-1]
+    remainder = remainder[1..-1] if match.begin(0) == match.end(0)
+    buf << remainder
+    buf
+  end
+
+  # TODO: Support backrefs
+  #
+  #   "hello".gsub(/([aeiou])/, '<\1>')             #=> "h<e>ll<o>"
+  #   "hello".gsub(/(?<foo>[aeiou])/, '{\k<foo>}')  #=> "h{e}ll{o}"
+  def gsub(pattern, replacement = nil)
+    return to_enum(:gsub, pattern) if replacement.nil? && !block_given?
+
+    replace =
+      if replacement.nil?
+        ->(old) { (yield old).to_s }
+      elsif replacement.is_a?(Hash)
+        ->(old) { replacement[old].to_s }
+      else
+        ->(_old) { replacement.to_s }
+      end
+    pattern = Regexp.compile(Regexp.escape(pattern)) if pattern.is_a?(String)
+    match = pattern.match(self)
+    return dup if match.nil?
+
+    buf = ''
+    remainder = self
+    until match.nil? || remainder.empty?
+      buf << remainder[0..match.begin(0) - 1] if match.begin(0).positive?
+      buf << replace.call(match[0])
+      remainder = remainder[match.end(0)..-1]
+      remainder = remainder[1..-1] if match.begin(0) == match.end(0)
+      match = pattern.match(remainder)
+    end
+    buf << remainder
+  end
+
+  def gsub!(pattern, replacement = nil, &blk)
+    replaced = gsub(pattern, replacement, &blk)
+    self[0..-1] = replaced
   end
 end

--- a/mruby/src/extn/core/string.rs
+++ b/mruby/src/extn/core/string.rs
@@ -1,15 +1,26 @@
-use crate::def::Define;
+use crate::convert::{FromMrb, TryFromMrb};
+use crate::def::{ClassLike, Define};
 use crate::eval::MrbEval;
-use crate::interpreter::Mrb;
+use crate::interpreter::{Mrb, MrbApi};
+use crate::sys;
+use crate::value::{Value, ValueLike};
 use crate::MrbError;
 use log::trace;
+
+mod args;
 
 pub fn patch(interp: &Mrb) -> Result<(), MrbError> {
     let string = interp
         .borrow_mut()
         .def_class::<RString>("String", None, None);
-    string.borrow().define(interp).map_err(|_| MrbError::New)?;
     interp.eval(include_str!("string.rb"))?;
+    string
+        .borrow_mut()
+        .add_method("scan", RString::scan, sys::mrb_args_req(1));
+    string
+        .borrow_mut()
+        .add_method("-@", RString::unary_minus, sys::mrb_args_none());
+    string.borrow().define(interp).map_err(|_| MrbError::New)?;
     trace!("Patched String onto interpreter");
     Ok(())
 }
@@ -17,13 +28,57 @@ pub fn patch(interp: &Mrb) -> Result<(), MrbError> {
 #[allow(clippy::module_name_repetitions)]
 pub struct RString;
 
+impl RString {
+    unsafe extern "C" fn scan(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+        let interp = interpreter_or_raise!(mrb);
+        let args = unwrap_or_raise!(interp, args::Scan::extract(&interp), interp.nil().inner());
+
+        let search = unwrap_or_raise!(
+            interp,
+            String::try_from_mrb(&interp, Value::new(&interp, slf)),
+            interp.nil().inner()
+        );
+
+        let parts = args.regexp.regex().map(|regex| {
+            regex
+                .find_iter(search.as_str())
+                .map(|(start, end)| search[start..end].to_owned())
+                .collect::<Vec<_>>()
+        });
+        Value::from_mrb(&interp, parts).inner()
+    }
+
+    /// Returns a frozen, possibly pre-existing copy of the string.
+    ///
+    /// The string will be deduplicated as long as it is not tainted, or has any
+    /// instance variables set on it.
+    ///
+    /// <https://ruby-doc.org/core-2.6.3/String.html#method-i-2D-40>
+    unsafe extern "C" fn unary_minus(
+        mrb: *mut sys::mrb_state,
+        slf: sys::mrb_value,
+    ) -> sys::mrb_value {
+        let interp = interpreter_or_raise!(mrb);
+        let s = unwrap_or_raise!(
+            interp,
+            String::try_from_mrb(&interp, Value::new(&interp, slf)),
+            interp.nil().inner()
+        );
+        unwrap_value_or_raise!(
+            interp,
+            Value::from_mrb(&interp, s).funcall::<Value, _, _>("freeze", &[])
+        )
+    }
+}
 // Tests from String core docs in Ruby 2.6.3
 // https://ruby-doc.org/core-2.6.3/String.html
 #[cfg(test)]
 mod tests {
+    use crate::convert::FromMrb;
     use crate::eval::MrbEval;
     use crate::extn::core::string;
     use crate::interpreter::Interpreter;
+    use crate::value::{Value, ValueLike};
 
     #[test]
     fn string_equal_squiggle() {
@@ -89,5 +144,59 @@ mod tests {
                 .unwrap(),
             "e"
         );
+    }
+
+    #[test]
+    fn string_scan() {
+        let interp = Interpreter::create().expect("mrb init");
+        string::patch(&interp).expect("string init");
+
+        let s = Value::from_mrb(&interp, "abababa");
+        let result = s
+            .funcall::<Vec<String>, _, _>("scan", &[interp.eval("/./").expect("eval")])
+            .expect("funcall");
+        assert_eq!(
+            result,
+            vec!["a", "b", "a", "b", "a", "b", "a"]
+                .into_iter()
+                .map(str::to_owned)
+                .collect::<Vec<_>>()
+        );
+        let result = s
+            .funcall::<Vec<String>, _, _>("scan", &[interp.eval("/../").expect("eval")])
+            .expect("funcall");
+        assert_eq!(
+            result,
+            vec!["ab", "ab", "ab"]
+                .into_iter()
+                .map(str::to_owned)
+                .collect::<Vec<_>>()
+        );
+        let result = s
+            .funcall::<Vec<String>, _, _>("scan", &[interp.eval("'aba'").expect("eval")])
+            .expect("funcall");
+        assert_eq!(
+            result,
+            vec!["aba", "aba"]
+                .into_iter()
+                .map(str::to_owned)
+                .collect::<Vec<_>>()
+        );
+        let result = s
+            .funcall::<Vec<String>, _, _>("scan", &[interp.eval("'no no no'").expect("eval")])
+            .expect("funcall");
+        assert_eq!(result, <Vec<String>>::new());
+    }
+
+    #[test]
+    fn string_unary_minus() {
+        let interp = Interpreter::create().expect("mrb init");
+        string::patch(&interp).expect("string init");
+
+        let s = interp.eval("-'abababa'").expect("eval");
+        let result = s.funcall::<bool, _, _>("frozen?", &[]).expect("funcall");
+        assert!(result);
+        let result = s.funcall::<String, _, _>("itself", &[]).expect("funcall");
+        assert_eq!(result, "abababa");
     }
 }

--- a/mruby/src/extn/core/string/args.rs
+++ b/mruby/src/extn/core/string/args.rs
@@ -1,0 +1,34 @@
+use std::io::Write;
+use std::mem;
+
+use crate::convert::{RustBackedValue, TryFromMrb};
+use crate::extn::core::regexp::Regexp;
+use crate::interpreter::Mrb;
+use crate::sys;
+use crate::value::Value;
+use crate::MrbError;
+
+pub struct Scan {
+    pub regexp: Regexp,
+}
+
+impl Scan {
+    pub unsafe fn extract(interp: &Mrb) -> Result<Self, MrbError> {
+        let pattern = mem::uninitialized::<sys::mrb_value>();
+        let mut argspec = vec![];
+        argspec
+            .write_all(sys::specifiers::OBJECT.as_bytes())
+            .map_err(|_| MrbError::ArgSpec)?;
+        argspec.write_all(b"\0").map_err(|_| MrbError::ArgSpec)?;
+        sys::mrb_get_args(interp.borrow().mrb, argspec.as_ptr() as *const i8, &pattern);
+        let pattern = Value::new(interp, pattern);
+        let regexp = Regexp::try_from_ruby(&interp, &pattern)
+            .map(|data| data.borrow().clone())
+            .or_else(|_| {
+                String::try_from_mrb(&interp, pattern)
+                    .map_err(MrbError::ConvertToRust)
+                    .and_then(Regexp::new)
+            })?;
+        Ok(Self { regexp })
+    }
+}


### PR DESCRIPTION
This commit is in support of GH-85.

Add the following APIs:

- Regexp::escape
- Regexp::union
- Regexp#===
- Regexp#names
- Regexp#named_captures
- Regexp#options
- MatchData#length
- MatchData#named_captures
- String#scan
- String#-@

Added the constants Regexp::IGNORECASE, Regexp::EXTENDED, and
Regexp::MULTILINE.

Regexp#to_s and Regexp#inspect were erroneously implemented with the
same function. Regexp#to_s now supports roundtripping through
Regexp::compile.

Imported escape functionality from Rust regex crate.

Fix null pointer exception in String#=~ when Regexp does not match.

Reimplemented the following String APIs to work with Regexp patterns:

- String#split (TODO: does not handle blocks)
- String#sub
- String#gsub
- String#gsub!