### PR TITLE
Add strscan impl to stdlib

### DIFF
--- a/mruby/src/extn/core/regexp.rs
+++ b/mruby/src/extn/core/regexp.rs
@@ -813,14 +813,11 @@ impl MatchData {
                         } else {
                             Some(usize::try_from(index).expect("positive i64 must be usize"))
                         };
-                        Value::from_mrb(
-                            &interp,
-                            index
-                                .and_then(|index| captures.pos(index))
-                                .map(|pos| pos.0)
-                                .and_then(|pos| i64::try_from(pos).ok()),
-                        )
-                        .inner()
+                        let index = index
+                            .and_then(|index| captures.pos(index))
+                            .map(|pos| borrow.string[0..pos.0].chars().count())
+                            .and_then(|pos| i64::try_from(pos).ok());
+                        Value::from_mrb(&interp, index).inner()
                     }
                     None => interp.nil().inner(),
                 }
@@ -840,7 +837,7 @@ impl MatchData {
                             regexp
                                 .captures(borrow.string.as_str())
                                 .and_then(|captures| captures.pos(index))
-                                .map(|pos| pos.0)
+                                .map(|pos| borrow.string[0..pos.0].chars().count())
                                 .and_then(|pos| i64::try_from(pos).ok())
                         })
                     });
@@ -881,14 +878,11 @@ impl MatchData {
                         } else {
                             Some(usize::try_from(index).expect("positive i64 must be usize"))
                         };
-                        Value::from_mrb(
-                            &interp,
-                            index
-                                .and_then(|index| captures.pos(index))
-                                .map(|pos| pos.1)
-                                .and_then(|pos| i64::try_from(pos).ok()),
-                        )
-                        .inner()
+                        let index = index
+                            .and_then(|index| captures.pos(index))
+                            .map(|pos| borrow.string[0..pos.1].chars().count())
+                            .and_then(|pos| i64::try_from(pos).ok());
+                        Value::from_mrb(&interp, index).inner()
                     }
                     None => interp.nil().inner(),
                 }
@@ -908,7 +902,7 @@ impl MatchData {
                             regexp
                                 .captures(borrow.string.as_str())
                                 .and_then(|captures| captures.pos(index))
-                                .map(|pos| pos.1)
+                                .map(|pos| borrow.string[0..pos.1].chars().count())
                                 .and_then(|pos| i64::try_from(pos).ok())
                         })
                     });

--- a/mruby/src/extn/stdlib/mod.rs
+++ b/mruby/src/extn/stdlib/mod.rs
@@ -6,6 +6,7 @@ pub mod forwardable;
 pub mod monitor;
 pub mod ostruct;
 pub mod set;
+pub mod strscan;
 
 pub fn patch(interp: &Mrb) -> Result<(), MrbError> {
     delegate::init(interp)?;
@@ -13,5 +14,6 @@ pub fn patch(interp: &Mrb) -> Result<(), MrbError> {
     monitor::init(interp)?;
     ostruct::init(interp)?;
     set::init(interp)?;
+    strscan::init(interp)?;
     Ok(())
 }

--- a/mruby/src/extn/stdlib/strscan.rb
+++ b/mruby/src/extn/stdlib/strscan.rb
@@ -1,0 +1,239 @@
+# frozen_string_literal: true
+
+class ScanError < StandardError; end
+
+class StringScanner
+  def self.must_C_version # rubocop:disable Naming/MethodName
+    self
+  end
+
+  attr_accessor :string
+  attr_accessor :charpos
+
+  def initialize(string)
+    @string = string
+    @charpos = 0
+    @last_match = nil
+  end
+
+  def <<(str)
+    @string << str
+  end
+  alias concat <<
+
+  def [](group)
+    return nil if @last_match.nil?
+
+    @last_match[group]
+  end
+
+  def beginning_of_line?
+    return true if @pos.zero?
+
+    @string[@pos - 1] == "\n"
+  end
+  alias bol? beginning_of_line?
+
+  def captures
+    @last_match.captures
+  end
+
+  def check(pattern)
+    scan_full(pattern, false, true)
+  end
+
+  def check_until(pattern)
+    old = @charpos
+    result = scan_until(pattern)
+    @charpos = old
+    result
+  end
+
+  def eos?
+    @charpos == @string.length
+  end
+  alias empty? eos?
+
+  def exist?(pattern)
+    !@string[@charpos..-1].match(pattern).nil?
+  end
+
+  def get_byte # rubocop:disable Naming/AccessorMethodName
+    raise NotImplementedError, 'byte math'
+  end
+  alias getbyte get_byte
+
+  def getch
+    scan(/./)
+  end
+
+  def inspect
+    before = @string.reverse[@string.length - @charpos, 5].reverse
+    before = "\"...#{before}\"" unless before&.empty?
+    after = @string[@charpos, 5]
+    after = "\"#{after}...\"" unless after&.empty?
+    "#<#{self.class.name} #{charpos}/#{@string.length} #{before} @ #{after} >"
+  end
+
+  def match?(pattern)
+    match = pattern.match(@string[@pos..-1])
+    return nil if match.nil?
+    return nil if match.begin(0).positive?
+
+    @last_match = match
+    match.end(0) - match.end(0)
+  end
+
+  def matched
+    @last_match[0]
+  end
+
+  def matched?
+    !matched.nil?
+  end
+
+  def matched_size
+    !matched&.length
+  end
+
+  def peek(len)
+    @string[pos, len]
+  end
+  alias peep peek
+
+  def pos
+    @string[0..@charpos].bytes.length
+  end
+  alias pointer pos
+
+  def pos=(_pointer)
+    raise NotImplementedError, 'byte math'
+  end
+
+  def post_match
+    return nil if @last_match.nil?
+
+    @string[@charpos..-1]
+  end
+
+  def pre_match
+    return nil if @last_match.nil?
+
+    match_len = @last_match.end(0) - @last_match.begin(0)
+    @string[0..@charpos - 1 - match_len]
+  end
+
+  def reset
+    @charpos = 0
+  end
+
+  def rest
+    @string[@charpos..-1]
+  end
+
+  def rest?
+    !eos?
+  end
+
+  def rest_size
+    rest.size
+  end
+  alias restsize rest_size
+
+  def scan(pattern)
+    scan_full(pattern, true, true)
+  end
+
+  def scan_full(pattern, advance_pointer_p, return_string_p)
+    previous_charpos = @charpos
+    match = pattern.match(@string[@charpos..-1])
+    if match.nil? || match.begin(0).positive?
+      @last_match = nil
+      @previous_charpos = nil
+      return nil
+    end
+
+    @charpos += match.end(0) if advance_pointer_p
+    @previous_charpos = previous_charpos
+    @last_match = match
+
+    @string[previous_charpos, match.end(0)] if return_string_p
+  end
+
+  def scan_until(pattern)
+    previous_charpos = @charpos
+    match = pattern.match(@string[@charpos..-1])
+    return nil if match.nil?
+
+    @charpos += match.end(0)
+    @previous_charpos = previous_charpos
+    @last_match = match
+
+    @string[previous_charpos, match.end(0)]
+  end
+
+  def search_full(pattern, advance_pointer_p, return_string_p)
+    previous_charpos = @charpos
+    match = pattern.match(@string[@charpos..-1])
+    return nil if match.nil?
+
+    @charpos += match.end(0) if advance_pointer_p
+    @previous_charpos = previous_charpos
+
+    @string[previous_charpos, match.end(0)] if return_string_p
+  end
+
+  def size
+    @last_match.size
+  end
+
+  def skip(pattern)
+    previous_charpos = @charpos
+    match = pattern.match(@string[@charpos..-1])
+    if match.nil? || match.begin(0).positive?
+      @last_match = nil
+      @previous_charpos = nil
+      return nil
+    end
+
+    @charpos += match.end(0)
+    @previous_charpos = previous_charpos
+    @last_match = match
+    match.end(0)
+  end
+
+  def skip_until(pattern)
+    previous_charpos = @charpos
+    match = pattern.match(@string[@charpos..-1])
+    if match.nil?
+      @last_match = nil
+      @previous_charpos = nil
+      return nil
+    end
+
+    @charpos += match.end(0)
+    @previous_charpos = previous_charpos
+    @last_match = match
+    match.end(0)
+  end
+
+  def unscan
+    raise ScanError, 'unscan failed: previous match record not exist' if @previous_charpos.nil?
+
+    @charpos = @previous_charpos
+    @previous_charpos = nil
+    nil
+  end
+
+  def terminate
+    @pos = @string.length
+    @last_match = nil
+  end
+  alias clear terminate
+
+  def values_at(*args)
+    return nil if @last_match.nil?
+
+    args.map { |index| @last_match[index] }
+  end
+end

--- a/mruby/src/extn/stdlib/strscan.rs
+++ b/mruby/src/extn/stdlib/strscan.rs
@@ -1,0 +1,34 @@
+use crate::interpreter::Mrb;
+use crate::load::MrbLoadSources;
+use crate::MrbError;
+
+pub fn init(interp: &Mrb) -> Result<(), MrbError> {
+    interp
+        .borrow_mut()
+        .def_module::<StringScanner>("StringScanner", None);
+    interp.def_rb_source_file("strscan.rb", include_str!("strscan.rb"))?;
+    Ok(())
+}
+
+pub struct StringScanner;
+
+// StringScanner tests from Ruby stdlib docs
+// https://ruby-doc.org/stdlib-2.6.3/libdoc/strscan/rdoc/StringScanner.html
+#[cfg(test)]
+mod tests {
+    use crate::eval::MrbEval;
+    use crate::interpreter::Interpreter;
+    use crate::load::MrbLoadSources;
+
+    #[test]
+    fn strscan_spec() {
+        let interp = Interpreter::create().expect("mrb init");
+        interp
+            .def_rb_source_file("/src/test/strscan_test.rb", include_str!("strscan_test.rb"))
+            .unwrap();
+        interp.eval("require '/src/test/strscan_test.rb'").unwrap();
+        if let Err(err) = interp.eval("spec") {
+            panic!("{}", err);
+        }
+    }
+}

--- a/mruby/src/extn/stdlib/strscan_test.rb
+++ b/mruby/src/extn/stdlib/strscan_test.rb
@@ -1,0 +1,336 @@
+# frozen_string_literal: true
+
+require 'strscan'
+
+def spec
+  test_strscan
+  test_shift
+  test_index
+  test_beginning_of_line?
+  test_captures
+  test_charpos
+  test_check
+  test_check_until
+  test_eos
+  test_exist
+  test_get_byte
+  test_getch
+  test_inspect
+  test_match?
+  test_matched
+  test_matched?
+  test_matched_size
+  test_peek
+  test_pos_setter
+  test_pos
+  test_post_match
+  test_pre_match
+  test_rest
+  test_rest_size
+  test_scan
+  test_scan_until
+  test_size
+  test_skip
+  test_skip_until
+  test_unscan
+  test_values_at
+end
+
+def test_strscan
+  s = StringScanner.new('This is an example string')
+  raise if s.eos?
+  raise unless s.scan(/\w+/) == 'This'
+  raise unless s.scan(/\w+/).nil?
+  raise unless s.scan(/\s+/) == ' '
+  raise unless s.scan(/\s+/).nil?
+  raise unless s.scan(/\w+/) == 'is'
+  raise if s.eos?
+  raise unless s.scan(/\s+/) == ' '
+  raise unless s.scan(/\w+/) == 'an'
+  raise unless s.scan(/\s+/) == ' '
+  raise unless s.scan(/\w+/) == 'example'
+  raise unless s.scan(/\s+/) == ' '
+  raise unless s.scan(/\w+/) == 'string'
+  raise unless s.eos?
+  raise unless s.scan(/\s+/).nil?
+  raise unless s.scan(/\w+/).nil?
+end
+
+def test_shift
+  s = StringScanner.new('Fri Dec 12 1975 14:39')
+  s.scan(/Fri /)
+  s << ' +1000 GMT'
+  raise unless s.string == 'Fri Dec 12 1975 14:39 +1000 GMT'
+  raise unless s.scan(/Dec/) == 'Dec'
+end
+
+def test_index
+  s = StringScanner.new('Fri Dec 12 1975 14:39')
+  raise unless s.scan(/(\w+) (\w+) (\d+) /) == 'Fri Dec 12 '
+  raise unless s[0] == 'Fri Dec 12 '
+  raise unless s[1] == 'Fri'
+  raise unless s[2] == 'Dec'
+  raise unless s[3] == '12'
+  raise unless s.post_match == '1975 14:39'
+  raise unless s.pre_match == ''
+
+  s.reset
+  raise unless s.scan(/(?<wday>\w+) (?<month>\w+) (?<day>\d+) /) == 'Fri Dec 12 '
+  raise unless s[0] == 'Fri Dec 12 '
+  raise unless s[1] == 'Fri'
+  raise unless s[2] == 'Dec'
+  raise unless s[3] == '12'
+  raise unless s[:wday] == 'Fri'
+  raise unless s[:month] == 'Dec'
+  raise unless s[:day] == '12'
+  raise unless s.post_match == '1975 14:39'
+  raise unless s.pre_match == ''
+end
+
+def test_beginning_of_line?
+  s = StringScanner.new("test\ntest\n")
+  raise unless s.bol?
+
+  s.scan(/te/)
+  raise if s.bol?
+
+  s.scan(/st\n/)
+  raise unless s.bol?
+
+  s.terminate
+  raise unless s.bol?
+end
+
+def test_captures
+  s = StringScanner.new('Fri Dec 12 1975 14:39')
+  raise unless s.scan(/(\w+) (\w+) (\d+) /) == 'Fri Dec 12 '
+  raise unless s.captures == %w[Fri Dec 12]
+  raise unless s.scan(/(\w+) (\w+) (\d+) /).nil?
+  raise unless s.captures.nil?
+end
+
+def test_charpos
+  s = StringScanner.new('abcädeföghi')
+  raise unless s.charpos.zero?
+  raise unless s.scan_until(/ä/) == 'abcä'
+  raise unless s.pos == 5
+  raise unless s.charpos == 4
+end
+
+def test_check
+  s = StringScanner.new('Fri Dec 12 1975 14:39')
+  raise unless s.check(/Fri/) == 'Fri'
+  raise unless s.pos.zero?
+  raise unless s.matched == 'Fri'
+  raise unless s.check(/12/).nil?
+  raise unless s.matched.nil?
+end
+
+def test_check_until
+  s = StringScanner.new('Fri Dec 12 1975 14:39')
+  raise unless s.check_until(/12/) == 'Fri Dec 12'
+  raise unless s.pos.zero?
+  raise unless s.matched == '12'
+end
+
+def test_eos
+  s = StringScanner.new('test string')
+  raise if s.eos?
+
+  s.scan(/test/)
+  raise if s.eos?
+
+  s.terminate
+  raise unless s.eos?
+end
+
+def test_exist
+  s = StringScanner.new('test string')
+  raise unless s.exist?(/s/) == 3
+  raise unless s.scan(/test/) == 'test'
+  raise unless s.exist?(/s/) == 2
+  raise unless s.exist?(/e/).nil?
+end
+
+def test_get_byte
+  s = StringScanner.new('ab')
+  raise unless s.get_byte == 'a'
+  raise unless s.get_byte == 'b'
+  raise unless s.get_byte.nil?
+
+  # Encoding not supported by mruby
+  #
+  # $KCODE = 'EUC'
+  # s = StringScanner.new("\244\242")
+  # s.get_byte         # => "\244"
+  # s.get_byte         # => "\242"
+  # s.get_byte         # => nil
+end
+
+def test_getch
+  s = StringScanner.new('ab')
+  raise unless s.getch == 'a'
+  raise unless s.getch == 'b'
+  raise unless s.getch.nil?
+
+  # Encoding not supported by mruby
+  #
+  # $KCODE = 'EUC'
+  # s = StringScanner.new("\244\242")
+  # s.getch           # => "\244\242"   # Japanese hira-kana "A" in EUC-JP
+  # s.getch           # => nil
+end
+
+def test_inspect
+  s = StringScanner.new('Fri Dec 12 1975 14:39')
+  raise unless s.inspect == '#<StringScanner 0/21 @ "Fri D...">'
+  raise unless s.scan_until(/12/) == 'Fri Dec 12'
+  raise unless s.inspect == '#<StringScanner 10/21 "...ec 12" @ " 1975...">'
+  raise unless s.terminate.inspect == '#<StringScanner fin>'
+end
+
+def test_match?
+  s = StringScanner.new('test string')
+  raise unless s.match?(/\w+/) == 4
+  raise unless s.match?(/\w+/) == 4
+  raise unless s.match?(/\s+/).nil?
+end
+
+def test_matched
+  s = StringScanner.new('test string')
+  raise unless s.match?(/\w+/) == 4
+  raise unless s.matched == 'test'
+end
+
+def test_matched?
+  s = StringScanner.new('test string')
+  raise unless s.match?(/\w+/) == 4
+  raise unless s.matched?
+  raise unless s.match?(/\d+/).nil?
+  raise if s.matched?
+end
+
+def test_matched_size
+  s = StringScanner.new('test string')
+  raise unless s.check(/\w+/) == 'test'
+  raise unless s.matched_size == 4
+  raise unless s.check(/\d+/).nil?
+  raise unless s.matched_size.nil?
+end
+
+def test_peek
+  s = StringScanner.new('test string')
+  raise unless s.peek(7) == 'test st'
+  raise unless s.peek(7) == 'test st'
+end
+
+def test_pos_setter
+  s = StringScanner.new('test string')
+  raise unless (s.pos = 7) == 7
+  raise unless s.rest == 'ring'
+end
+
+def test_pos
+  s = StringScanner.new('test string')
+  raise unless s.pos.zero?
+  raise unless s.scan_until(/str/) == 'test str'
+  raise unless s.pos == 8
+
+  s.terminate
+  raise unless s.pos == 11
+end
+
+def test_post_match
+  s = StringScanner.new('test string')
+  raise unless s.scan(/\w+/) == 'test'
+  raise unless s.scan(/\s+/) == ' '
+  raise unless s.pre_match == 'test'
+  raise unless s.post_match == 'string'
+end
+
+def test_pre_match
+  s = StringScanner.new('test string')
+  raise unless s.scan(/\w+/) == 'test'
+  raise unless s.scan(/\s+/) == ' '
+  raise unless s.pre_match == 'test'
+  raise unless s.post_match == 'string'
+end
+
+def test_rest
+  s = StringScanner.new('test string')
+  raise unless s.rest == 'test string'
+  raise unless s.scan(/\w+/) == 'test'
+  raise unless s.scan(/\s+/) == ' '
+  raise unless s.rest == 'string'
+  raise unless s.scan(/\w+/) == 'string'
+  raise unless s.rest == ''
+end
+
+def test_rest_size
+  s = StringScanner.new('test string')
+  raise unless s.rest_size == s.rest.size
+  raise unless s.scan(/\w+/) == 'test'
+  raise unless s.rest_size == s.rest.size
+  raise unless s.scan(/\s+/) == ' '
+  raise unless s.rest_size == s.rest.size
+  raise unless s.scan(/\w+/) == 'string'
+  raise unless s.rest == ''
+end
+
+def test_scan
+  s = StringScanner.new('test string')
+  raise unless s.scan(/\w+/) == 'test'
+  raise unless s.scan(/\w+/).nil?
+  raise unless s.scan(/\s+/) == ' '
+  raise unless s.scan(/\w+/) == 'string'
+  raise unless s.scan(/./).nil?
+end
+
+def test_scan_until
+  s = StringScanner.new('Fri Dec 12 1975 14:39')
+  raise unless s.scan_until(/1/) == 'Fri Dec 1'
+  raise unless s.pre_match == 'Fri Dec '
+  raise unless s.scan_until(/XYZ/).nil?
+end
+
+def test_size
+  s = StringScanner.new('Fri Dec 12 1975 14:39')
+  raise unless s.scan(/(\w+) (\w+) (\d+) /) == 'Fri Dec 12 '
+  raise unless s.size == 4
+end
+
+def test_skip
+  s = StringScanner.new('test string')
+  raise unless s.skip(/\w+/) == 4
+  raise unless s.skip(/\w+/).nil?
+  raise unless s.skip(/\s+/) == 1
+  raise unless s.skip(/\w+/) == 6
+  raise unless s.skip(/./).nil?
+end
+
+def test_skip_until
+  s = StringScanner.new('Fri Dec 12 1975 14:39')
+  raise unless s.skip_until(/12/) == 10
+end
+
+def test_unscan
+  s = StringScanner.new('test string')
+  raise unless s.scan(/\w+/) == 'test'
+
+  s.unscan
+  raise unless s.scan(/../) == 'te'
+  raise unless s.scan(/\d/).nil?
+
+  s.unscan
+  raise 'Expected ScanError'
+rescue ScanError
+  nil
+end
+
+def test_values_at
+  s = StringScanner.new('Fri Dec 12 1975 14:39')
+  raise unless s.scan(/(\w+) (\w+) (\d+) /) == 'Fri Dec 12 '
+  raise unless s.values_at(0, -1, 5, 2) == ['Fri Dec 12 ', '12', nil, 'Dec']
+  raise unless s.scan(/(\w+) (\w+) (\d+) /).nil?
+  raise unless s.values_at(0, -1, 5, 2).nil?
+end


### PR DESCRIPTION
The YARV Ruby implementation is in C. This PR implements `StringScanner` in pure Ruby. Implementation is compliant with the examples in the Ruby 2.6.3 docs.

The implementation may behave poorly when using `SringScanner#get_byte` in conjunction with `StringScanner#scan` for non-ASCII `String`s. For now, the tests pass.

`StringScanner` required implementing other parts of core:

- `MatchData#size`
- `MatchData#captures`

Fix a bug in `Regexp` where `#begin` and `#end` were improperly using byte indexes. Ruby expects indexes to be char aligned. This adds a fix, but not test 😞 

This PR introduces a new way of testing Ruby stdlib packages. Rather than reimplement the examples from the docs in Rust, which is time consuming, tedious, and error prone, implement the tests in Ruby code and use `raise unless xxx == yyy`. `strscan_test.rb` is the first instance of this approach.