### PR TITLE
Add a full implementation of YARV String in Ruby and Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,7 +742,7 @@ dependencies = [
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "mruby-sys 2.0.1-sys.4.c078758",
+ "mruby-sys 2.0.1-5",
  "mruby-vfs 0.5.0-alpha",
  "onig 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "path_abs 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "mruby-sys"
-version = "2.0.1-sys.4.c078758"
+version = "2.0.1-5"
 dependencies = [
  "bindgen 0.49.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,7 +74,7 @@ name = "base64"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -83,7 +83,7 @@ name = "base64"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "byteorder"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -132,7 +132,7 @@ name = "bytes"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -239,7 +239,7 @@ name = "criterion-plot"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -470,7 +470,7 @@ name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -483,7 +483,7 @@ name = "h2"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -739,10 +739,11 @@ dependencies = [
 name = "mruby"
 version = "0.1.0"
 dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "mruby-sys 2.0.1-5",
+ "mruby-sys 2.0.1-6",
  "mruby-vfs 0.5.0-alpha",
  "onig 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "path_abs 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -771,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "mruby-sys"
-version = "2.0.1-5"
+version = "2.0.1-6"
 dependencies = [
  "bindgen 0.49.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1096,7 +1097,7 @@ name = "rand_xoshiro"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1913,7 +1914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bindgen 0.49.2 (registry+https://github.com/rust-lang/crates.io-index)" = "846a1fba6535362a01487ef6b10f0275faa12e5c5d835c5c1c627aabc46ccbd6"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
-"checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
+"checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 "checksum cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "926013f2860c46252efceabb19f4a6b308197505082c609025aa6706c011d427"
 "checksum cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "39f75544d7bbaf57560d2168f28fd649ff9c76153874db88bdbdfd839b1a7e7d"

--- a/mruby-sys/Cargo.toml
+++ b/mruby-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mruby-sys"
-version = "2.0.1-5"
+version = "2.0.1-6"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 links = "mruby"

--- a/mruby-sys/Cargo.toml
+++ b/mruby-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mruby-sys"
-version = "2.0.1-sys.4.c078758"
+version = "2.0.1-5"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 links = "mruby"

--- a/mruby-sys/sys.gembox
+++ b/mruby-sys/sys.gembox
@@ -44,9 +44,6 @@ MRuby::GemBox.new do |conf|
   # Use Enumerable module extension
   conf.gem core: 'mruby-enum-ext'
 
-  # Use String class extension
-  conf.gem core: 'mruby-string-ext'
-
   # Use Numeric class extension
   conf.gem core: 'mruby-numeric-ext'
 

--- a/mruby/Cargo.toml
+++ b/mruby/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 doctest = false
 
 [dependencies]
+byteorder = "1.3.2"
 log = "0.4.6"
 onig = "4.3.2"
 path_abs = "0.4.1"

--- a/mruby/src/extn/core/string.rb
+++ b/mruby/src/extn/core/string.rb
@@ -1,81 +1,229 @@
 # frozen_string_literal: true
 
 class String
-  alias __old_idx []
+  def self.try_convert(obj = nil)
+    raise ArgumentError if obj.nil?
 
-  # https://ruby-doc.org/core-2.6.3/String.html#method-i-5B-5D
-  def [](*args)
-    if (regexp = args[0]).is_a?(Regexp)
-      capture = args[1] || 0
-      return regexp.match(self)&.[](capture)
-    end
-    __old_idx(*args)
+    obj.to_str
+  rescue StandardError
+    nil
   end
 
-  # https://ruby-doc.org/core-2.6.3/String.html#method-i-3D-7E
+  def +@
+    return dup if frozen?
+
+    self
+  end
+
+  def -@
+    return self if frozen?
+
+    dup.freeze
+  end
+
+  def <<(obj)
+    obj = obj.chr if obj.is_a?(Integer)
+
+    self[0..-1] = "#{self}#{obj}"
+    self
+  end
+  alias concat <<
+
   def =~(other)
     return other.match(self)&.begin(0) if other.is_a?(Regexp)
+    raise TypeError, "type mismatch: #{other.class} given" if other.is_a?(String)
     return other =~ self if other.respond_to?(:=~)
 
     nil
   end
 
-  # TODO: handle block
-  def split(pattern, limit = nil)
-    if pattern == ''
-      parts = []
-      length.times do |i|
-        parts << self[i]
-      end
-      return parts
-    end
+  alias __old_element_reference []
+  def [](*args)
+    return __old_element_reference(*args) unless args[0].is_a?(Regexp)
 
-    pattern = Regexp.compile(Regexp.escape(pattern)) if pattern.is_a?(String)
-
-    parts = []
-    remainder = self
-    match = pattern.match(remainder)
-    until match.nil? || (limit && parts.length >= limit)
-      parts <<
-        if match.begin(0).positive?
-          remainder[0..match.begin(0) - 1]
-        else
-          ''
-        end
-      remainder = remainder[match.end(0)..-1]
-      remainder = remainder[1..-1] if match.begin(0) == match.end(0)
-      match = nil
-      pattern.match(remainder) unless remainder.nil?
-    end
-    return parts if remainder.nil? || remainder.empty?
-
-    parts << remainder if limit.nil? || parts.length < limit
-    parts
+    regexp = args[0]
+    capture = args.fetch(1, 0)
+    regexp.match(self)&.[](capture)
   end
 
-  def sub(pattern, replacement = nil)
-    return to_enum(:sub, pattern) if replacement.nil? && !block_given?
+  alias __old_element_assignment []=
+  def []=(*args)
+    return __old_element_assignment(*args) unless args[0].is_a?(Regexp) # rubocop:disable Lint/ReturnInVoidContext
 
-    replace =
-      if replacement.nil?
-        ->(old) { (yield old).to_s }
-      elsif replacement.is_a?(Hash)
-        ->(old) { replacement[old].to_s }
-      else
-        ->(_old) { replacement.to_s }
+    *args, replace = *args
+    regexp = args[0]
+    capture = args.fetch(1, 0)
+    match = regexp.match(self)
+    return if match.nil?
+
+    self[match.begin(capture)...match.end(capture)] = replace
+  end
+
+  def ascii_only?
+    bytes.length == length
+  end
+
+  def b
+    # mruby has no Encoding, so there is no difference between an ASCII_8BIT
+    # String and a UTF-8 String.
+    dup
+  end
+
+  def byteslice(*args)
+    if args[0].is_a?(Integer)
+      position, len = *args
+      len = 1 if len.nil?
+      position = length + position if position.negative?
+
+      slice = bytes[position...position + len]
+      slice.pack('c*')
+    elsif args.length == 1 && args[0].is_a?(Range)
+      range, = *args
+      position = range.begin
+      len = range.size
+
+      slice = bytes[position...position + len]
+      slice.pack('c*')
+    else
+      raise ArgumentError
+    end
+  end
+
+  def casecmp(str)
+    return nil unless String.try_convert(str)
+
+    downcase <=> str.downcase
+  end
+
+  def casecmp?(str)
+    casecmp(str)&.zero? == true
+  end
+
+  def center(width, padstr = ' ')
+    return self if length >= width
+
+    left_pad = (width - length) / 2
+    left_pad = (padstr * left_pad)[0...left_pad]
+    right_pad = (width - length) / 2 + (width - length) % 2
+    right_pad = (padstr * right_pad)[0...right_pad]
+    "#{left_pad}#{self}#{right_pad}"
+  end
+
+  def chars
+    if block_given?
+      split('').each do |char|
+        yield char
       end
-    pattern = Regexp.compile(Regexp.escape(pattern)) if pattern.is_a?(String)
-    match = pattern.match(self)
-    return dup if match.nil?
+      self
+    else
+      split('')
+    end
+  end
 
-    buf = ''
-    remainder = self
-    buf << remainder[0..match.begin(0) - 1] if match.begin(0).positive?
-    buf << replace.call(match[0])
-    remainder = remainder[match.end(0)..-1]
-    remainder = remainder[1..-1] if match.begin(0) == match.end(0)
-    buf << remainder
-    buf
+  def chr
+    dup[0]
+  end
+
+  def clear
+    self[0..-1] = ''
+  end
+
+  def codepoints
+    each_codepoint.to_a
+  end
+
+  def count
+    raise NotImplementedError
+  end
+
+  def crypt(_salt)
+    raise NotImplementedError
+  end
+
+  def delete(*_args)
+    raise NotImplementedError
+  end
+
+  def delete!(*args)
+    replaced = delete(*args)
+    self[0..-1] = replaced
+  end
+
+  def delete_prefix(prefix)
+    self[0...prefix.length] = '' if start_with?(prefix)
+
+    self
+  end
+
+  def delete_prefix!(prefix)
+    replaced = delete_prefix(prefix)
+    self[0..-1] = replaced unless self == replaced
+  end
+
+  def delete_suffix(suffix)
+    self[-suffix.length..-1] = '' if end_with?(suffix)
+
+    self
+  end
+
+  def delete_suffix!(prefix)
+    replaced = delete_suffix(prefix)
+    self[0..-1] = replaced unless self == replaced
+  end
+
+  def dump
+    raise NotImplementedError
+  end
+
+  def each_codepoint
+    return to_enum(:each_codepoint) unless block_given?
+
+    split('').each do |c|
+      yield c.ord
+    end
+  end
+
+  def each_grapheme_cluster
+    raise NotImplementedError
+  end
+
+  def encode(*_args)
+    # mruby does not support encoding, all Strings are UTF-8. This method is a
+    # NOOP and is here for compatibility.
+    dup
+  end
+
+  def encode!(*_args)
+    # mruby does not support encoding, all Strings are UTF-8. This method is a
+    # NOOP and is here for compatibility.
+    self
+  end
+
+  def encoding
+    # mruby does not support encoding, all Strings are UTF-8. This method is a
+    # NOOP and is here for compatibility.
+    nil
+  end
+
+  def end_with?(*suffixes)
+    suffixes.each do |suffix|
+      return true if self[-suffix.length..-1] == suffix
+    end
+    false
+  end
+
+  def force_encoding(*_args)
+    # mruby does not support encoding, all Strings are UTF-8. This method is a
+    # NOOP and is here for compatibility.
+    self
+  end
+
+  def getbyte(index)
+    bytes[index]
+  end
+
+  def grapheme_clusters
+    each_grapheme_cluster.to_a
   end
 
   # TODO: Support backrefs
@@ -98,7 +246,7 @@ class String
     return dup if match.nil?
 
     buf = ''
-    remainder = self
+    remainder = dup
     until match.nil? || remainder.empty?
       buf << remainder[0..match.begin(0) - 1] if match.begin(0).positive?
       buf << replace.call(match[0])
@@ -111,6 +259,327 @@ class String
 
   def gsub!(pattern, replacement = nil, &blk)
     replaced = gsub(pattern, replacement, &blk)
+    self[0..-1] = replaced unless self == replaced
+  end
+
+  def hex
+    raise NotImplementedError
+  end
+
+  def insert(index, other_str)
+    return self << other_str if index == -1
+
+    index += 1 if index.negative?
+
+    self[index, 0] = other_str
+    self
+  end
+
+  def lines(*args)
+    each_line(*args).to_a
+  end
+
+  def ljust(integer, padstr = ' ')
+    raise ArgumentError, 'zero width padding' if padstr == ''
+
+    return self if integer <= length
+
+    pad_repetitions = (integer / padstr.length).ceil
+    padding = (padstr * pad_repetitions)[0...(integer - length)]
+    "#{self}#{padding}"
+  end
+
+  def lstrip
+    strip_pointer = 0
+    string_end = length - 1
+    strip_pointer += 1 while strip_pointer <= string_end && " \f\n\r\t\v".include?(self[strip_pointer])
+    return '' if string_end.zero?
+
+    dup[strip_pointer..string_end]
+  end
+
+  def lstrip!
+    replaced = lstrip
+    self[0..-1] = replaced unless self == replaced
+  end
+
+  def match(pattern, pos = 0)
+    pattern = Regexp.compile(Regexp.escape(pattern)) if pattern.is_a?(String)
+
+    pattern.match(self[pos..-1])
+  end
+
+  def match?(pattern, pos = 0)
+    pattern = Regexp.compile(Regexp.escape(pattern)) if pattern.is_a?(String)
+
+    # TODO: Don't set $~ and other Regexp globals
+    pattern.match?(self[pos..-1])
+  end
+
+  def next
+    raise NotImplementedError
+  end
+  alias succ next
+
+  def next!
+    raise NotImplementedError
+  end
+  alias succ! next!
+
+  def oct
+    raise NotImplementedError
+  end
+
+  def partition(pattern)
+    pattern = Regexp.compile(Regexp.escape(pattern)) if pattern.is_a?(String)
+
+    match = pattern.match(self)
+    [match.pre_match, match[0], match.post_match]
+  end
+
+  def prepend(*args)
+    insert(0, args.join(''))
+  end
+
+  def rjust(integer, padstr = ' ')
+    raise ArgumentError, 'zero width padding' if padstr == ''
+
+    return self if integer <= length
+
+    pad_repetitions = (integer / padstr.length).ceil
+    padding = (padstr * pad_repetitions)[0...(integer - length)]
+    "#{padding}#{self}"
+  end
+
+  def rpartition(pattern)
+    pattern = Regexp.compile(Regexp.escape(pattern)) if pattern.is_a?(String)
+
+    _ = pattern
+    raise NotImplementedError
+  end
+
+  def rstrip
+    strip_pointer = length - 1
+    string_start = 0
+    strip_pointer -= 1 while strip_pointer >= string_start && " \f\n\r\t\v".include?(self[strip_pointer])
+    return '' if strip_pointer.zero?
+
+    dup[string_start..strip_pointer]
+  end
+
+  def rstrip!
+    replaced = rstrip
+    self[0..-1] = replaced unless self == replaced
+  end
+
+  def scan(pattern)
+    pattern = Regexp.compile(Regexp.escape(pattern)) if pattern.is_a?(String)
+    raise TypeError, "wrong argument type #{pattern.inspect} (expected Regexp)" if pattern.nil?
+    raise TypeError, "wrong argument type #{pattern.class.name} (expected Regexp)" unless pattern.is_a?(Regexp)
+
+    remainder = dup
+    match = pattern.match(remainder)
+    collect = []
+    until remainder.empty? || match.nil?
+      collect <<
+        if block_given?
+          yield match[0]
+        else
+          match[0]
+        end
+      remainder = remainder[match.end(0)..-1]
+      remainder = remainder[1..-1] if match.begin(0) == match.end(0)
+      match = nil
+      match = pattern.match(remainder) unless remainder.nil?
+    end
+    collect
+  end
+
+  def scrub
+    # TODO: This is a stub. Implement scrub correctly.
+    self
+  end
+
+  def scrub!
+    # TODO: This is a stub. Implement scrub! correctly.
+    self
+  end
+
+  def setbyte(index, integer)
+    slice = bytes
+    slice[index] = integer
+    self[0..-1] = slice.pack('c*')
+  end
+
+  def split(pattern, limit = nil)
+    parts = []
+    return parts if self == ''
+
+    pattern = Regexp.compile(Regexp.escape(pattern)) if pattern.is_a?(String)
+    return length.times.map { |i| self[i].dup } if pattern.to_s == ''
+
+    remainder = dup
+    match = pattern.match(remainder)
+    if limit&.positive?
+      until match.nil? || remainder.nil? || parts.length >= limit - 1
+        parts << remainder[0...match.begin(0)]
+        remainder = remainder[match.end(0)..-1]
+        remainder = remainder[1..-1] if match.begin(0) == match.end(0)
+        match = nil
+        match = pattern.match(remainder) unless remainder.nil?
+      end
+      parts << remainder unless remainder.nil?
+    else
+      until match.nil? || remainder.nil?
+        parts << remainder[0...match.begin(0)]
+        remainder = remainder[match.end(0)..-1]
+        remainder = remainder[1..-1] if match.begin(0) == match.end(0)
+        match = nil
+        match = pattern.match(remainder) unless remainder.nil?
+      end
+      parts << remainder unless remainder.nil?
+      if limit&.negative? && -limit > parts.length
+        (-limit - parts.length).times do
+          parts << ''
+        end
+      end
+    end
+    parts.each { |part| yield part } if block_given?
+
+    parts
+  end
+
+  def squeeze(*_args)
+    raise NotImplementedError
+  end
+
+  def start_with?(*prefixes)
+    prefixes.each do |prefix|
+      return true if self[0...prefix.length] == prefix
+    end
+    false
+  end
+
+  def strip
+    result = lstrip
+    result = self if result.nil?
+    result.rstrip
+  end
+
+  def strip!
+    replaced = strip
+    self[0..-1] = replaced unless self == replaced
+  end
+
+  def sub(pattern, replacement = nil)
+    return to_enum(:sub, pattern) if replacement.nil? && !block_given?
+
+    replace =
+      if replacement.nil?
+        ->(old) { (yield old).to_s }
+      elsif replacement.is_a?(Hash)
+        ->(old) { replacement[old].to_s }
+      else
+        ->(_old) { replacement.to_s }
+      end
+    pattern = Regexp.compile(Regexp.escape(pattern)) if pattern.is_a?(String)
+    match = pattern.match(self)
+    return dup if match.nil?
+
+    buf = ''
+    remainder = dup
+    buf << remainder[0..match.begin(0) - 1] if match.begin(0).positive?
+    buf << replace.call(match[0])
+    remainder = remainder[match.end(0)..-1]
+    remainder = remainder[1..-1] if match.begin(0) == match.end(0)
+    buf << remainder
+    buf
+  end
+
+  def sub!(pattern, replacement = nil, &blk)
+    replaced = sub(pattern, replacement, &blk)
     self[0..-1] = replaced
+  end
+
+  def sum
+    raise NotImplementedError
+  end
+
+  def swapcase(*_args)
+    raise NotImplementedError
+  end
+
+  def swapcase!(*_args)
+    raise NotImplementedError
+  end
+
+  def to_c
+    raise NotImplementedError
+  end
+
+  def to_r
+    raise NotImplementedError
+  end
+
+  def to_str
+    dup
+  end
+
+  def tr(from_str, to_str)
+    # TODO: Support character ranges c1-c2
+    # TODO: Support backslash escapes
+    to_str = to_str.rjust(from_str.length, to_str[-1])
+
+    gsub(Regexp.compile("[#{from_str}]")) do |char|
+      to_str[from_str.index(char)]
+    end
+  end
+
+  def tr!(from_str, to_str)
+    # TODO: Support character ranges c1-c2
+    # TODO: Support backslash escapes
+    to_str = to_str.rjust(from_str.length, to_str[-1])
+
+    gsub!(Regexp.compile("[#{from_str}]")) do |char|
+      to_str[from_str.index(char)]
+    end
+  end
+
+  def tr_s(_from_str, _to_str)
+    # TODO: Support character ranges c1-c2
+    # TODO: Support backslash escapes
+    raise NotImplementedError
+  end
+
+  def tr_s!(_from_str, _to_str)
+    # TODO: Support character ranges c1-c2
+    # TODO: Support backslash escapes
+    raise NotImplementedError
+  end
+
+  def undump
+    raise NotImplementedError
+  end
+
+  def unicode_normalize(_form = :nfc)
+    raise NotImplementedError
+  end
+
+  def unicode_normalize!(_form = :nfc)
+    raise NotImplementedError
+  end
+
+  def unicode_normalized?(_form = :nfc)
+    raise NotImplementedError
+  end
+
+  def upto(_other_str, _exclusive = false)
+    raise NotImplementedError
+  end
+
+  def valid_encoding
+    # mruby does not support encoding, all Strings are UTF-8. This method is a
+    # NOOP and is here for compatibility.
+    true
   end
 end

--- a/mruby/src/extn/core/string.rs
+++ b/mruby/src/extn/core/string.rs
@@ -12,6 +12,9 @@ use crate::MrbError;
 use log::trace;
 
 pub fn patch(interp: &Mrb) -> Result<(), MrbError> {
+    if interp.borrow().class_spec::<RString>().is_some() {
+        return Ok(());
+    }
     let string = interp
         .borrow_mut()
         .def_class::<RString>("String", None, None);

--- a/mruby/src/extn/core/string/args.rs
+++ b/mruby/src/extn/core/string/args.rs
@@ -7,28 +7,3 @@ use crate::interpreter::Mrb;
 use crate::sys;
 use crate::value::Value;
 use crate::MrbError;
-
-pub struct Scan {
-    pub regexp: Regexp,
-}
-
-impl Scan {
-    pub unsafe fn extract(interp: &Mrb) -> Result<Self, MrbError> {
-        let pattern = mem::uninitialized::<sys::mrb_value>();
-        let mut argspec = vec![];
-        argspec
-            .write_all(sys::specifiers::OBJECT.as_bytes())
-            .map_err(|_| MrbError::ArgSpec)?;
-        argspec.write_all(b"\0").map_err(|_| MrbError::ArgSpec)?;
-        sys::mrb_get_args(interp.borrow().mrb, argspec.as_ptr() as *const i8, &pattern);
-        let pattern = Value::new(interp, pattern);
-        let regexp = Regexp::try_from_ruby(&interp, &pattern)
-            .map(|data| data.borrow().clone())
-            .or_else(|_| {
-                String::try_from_mrb(&interp, pattern)
-                    .map_err(MrbError::ConvertToRust)
-                    .and_then(Regexp::new)
-            })?;
-        Ok(Self { regexp })
-    }
-}


### PR DESCRIPTION
We kept having to reimplement bits of the mruby-string-ext gem because of `Regexp`, so stop depending on it.