### PR TITLE
Add uri impl to stdlib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,7 +743,7 @@ dependencies = [
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "mruby-sys 2.0.1-6",
+ "mruby-sys 2.0.1-7",
  "mruby-vfs 0.5.0-alpha",
  "onig 4.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "path_abs 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "mruby-sys"
-version = "2.0.1-6"
+version = "2.0.1-7"
 dependencies = [
  "bindgen 0.49.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/mruby-sys/Cargo.toml
+++ b/mruby-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mruby-sys"
-version = "2.0.1-6"
+version = "2.0.1-7"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 links = "mruby"

--- a/mruby-sys/sys.gembox
+++ b/mruby-sys/sys.gembox
@@ -7,6 +7,9 @@ MRuby::GemBox.new do |conf|
   # eval and instance eval
   conf.gem core: 'mruby-eval'
 
+  # method metaprogramming
+  conf.gem core: 'mruby-method'
+
   # mrb_protect
   conf.gem core: 'mruby-error'
 

--- a/mruby/src/extn/.rubocop.yml
+++ b/mruby/src/extn/.rubocop.yml
@@ -3,6 +3,8 @@ AllCops:
   DisplayCopNames: true
   Exclude:
     - stdlib/spec/**/*.rb
+    - stdlib/uri.rb
+    - stdlib/uri/*.rb
     - test/mspec.rb
     - test/mspec/**/*.rb
 Metrics:

--- a/mruby/src/extn/core/array.rb
+++ b/mruby/src/extn/core/array.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Array
+  def to_ary
+    self
+  end
+end

--- a/mruby/src/extn/core/array.rs
+++ b/mruby/src/extn/core/array.rs
@@ -1,0 +1,11 @@
+use crate::eval::MrbEval;
+use crate::interpreter::Mrb;
+use crate::MrbError;
+
+pub fn patch(interp: &Mrb) -> Result<(), MrbError> {
+    interp.borrow_mut().def_class::<Array>("Array", None, None);
+    interp.eval(include_str!("array.rb"))?;
+    Ok(())
+}
+
+pub struct Array;

--- a/mruby/src/extn/core/mod.rs
+++ b/mruby/src/extn/core/mod.rs
@@ -1,6 +1,7 @@
 use crate::interpreter::Mrb;
 use crate::MrbError;
 
+pub mod array;
 pub mod env;
 pub mod error;
 pub mod kernel;
@@ -10,6 +11,7 @@ pub mod string;
 pub mod thread;
 
 pub fn patch(interp: &Mrb) -> Result<(), MrbError> {
+    array::patch(interp)?;
     env::patch(interp)?;
     error::patch(interp)?;
     kernel::patch(interp)?;

--- a/mruby/src/extn/core/regexp.rs
+++ b/mruby/src/extn/core/regexp.rs
@@ -444,7 +444,7 @@ impl Regexp {
                 if arg.ruby_type() == Ruby::Array {
                     unwrap_or_raise!(interp, arg.try_into::<Vec<Value>>(), interp.nil().inner())
                 } else {
-                    args.rest
+                    vec![arg]
                 }
             } else {
                 args.rest
@@ -452,18 +452,20 @@ impl Regexp {
             let mut raw_patterns = vec![];
             for pattern in patterns {
                 if pattern.ruby_type() == Ruby::String {
-                    raw_patterns.push(unwrap_or_raise!(
+                    let pattern = unwrap_or_raise!(
                         interp,
                         pattern.try_into::<String>(),
                         interp.nil().inner()
-                    ));
+                    );
+                    raw_patterns.push(syntax::escape(pattern.as_str()));
                 } else {
                     let regexp = unwrap_or_raise!(
                         interp,
                         Self::try_from_ruby(&interp, &pattern),
                         interp.nil().inner()
                     );
-                    raw_patterns.push(regexp.borrow().pattern.clone());
+                    let pattern = syntax::escape(regexp.borrow().pattern.as_str());
+                    raw_patterns.push(pattern);
                 }
             }
             raw_patterns.join("|")

--- a/mruby/src/extn/core/regexp/syntax.rs
+++ b/mruby/src/extn/core/regexp/syntax.rs
@@ -39,8 +39,8 @@ pub fn escape_into(text: &str, buf: &mut String) {
 /// `false` is fixed and won't change in a semver compatible release.
 pub fn is_meta_character(c: char) -> bool {
     match c {
-        '\\' | '.' | '+' | '*' | '?' | '(' | ')' | '|' | '[' | ']' | '{' | '}' | '^' | '$'
-        | '#' | '&' | '-' | '~' => true,
+        '\\' | '/' | '.' | '+' | '*' | '?' | '(' | ')' | '|' | '[' | ']' | '{' | '}' | '^'
+        | '$' | '#' | '&' | '-' | '~' => true,
         _ => false,
     }
 }

--- a/mruby/src/extn/core/string.rb
+++ b/mruby/src/extn/core/string.rb
@@ -1,5 +1,45 @@
 # frozen_string_literal: true
 
+class Encoding
+  ASCII_8BIT = new('ASCII-8BIT')
+  US_ASCII = new('US-ASCII')
+  UTF_8 = new('UTF-8')
+
+  def self.find(string)
+    new(string)
+  end
+
+  attr_reader :name
+
+  def initialize(name)
+    @name = name
+  end
+
+  def ascii_compatible?
+    true
+  end
+
+  def dummy?
+    true
+  end
+
+  def inspect
+    "#<#{self.class}:#{@name}"
+  end
+
+  def names
+    [name]
+  end
+
+  def replicate(name)
+    new(name)
+  end
+
+  def to_s
+    name
+  end
+end
+
 class String
   def self.try_convert(obj = nil)
     raise ArgumentError if obj.nil?

--- a/mruby/src/extn/core/string.rb
+++ b/mruby/src/extn/core/string.rb
@@ -180,13 +180,13 @@ class String
     raise NotImplementedError
   end
 
-  def delete(*_args)
-    raise NotImplementedError
+  def delete(*args)
+    args.inject(self) { |string, pattern| string.tr(pattern, '') }
   end
 
   def delete!(*args)
     replaced = delete(*args)
-    self[0..-1] = replaced
+    self[0..-1] = replaced unless self == replaced
   end
 
   def delete_prefix(prefix)
@@ -300,6 +300,7 @@ class String
   def gsub!(pattern, replacement = nil, &blk)
     replaced = gsub(pattern, replacement, &blk)
     self[0..-1] = replaced unless self == replaced
+    self
   end
 
   def hex
@@ -538,7 +539,7 @@ class String
 
   def sub!(pattern, replacement = nil, &blk)
     replaced = sub(pattern, replacement, &blk)
-    self[0..-1] = replaced
+    self[0..-1] = replaced unless self == replaced
   end
 
   def sum
@@ -568,21 +569,16 @@ class String
   def tr(from_str, to_str)
     # TODO: Support character ranges c1-c2
     # TODO: Support backslash escapes
-    to_str = to_str.rjust(from_str.length, to_str[-1])
+    to_str = to_str.rjust(from_str.length, to_str[-1]) if to_str.length.positive?
 
     gsub(Regexp.compile("[#{from_str}]")) do |char|
-      to_str[from_str.index(char)]
+      to_str[from_str.index(char)] || ''
     end
   end
 
   def tr!(from_str, to_str)
-    # TODO: Support character ranges c1-c2
-    # TODO: Support backslash escapes
-    to_str = to_str.rjust(from_str.length, to_str[-1])
-
-    gsub!(Regexp.compile("[#{from_str}]")) do |char|
-      to_str[from_str.index(char)]
-    end
+    replaced = tr(from_str, to_str)
+    self[0..-1] = replaced unless self == replaced
   end
 
   def tr_s(_from_str, _to_str)

--- a/mruby/src/extn/core/string.rb
+++ b/mruby/src/extn/core/string.rb
@@ -85,6 +85,7 @@ class String
     capture = args.fetch(1, 0)
     regexp.match(self)&.[](capture)
   end
+  alias slice []
 
   alias __old_element_assignment []=
   def []=(*args)

--- a/mruby/src/extn/stdlib/mod.rs
+++ b/mruby/src/extn/stdlib/mod.rs
@@ -7,6 +7,7 @@ pub mod monitor;
 pub mod ostruct;
 pub mod set;
 pub mod strscan;
+pub mod uri;
 
 pub fn patch(interp: &Mrb) -> Result<(), MrbError> {
     delegate::init(interp)?;
@@ -15,5 +16,6 @@ pub fn patch(interp: &Mrb) -> Result<(), MrbError> {
     ostruct::init(interp)?;
     set::init(interp)?;
     strscan::init(interp)?;
+    uri::init(interp)?;
     Ok(())
 }

--- a/mruby/src/extn/stdlib/spec/uri/decode_www_form_component_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/decode_www_form_component_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../spec_helper'
+require 'uri'
+
+describe "URI.decode_www_form_component" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/decode_www_form_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/decode_www_form_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../spec_helper'
+require 'uri'
+
+describe "URI.decode_www_form" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/encode_www_form_component_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/encode_www_form_component_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../spec_helper'
+require 'uri'
+
+describe "URI.encode_www_form_component" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/encode_www_form_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/encode_www_form_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../spec_helper'
+require 'uri'
+
+describe "URI.encode_www_form" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/eql_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/eql_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/normalization'
+require_relative 'shared/eql'
+require 'uri'
+
+describe "URI#eql?" do
+  it_behaves_like :uri_eql, :eql?
+
+  it_behaves_like :uri_eql_against_other_types, :eql?
+end

--- a/mruby/src/extn/stdlib/spec/uri/equality_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/equality_spec.rb
@@ -1,0 +1,46 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/normalization'
+require_relative 'shared/eql'
+require 'uri'
+
+describe "URI#==" do
+  it "ignores capitalization of host names" do
+    URI("http://exAMPLE.cOm").should == URI("http://example.com")
+  end
+
+  it "ignores capitalization of scheme" do
+    URI("hTTp://example.com").should == URI("http://example.com")
+  end
+
+  it "treats a blank path and a path of '/' as the same" do
+    URI("http://example.com").should == URI("http://example.com/")
+  end
+
+  it "is case sensitive in all components of the URI but the host and scheme" do
+    URI("http://example.com/paTH").should_not == URI("http://example.com/path")
+    URI("http://uSer@example.com").should_not == URI("http://user@example.com")
+    URI("http://example.com/path?quERy").should_not == URI("http://example.com/path?query")
+    URI("http://example.com/#fragMENT").should_not == URI("http://example.com/#fragment")
+  end
+
+  it "differentiates based on port number" do
+    URI("http://example.com:8080").should_not == URI("http://example.com")
+  end
+
+  # Note: The previous tests will be included in following ones
+
+  it_behaves_like :uri_eql, :==
+
+  it_behaves_like :uri_eql_against_other_types, :==
+
+  quarantine! do # Quarantined until redmine:2542 is accepted
+    it "returns true only if the normalized forms are equivalent" do
+      URISpec::NORMALIZED_FORMS.each do |form|
+        normal_uri = URI(form[:normalized])
+        form[:equivalent].each do |same|
+          URI(same).should == normal_uri
+        end
+      end
+    end
+  end
+end

--- a/mruby/src/extn/stdlib/spec/uri/escape/decode_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/escape/decode_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Escape#decode" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/escape/encode_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/escape/encode_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Escape#encode" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/escape/escape_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/escape/escape_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Escape#escape" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/escape/unescape_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/escape/unescape_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Escape#unescape" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/extract_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/extract_spec.rb
@@ -1,0 +1,86 @@
+require_relative '../../spec_helper'
+require 'uri'
+
+describe "URI.extract" do
+  it "behaves according to its documentation" do
+    URI.extract("text here http://foo.example.org/bla and here mailto:test@example.com and here also.").should == ["http://foo.example.org/bla", "mailto:test@example.com"]
+  end
+
+  it "treats contiguous URIs as a single URI" do
+    URI.extract('http://example.jphttp://example.jp').should == ['http://example.jphttp://example.jp']
+  end
+
+  it "treats pretty much anything with a colon as a URI" do
+    URI.extract('From: XXX [mailto:xxx@xxx.xxx.xxx]').should == ['From:', 'mailto:xxx@xxx.xxx.xxx]']
+  end
+
+  it "wraps a URI string in an array" do
+    URI.extract("http://github.com/brixen/rubyspec/tree/master").should == ["http://github.com/brixen/rubyspec/tree/master"]
+  end
+
+  it "pulls a variety of protocol URIs from a string" do
+    URI.extract("this is a string, it has http://rubini.us/ in it").should == ["http://rubini.us/"]
+    URI.extract("mailto:spambait@example.com").should == ["mailto:spambait@example.com"]
+    URI.extract("ftp://ruby-lang.org/").should == ["ftp://ruby-lang.org/"]
+    URI.extract("https://mail.google.com").should == ["https://mail.google.com"]
+    URI.extract("anything://example.com/").should == ["anything://example.com/"]
+  end
+
+  it "pulls all URIs within a string in order into an array when a block is not given" do
+    URI.extract("1.3. Example URI
+
+       The following examples illustrate URI that are in common use.
+
+       ftp://ftp.is.co.za/rfc/rfc1808.txt
+          -- ftp scheme for File Transfer Protocol services
+
+       gopher://spinaltap.micro.umn.edu/00/Weather/California/Los%20Angeles
+          -- gopher scheme for Gopher and Gopher+ Protocol services
+
+       http://www.math.uio.no/faq/compression-faq/part1.html
+          -- http scheme for Hypertext Transfer Protocol services
+
+       mailto:mduerst@ifi.unizh.ch
+          -- mailto scheme for electronic mail addresses
+
+       news:comp.infosystems.www.servers.unix
+          -- news scheme for USENET news groups and articles
+
+       telnet://melvyl.ucop.edu/
+          -- telnet scheme for interactive services via the TELNET Protocol
+    ").should == ["ftp://ftp.is.co.za/rfc/rfc1808.txt","gopher://spinaltap.micro.umn.edu/00/Weather/California/Los%20Angeles","http://www.math.uio.no/faq/compression-faq/part1.html","mailto:mduerst@ifi.unizh.ch","news:comp.infosystems.www.servers.unix","telnet://melvyl.ucop.edu/"]
+  end
+
+  it "yields each URI in the given string in order to a block, if given, and returns nil" do
+    results = ["http://foo.example.org/bla", "mailto:test@example.com"]
+    URI.extract("text here http://foo.example.org/bla and here mailto:test@example.com and here also.") {|uri|
+      uri.should == results.shift
+    }.should == nil
+    results.should == []
+  end
+
+  it "allows the user to specify a list of acceptable protocols of URIs to scan for" do
+    URI.extract("1.3. Example URI
+
+       The following examples illustrate URI that are in common use.
+
+       ftp://ftp.is.co.za/rfc/rfc1808.txt
+          -- ftp scheme for File Transfer Protocol services
+
+       gopher://spinaltap.micro.umn.edu/00/Weather/California/Los%20Angeles
+          -- gopher scheme for Gopher and Gopher+ Protocol services
+
+       http://www.math.uio.no/faq/compression-faq/part1.html
+          -- http scheme for Hypertext Transfer Protocol services
+
+       mailto:mduerst@ifi.unizh.ch
+          -- mailto scheme for electronic mail addresses
+
+       news:comp.infosystems.www.servers.unix
+          -- news scheme for USENET news groups and articles
+
+       telnet://melvyl.ucop.edu/
+          -- telnet scheme for interactive services via the TELNET Protocol
+    ", ["http","ftp","mailto"]).should == ["ftp://ftp.is.co.za/rfc/rfc1808.txt","http://www.math.uio.no/faq/compression-faq/part1.html","mailto:mduerst@ifi.unizh.ch"]
+  end
+end

--- a/mruby/src/extn/stdlib/spec/uri/fixtures/classes.rb
+++ b/mruby/src/extn/stdlib/spec/uri/fixtures/classes.rb
@@ -1,0 +1,11 @@
+require 'uri'
+
+module URISpec
+  def self.components(uri)
+    result = {}
+    uri.component.each do |component|
+      result[component] = uri.send(component)
+    end
+    result
+  end
+end

--- a/mruby/src/extn/stdlib/spec/uri/fixtures/normalization.rb
+++ b/mruby/src/extn/stdlib/spec/uri/fixtures/normalization.rb
@@ -1,0 +1,54 @@
+module URISpec
+  # Not an exhaustive list. Refer to rfc3986
+  NORMALIZED_FORMS = [
+    { normalized:     "http://example.com/",
+      equivalent:  %w{ hTTp://example.com/
+                          http://exaMple.com/
+                          http://exa%4dple.com/
+                          http://exa%4Dple.com/
+                          http://exa%6dple.com/
+                          http://exa%6Dple.com/
+                          http://@example.com/
+                          http://example.com:/
+                          http://example.com:80/
+                          http://example.com
+                        },
+      different:   %w{ http://example.com/#
+                          http://example.com/?
+                          http://example.com:8888/
+                          http:///example.com
+                          http:example.com
+                          https://example.com/
+                        },
+    },
+    { normalized:     "http://example.com/index.html",
+      equivalent:  %w{ http://example.com/index.ht%6dl
+                          http://example.com/index.ht%6Dl
+                        },
+     different:    %w{ http://example.com/index.hTMl
+                          http://example.com/index.ht%4dl
+                          http://example.com/index
+                          http://example.com/
+                          http://example.com/
+                        },
+    },
+    { normalized:     "http://example.com/x?y#z",
+      equivalent:  %w{ http://example.com/x?y#%7a
+                          http://example.com/x?y#%7A
+                          http://example.com/x?%79#z
+                        },
+     different:    %w{ http://example.com/x?Y#z
+                          http://example.com/x?y#Z
+                          http://example.com/x?y=#z
+                          http://example.com/x?y
+                          http://example.com/x#z
+                        },
+    },
+    { normalized:     "http://example.com/x?q=a%20b",
+      equivalent:  %w{
+                        },
+      different:   %w{ http://example.com/x?q=a+b
+                        },
+    },
+  ]
+end

--- a/mruby/src/extn/stdlib/spec/uri/ftp/build_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/ftp/build_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::FTP.build" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/ftp/merge_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/ftp/merge_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::FTP#merge" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/ftp/new2_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/ftp/new2_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::FTP.new2" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/ftp/path_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/ftp/path_spec.rb
@@ -1,0 +1,26 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::FTP#path=" do
+  before :each do
+    @url = URI.parse('ftp://example.com')
+  end
+
+  it "does not require a leading /" do
+    @url.path = 'foo'
+    @url.path.should == 'foo'
+  end
+
+  it "does not strip the leading /" do
+    @url.path = '/foo'
+    @url.path.should == '/foo'
+  end
+end
+
+describe "URI::FTP#path" do
+  it "unescapes the leading /" do
+    url = URI.parse('ftp://example.com/%2Ffoo')
+
+    url.path.should == '/foo'
+  end
+end

--- a/mruby/src/extn/stdlib/spec/uri/ftp/set_typecode_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/ftp/set_typecode_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::FTP#set_typecode" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/ftp/to_s_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/ftp/to_s_spec.rb
@@ -1,0 +1,15 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+
+describe "URI::FTP#to_s" do
+  before :each do
+    @url = URI.parse('ftp://example.com')
+  end
+
+  it "escapes the leading /" do
+    @url.path = '/foo'
+
+    @url.to_s.should == 'ftp://example.com/%2Ffoo'
+  end
+end

--- a/mruby/src/extn/stdlib/spec/uri/ftp/typecode_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/ftp/typecode_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::FTP#typecode" do
+  it "needs to be reviewed for spec completeness"
+end
+
+describe "URI::FTP#typecode=" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/absolute_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/absolute_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#absolute" do
+  it "needs to be reviewed for spec completeness"
+end
+
+describe "URI::Generic#absolute?" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/build2_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/build2_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic.build2" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/build_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/build_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic.build" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/coerce_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/coerce_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#coerce" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/component_ary_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/component_ary_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#component_ary" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/component_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/component_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#component" do
+  it "needs to be reviewed for spec completeness"
+end
+
+describe "URI::Generic.component" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/default_port_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/default_port_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#default_port" do
+  it "needs to be reviewed for spec completeness"
+end
+
+describe "URI::Generic.default_port" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/eql_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/eql_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#eql?" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/equal_value_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/equal_value_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#==" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/fragment_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/fragment_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#fragment" do
+  it "needs to be reviewed for spec completeness"
+end
+
+describe "URI::Generic#fragment=" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/hash_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/hash_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#hash" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/hierarchical_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/hierarchical_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#hierarchical?" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/host_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/host_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#host" do
+  it "needs to be reviewed for spec completeness"
+end
+
+describe "URI::Generic#host=" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/inspect_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/inspect_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#inspect" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/merge_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/merge_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#merge" do
+  it "needs to be reviewed for spec completeness"
+end
+
+describe "URI::Generic#merge!" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/minus_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/minus_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#-" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/normalize_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/normalize_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#normalize" do
+  it "needs to be reviewed for spec completeness"
+end
+
+describe "URI::Generic#normalize!" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/opaque_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/opaque_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#opaque" do
+  it "needs to be reviewed for spec completeness"
+end
+
+describe "URI::Generic#opaque=" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/password_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/password_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#password" do
+  it "needs to be reviewed for spec completeness"
+end
+
+describe "URI::Generic#password=" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/path_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/path_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#path" do
+  it "needs to be reviewed for spec completeness"
+end
+
+describe "URI::Generic#path=" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/plus_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/plus_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#+" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/port_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/port_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#port" do
+  it "needs to be reviewed for spec completeness"
+end
+
+describe "URI::Generic#port=" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/query_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/query_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#query" do
+  it "needs to be reviewed for spec completeness"
+end
+
+describe "URI::Generic#query=" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/registry_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/registry_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#registry" do
+  it "needs to be reviewed for spec completeness"
+end
+
+describe "URI::Generic#registry=" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/relative_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/relative_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#relative?" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/route_from_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/route_from_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#route_from" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/route_to_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/route_to_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#route_to" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/scheme_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/scheme_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#scheme" do
+  it "needs to be reviewed for spec completeness"
+end
+
+describe "URI::Generic#scheme=" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/select_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/select_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#select" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/set_fragment_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/set_fragment_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#set_fragment" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/set_host_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/set_host_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#set_host" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/set_opaque_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/set_opaque_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#set_opaque" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/set_password_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/set_password_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#set_password" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/set_path_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/set_path_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#set_path" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/set_port_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/set_port_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#set_port" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/set_query_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/set_query_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#set_query" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/set_registry_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/set_registry_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#set_registry" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/set_scheme_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/set_scheme_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#set_scheme" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/set_user_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/set_user_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#set_user" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/set_userinfo_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/set_userinfo_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#set_userinfo" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/to_s_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/to_s_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#to_s" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/use_registry_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/use_registry_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic.use_registry" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/user_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/user_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#user" do
+  it "needs to be reviewed for spec completeness"
+end
+
+describe "URI::Generic#user=" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/generic/userinfo_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/generic/userinfo_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Generic#userinfo" do
+  it "needs to be reviewed for spec completeness"
+end
+
+describe "URI::Generic#userinfo=" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/http/build_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/http/build_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::HTTP.build" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/http/request_uri_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/http/request_uri_spec.rb
@@ -1,0 +1,16 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::HTTP.request_uri" do
+  it "returns a string of the path + query" do
+    URI("http://reddit.com/r/ruby/").request_uri.should == "/r/ruby/"
+    URI("http://reddit.com/r/ruby/search?q=rubinius").request_uri.should == "/r/ruby/search?q=rubinius"
+  end
+
+  it "returns '/' if the path of the URI is blank" do
+    URI("http://ruby.reddit.com").request_uri.should == "/"
+  end
+end
+describe "URI::HTTP#request_uri" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/join_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/join_spec.rb
@@ -1,0 +1,59 @@
+require_relative '../../spec_helper'
+require 'uri'
+
+describe "URI.join" do
+  it "returns a URI object of the concatenation of a protocol and domain, and a path" do
+    URI.join("http://localhost/","main.rbx").should == URI.parse("http://localhost/main.rbx")
+  end
+
+  it "accepts URI objects" do
+    URI.join(URI("http://localhost/"),"main.rbx").should == URI.parse("http://localhost/main.rbx")
+    URI.join("http://localhost/",URI("main.rbx")).should == URI.parse("http://localhost/main.rbx")
+    URI.join(URI("http://localhost/"),URI("main.rbx")).should == URI.parse("http://localhost/main.rbx")
+  end
+
+  it "accepts string-like arguments with to_str" do
+    str = mock('string-like')
+    str.should_receive(:to_str).and_return("http://ruby-lang.org")
+    str2 = mock('string-like also')
+    str2.should_receive(:to_str).and_return("foo/bar")
+    URI.join(str, str2).should == URI.parse("http://ruby-lang.org/foo/bar")
+  end
+
+  it "raises an error if given no argument" do
+    lambda {
+      URI.join
+    }.should raise_error(ArgumentError)
+  end
+
+  it "doesn't create redundant '/'s" do
+    URI.join("http://localhost/", "/main.rbx").should == URI.parse("http://localhost/main.rbx")
+  end
+
+  it "discards arguments given before an absolute uri" do
+    URI.join("http://localhost/a/b/c/d", "http://ruby-lang.com/foo", "bar").should == URI.parse("http://ruby-lang.com/bar")
+  end
+
+  it "resolves .. in paths" do
+    URI.join("http://localhost/a/b/c/d", "../../e/f", "g/h/../i").to_s.should == "http://localhost/a/e/g/i"
+  end
+end
+
+
+# assert_equal(URI.parse('http://foo/bar'), URI.join('http://foo/bar'))
+# assert_equal(URI.parse('http://foo/bar'), URI.join('http://foo', 'bar'))
+# assert_equal(URI.parse('http://foo/bar/'), URI.join('http://foo', 'bar/'))
+#
+# assert_equal(URI.parse('http://foo/baz'), URI.join('http://foo', 'bar', 'baz'))
+# assert_equal(URI.parse('http://foo/baz'), URI.join('http://foo', 'bar', '/baz'))
+# assert_equal(URI.parse('http://foo/baz/'), URI.join('http://foo', 'bar', '/baz/'))
+# assert_equal(URI.parse('http://foo/bar/baz'), URI.join('http://foo', 'bar/', 'baz'))
+# assert_equal(URI.parse('http://foo/hoge'), URI.join('http://foo', 'bar', 'baz', 'hoge'))
+#
+# assert_equal(URI.parse('http://foo/bar/baz'), URI.join('http://foo', 'bar/baz'))
+# assert_equal(URI.parse('http://foo/bar/hoge'), URI.join('http://foo', 'bar/baz', 'hoge'))
+# assert_equal(URI.parse('http://foo/bar/baz/hoge'), URI.join('http://foo', 'bar/baz/', 'hoge'))
+# assert_equal(URI.parse('http://foo/hoge'), URI.join('http://foo', 'bar/baz', '/hoge'))
+# assert_equal(URI.parse('http://foo/bar/hoge'), URI.join('http://foo', 'bar/baz', 'hoge'))
+# assert_equal(URI.parse('http://foo/bar/baz/hoge'), URI.join('http://foo', 'bar/baz/', 'hoge'))
+# assert_equal(URI.parse('http://foo/hoge'), URI.join('http://foo', 'bar/baz', '/hoge'))

--- a/mruby/src/extn/stdlib/spec/uri/ldap/attributes_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/ldap/attributes_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::LDAP#attributes" do
+  it "needs to be reviewed for spec completeness"
+end
+
+describe "URI::LDAP#attributes=" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/ldap/build_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/ldap/build_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::LDAP.build" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/ldap/dn_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/ldap/dn_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::LDAP#dn" do
+  it "needs to be reviewed for spec completeness"
+end
+
+describe "URI::LDAP#dn=" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/ldap/extensions_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/ldap/extensions_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::LDAP#extensions" do
+  it "needs to be reviewed for spec completeness"
+end
+
+describe "URI::LDAP#extensions=" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/ldap/filter_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/ldap/filter_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::LDAP#filter" do
+  it "needs to be reviewed for spec completeness"
+end
+
+describe "URI::LDAP#filter=" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/ldap/hierarchical_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/ldap/hierarchical_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::LDAP#hierarchical?" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/ldap/scope_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/ldap/scope_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::LDAP#scope" do
+  it "needs to be reviewed for spec completeness"
+end
+
+describe "URI::LDAP#scope=" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/ldap/set_attributes_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/ldap/set_attributes_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::LDAP#set_attributes" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/ldap/set_dn_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/ldap/set_dn_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::LDAP#set_dn" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/ldap/set_extensions_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/ldap/set_extensions_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::LDAP#set_extensions" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/ldap/set_filter_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/ldap/set_filter_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::LDAP#set_filter" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/ldap/set_scope_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/ldap/set_scope_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::LDAP#set_scope" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/mailto/build_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/mailto/build_spec.rb
@@ -1,0 +1,98 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Mailto.build" do
+  it "conforms to the MatzRuby tests" do
+    ok = []
+    bad = []
+
+    # RFC2368, 6. Examples
+    # mailto:chris@example.com
+    ok << ["mailto:chris@example.com"]
+    ok[-1] << ["chris@example.com", nil]
+    ok[-1] << {to: "chris@example.com"}
+
+    # mailto:infobot@example.com?subject=current-issue
+    ok << ["mailto:infobot@example.com?subject=current-issue"]
+    ok[-1] << ["infobot@example.com", ["subject=current-issue"]]
+    ok[-1] << {to: "infobot@example.com",
+      headers: ["subject=current-issue"]}
+
+    # mailto:infobot@example.com?body=send%20current-issue
+    ok << ["mailto:infobot@example.com?body=send%20current-issue"]
+    ok[-1] << ["infobot@example.com", ["body=send%20current-issue"]]
+    ok[-1] << {to: "infobot@example.com",
+      headers: ["body=send%20current-issue"]}
+
+    # mailto:infobot@example.com?body=send%20current-issue%0D%0Asend%20index
+    ok << ["mailto:infobot@example.com?body=send%20current-issue%0D%0Asend%20index"]
+    ok[-1] << ["infobot@example.com",
+      ["body=send%20current-issue%0D%0Asend%20index"]]
+    ok[-1] << {to: "infobot@example.com",
+      headers: ["body=send%20current-issue%0D%0Asend%20index"]}
+
+    # mailto:foobar@example.com?In-Reply-To=%3c3469A91.D10AF4C@example.com
+    ok << ["mailto:foobar@example.com?In-Reply-To=%3c3469A91.D10AF4C@example.com"]
+    ok[-1] << ["foobar@example.com",
+      ["In-Reply-To=%3c3469A91.D10AF4C@example.com"]]
+    ok[-1] << {to: "foobar@example.com",
+      headers: ["In-Reply-To=%3c3469A91.D10AF4C@example.com"]}
+
+    # mailto:majordomo@example.com?body=subscribe%20bamboo-l
+    ok << ["mailto:majordomo@example.com?body=subscribe%20bamboo-l"]
+    ok[-1] << ["majordomo@example.com", ["body=subscribe%20bamboo-l"]]
+    ok[-1] << {to: "majordomo@example.com",
+      headers: ["body=subscribe%20bamboo-l"]}
+
+    # mailto:joe@example.com?cc=bob@example.com&body=hello
+    ok << ["mailto:joe@example.com?cc=bob@example.com&body=hello"]
+    ok[-1] << ["joe@example.com", ["cc=bob@example.com", "body=hello"]]
+    ok[-1] << {to: "joe@example.com",
+      headers: ["cc=bob@example.com", "body=hello"]}
+
+    # mailto:?to=joe@example.com&cc=bob@example.com&body=hello
+    ok << ["mailto:?to=joe@example.com&cc=bob@example.com&body=hello"]
+    ok[-1] << [nil,
+      ["to=joe@example.com", "cc=bob@example.com", "body=hello"]]
+    ok[-1] << {headers: ["to=joe@example.com", "cc=bob@example.com", "body=hello"]}
+
+    # mailto:gorby%25kremvax@example.com
+    ok << ["mailto:gorby%25kremvax@example.com"]
+    ok[-1] << ["gorby%25kremvax@example.com", nil]
+    ok[-1] << {to: "gorby%25kremvax@example.com"}
+
+    # mailto:unlikely%3Faddress@example.com?blat=foop
+    ok << ["mailto:unlikely%3Faddress@example.com?blat=foop"]
+    ok[-1] << ["unlikely%3Faddress@example.com", ["blat=foop"]]
+    ok[-1] << {to: "unlikely%3Faddress@example.com",
+      headers: ["blat=foop"]}
+
+    ok_all = ok.flatten.join("\0")
+
+    # mailto:joe@example.com?cc=bob@example.com?body=hello   ; WRONG!
+    bad << ["joe@example.com", ["cc=bob@example.com?body=hello"]]
+
+    # mailto:javascript:alert()
+    bad << ["javascript:alert()", []]
+
+    # '=' which is in hname or hvalue is wrong.
+    bad << ["foo@example.jp?subject=1+1=2", []]
+
+    ok.each do |x|
+      URI::MailTo.build(x[1]).to_s.should == x[0]
+      URI::MailTo.build(x[2]).to_s.should == x[0]
+    end
+
+    bad.each do |x|
+      lambda { URI::MailTo.build(x) }.should raise_error(URI::InvalidComponentError)
+    end
+
+    ok.flatten.join("\0").should == ok_all
+  end
+end
+
+
+
+describe "URI::MailTo.build" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/mailto/headers_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/mailto/headers_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::MailTo#headers" do
+  it "needs to be reviewed for spec completeness"
+end
+
+describe "URI::MailTo#headers=" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/mailto/set_headers_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/mailto/set_headers_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::MailTo#set_headers" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/mailto/set_to_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/mailto/set_to_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::MailTo#set_to" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/mailto/to_mailtext_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/mailto/to_mailtext_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::MailTo#to_mailtext" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/mailto/to_rfc822text_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/mailto/to_rfc822text_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::MailTo#to_rfc822text" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/mailto/to_s_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/mailto/to_s_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::MailTo#to_s" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/mailto/to_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/mailto/to_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::MailTo#to" do
+  it "needs to be reviewed for spec completeness"
+end
+
+describe "URI::MailTo#to=" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/merge_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/merge_spec.rb
@@ -1,0 +1,20 @@
+require_relative '../../spec_helper'
+require 'uri'
+
+describe "URI#merge" do
+  it "returns the receiver and the argument, joined as per URI.join" do
+    URI("http://localhost/").merge("main.rbx").should == URI.parse("http://localhost/main.rbx")
+    URI("http://localhost/a/b/c/d").merge("http://ruby-lang.com/foo").should == URI.parse("http://ruby-lang.com/foo")
+    URI("http://localhost/a/b/c/d").merge("../../e/f").to_s.should == "http://localhost/a/e/f"
+  end
+
+  it "accepts URI objects as argument" do
+    URI("http://localhost/").merge(URI("main.rbx")).should == URI.parse("http://localhost/main.rbx")
+  end
+
+  it "accepts a string-like argument" do
+    str = mock('string-like')
+    str.should_receive(:to_str).and_return("foo/bar")
+    URI("http://localhost/").merge(str).should == URI.parse("http://localhost/foo/bar")
+  end
+end

--- a/mruby/src/extn/stdlib/spec/uri/normalize_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/normalize_spec.rb
@@ -1,0 +1,35 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/normalization'
+require 'uri'
+
+describe "URI#normalize" do
+  it "adds a / onto the end of the URI if the path is blank" do
+    no_path = URI("http://example.com")
+    no_path.to_s.should_not == "http://example.com/"
+    no_path.normalize.to_s.should == "http://example.com/"
+  end
+
+  it "downcases the host of the URI" do
+    uri = URI("http://exAMPLE.cOm/")
+    uri.to_s.should_not == "http://example.com/"
+    uri.normalize.to_s.should == "http://example.com/"
+  end
+
+  # The previous tests are included by the one below
+
+  quarantine! do # Quarantined until redmine:2542 is accepted
+    it "respects RFC 3986" do
+      URISpec::NORMALIZED_FORMS.each do |form|
+        normal_uri = URI(form[:normalized])
+        normalized = normal_uri.normalize.to_s
+        normal_uri.to_s.should == normalized
+        form[:equivalent].each do |same|
+          URI(same).normalize.to_s.should == normalized
+        end
+        form[:different].each do |other|
+          URI(other).normalize.to_s.should_not == normalized
+        end
+      end
+    end
+  end
+end

--- a/mruby/src/extn/stdlib/spec/uri/parse_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/parse_spec.rb
@@ -1,0 +1,203 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "URI.parse" do
+
+  it "returns a URI::HTTP object when parsing an HTTP URI" do
+    URI.parse("http://www.example.com/").should be_kind_of(URI::HTTP)
+  end
+
+  it "populates the components of a parsed URI::HTTP, setting the port to 80 by default" do
+    # general case
+    URISpec.components(URI.parse("http://user:pass@example.com/path/?query=val&q2=val2#fragment")).should == {
+      scheme: "http",
+      userinfo: "user:pass",
+      host: "example.com",
+      port: 80,
+      path: "/path/",
+      query: "query=val&q2=val2",
+      fragment: "fragment"
+    }
+
+    # multiple paths
+    URISpec.components(URI.parse("http://a/b/c/d;p?q")).should == {
+      scheme: "http",
+      userinfo: nil,
+      host: "a",
+      port: 80,
+      path: "/b/c/d;p",
+      query: "q",
+      fragment: nil
+    }
+
+    # multi-level domain
+    URISpec.components(URI.parse('http://www.math.uio.no/faq/compression-faq/part1.html')).should == {
+      scheme: "http",
+      userinfo: nil,
+      host: "www.math.uio.no",
+      port: 80,
+      path: "/faq/compression-faq/part1.html",
+      query: nil,
+      fragment: nil
+    }
+  end
+
+  it "parses out the port number of a URI, when given" do
+    URI.parse("http://example.com:8080/").port.should == 8080
+  end
+
+  it "returns a URI::HTTPS object when parsing an HTTPS URI" do
+    URI.parse("https://important-intern-net.net").should be_kind_of(URI::HTTPS)
+  end
+
+  it "sets the port of a parsed https URI to 443 by default" do
+    URI.parse("https://example.com/").port.should == 443
+  end
+
+  it "populates the components of a parsed URI::FTP object" do
+    # generic, empty password.
+    url = URI.parse("ftp://anonymous@ruby-lang.org/pub/ruby/1.8/ruby-1.8.6.tar.bz2;type=i")
+    url.should be_kind_of(URI::FTP)
+    URISpec.components(url).should == {
+      scheme: "ftp",
+      userinfo: "anonymous",
+      host: "ruby-lang.org",
+      port: 21,
+      path: "pub/ruby/1.8/ruby-1.8.6.tar.bz2",
+      typecode: "i"
+    }
+
+    # multidomain, no user or password
+    url = URI.parse('ftp://ftp.is.co.za/rfc/rfc1808.txt')
+    url.should be_kind_of(URI::FTP)
+    URISpec.components(url).should == {
+      scheme: "ftp",
+      userinfo: nil,
+      host: "ftp.is.co.za",
+      port: 21,
+      path: "rfc/rfc1808.txt",
+      typecode: nil
+    }
+
+    # empty user
+    url = URI.parse('ftp://:pass@localhost/')
+    url.should be_kind_of(URI::FTP)
+    URISpec.components(url).should == {
+      scheme: "ftp",
+      userinfo: ":pass",
+      host: "localhost",
+      port: 21,
+      path: "",
+      typecode: nil
+    }
+    url.password.should == "pass"
+  end
+
+  it "returns a URI::LDAP object when parsing an LDAP URI" do
+    #taken from http://www.faqs.org/rfcs/rfc2255.html 'cause I don't really know what an LDAP url looks like
+    ldap_uris = %w{ ldap:///o=University%20of%20Michigan,c=US ldap://ldap.itd.umich.edu/o=University%20of%20Michigan,c=US ldap://ldap.itd.umich.edu/o=University%20of%20Michigan,c=US?postalAddress ldap://host.com:6666/o=University%20of%20Michigan,c=US??sub?(cn=Babs%20Jensen) ldap://ldap.itd.umich.edu/c=GB?objectClass?one ldap://ldap.question.com/o=Question%3f,c=US?mail ldap://ldap.netscape.com/o=Babsco,c=US??(int=%5c00%5c00%5c00%5c04) ldap:///??sub??bindname=cn=Manager%2co=Foo ldap:///??sub??!bindname=cn=Manager%2co=Foo }
+    ldap_uris.each do |ldap_uri|
+      URI.parse(ldap_uri).should be_kind_of(URI::LDAP)
+    end
+  end
+
+  it "populates the components of a parsed URI::LDAP object" do
+    URISpec.components(URI.parse("ldap://ldap.itd.umich.edu/o=University%20of%20Michigan,c=US?postalAddress?scope?filter?extensions")).should == {
+      scheme: "ldap",
+      host: "ldap.itd.umich.edu",
+      port: 389,
+      dn: "o=University%20of%20Michigan,c=US",
+      attributes: "postalAddress",
+      scope: "scope",
+      filter: "filter",
+      extensions: "extensions"
+    }
+  end
+
+  it "returns a URI::MailTo object when passed a mailto URI" do
+    URI.parse("mailto:spam@mailinator.com").should be_kind_of(URI::MailTo)
+  end
+
+  it "populates the components of a parsed URI::MailTo object" do
+    URISpec.components(URI.parse("mailto:spam@mailinator.com?subject=Discounts%20On%20Imported%20methods!!!&body=Exciting%20offer")).should == {
+      scheme: "mailto",
+      to: "spam@mailinator.com",
+      headers: [["subject","Discounts%20On%20Imported%20methods!!!"],
+                   ["body", "Exciting%20offer"]]
+    }
+  end
+
+  # TODO
+  # Test registry
+  it "does its best to extract components from URI::Generic objects" do
+    # generic
+    URISpec.components(URI("scheme://userinfo@host/path?query#fragment")).should == {
+      scheme: "scheme",
+      userinfo: "userinfo",
+      host: "host",
+      port: nil,
+      path: "/path",
+      query: "query",
+      fragment: "fragment",
+      registry: nil,
+      opaque: nil
+    }
+
+    # gopher
+    gopher = URI.parse('gopher://spinaltap.micro.umn.edu/00/Weather/California/Los%20Angeles')
+    gopher.should be_kind_of(URI::Generic)
+
+    URISpec.components(gopher).should == {
+      scheme: "gopher",
+      userinfo: nil,
+      host: "spinaltap.micro.umn.edu",
+      port: nil,
+      path: "/00/Weather/California/Los%20Angeles",
+      query: nil,
+      fragment: nil,
+      registry: nil,
+      opaque: nil
+    }
+
+    # news
+    news = URI.parse('news:comp.infosystems.www.servers.unix')
+    news.should be_kind_of(URI::Generic)
+    URISpec.components(news).should == {
+      scheme: "news",
+      userinfo: nil,
+      host: nil,
+      port: nil,
+      path: nil,
+      query: nil,
+      fragment: nil,
+      registry: nil,
+      opaque: "comp.infosystems.www.servers.unix"
+    }
+
+    # telnet
+    telnet = URI.parse('telnet://melvyl.ucop.edu/')
+    telnet.should be_kind_of(URI::Generic)
+    URISpec.components(telnet).should == {
+      scheme: "telnet",
+      userinfo: nil,
+      host: "melvyl.ucop.edu",
+      port: nil,
+      path: "/",
+      query: nil,
+      fragment: nil,
+      registry: nil,
+      opaque: nil
+    }
+
+    # files
+    file_l = URI.parse('file:///foo/bar.txt')
+    file_l.should be_kind_of(URI::Generic)
+    file = URI.parse('file:/foo/bar.txt')
+    file.should be_kind_of(URI::Generic)
+  end
+
+  it "doesn't raise errors on URIs which has underscore in reg_name" do
+    URI.parse('http://a_b:80/').host.should == "a_b"
+    URI.parse('http://a_b/').host.should == "a_b"
+  end
+end

--- a/mruby/src/extn/stdlib/spec/uri/parser/escape_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/parser/escape_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Parser#escape" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/parser/extract_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/parser/extract_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../../../spec_helper'
+require_relative '../shared/extract'
+require 'uri'
+
+describe "URI::Parser#extract" do
+  it_behaves_like :uri_extract, :extract, URI::Parser.new
+end

--- a/mruby/src/extn/stdlib/spec/uri/parser/inspect_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/parser/inspect_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Parser#split" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/parser/join_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/parser/join_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../../../spec_helper'
+require_relative '../shared/join'
+require 'uri'
+
+describe "URI::Parser#join" do
+  it_behaves_like :uri_join, :join, URI::Parser.new
+end

--- a/mruby/src/extn/stdlib/spec/uri/parser/make_regexp_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/parser/make_regexp_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Parser#make_regexp" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/parser/parse_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/parser/parse_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../../../spec_helper'
+require_relative '../fixtures/classes'
+require_relative '../shared/parse'
+
+describe "URI::Parser#parse" do
+  it_behaves_like :uri_parse, :parse, URI::Parser.new
+end

--- a/mruby/src/extn/stdlib/spec/uri/parser/split_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/parser/split_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Parser#split" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/parser/unescape_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/parser/unescape_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Parser#unescape" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/plus_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/plus_spec.rb
@@ -1,0 +1,459 @@
+require_relative '../../spec_helper'
+require 'uri'
+
+#an alias of URI#merge
+describe "URI#+" do
+  it "replaces the end of the path of the URI when added to a string that looks like a relative path" do
+    (URI('http://foo') + 'bar').should == URI("http://foo/bar")
+    (URI('http://foo/baz') + 'bar').should == URI("http://foo/bar")
+    (URI('http://foo/baz/') + 'bar').should == URI("http://foo/baz/bar")
+    (URI('mailto:foo@example.com') + "#bar").should == URI("mailto:foo@example.com#bar")
+  end
+
+  it "replaces the entire path of the URI when added to a string that begins with a /" do
+    (URI('http://foo/baz/') + '/bar').should == URI("http://foo/bar")
+  end
+
+  it "replaces the entire url when added to a string that looks like a full url" do
+    (URI.parse('http://a/b') + 'http://x/y').should == URI("http://x/y")
+    (URI.parse('telnet:example.com') + 'http://x/y').should == URI("http://x/y")
+  end
+
+  it "canonicalizes the URI's path, removing ../'s" do
+    (URI.parse('http://a/b/c/../') + "./").should == URI("http://a/b/")
+    (URI.parse('http://a/b/c/../') + ".").should == URI("http://a/b/")
+    (URI.parse('http://a/b/c/')   + "../").should == URI("http://a/b/")
+    (URI.parse('http://a/b/c/../../') + "./").should == URI("http://a/")
+    (URI.parse('http://a/b/c/')   + "../e/").should == URI("http://a/b/e/")
+    (URI.parse('http://a/b/c/')   + "../e/../").should == URI("http://a/b/")
+    (URI.parse('http://a/b/../c/') + ".").should == URI("http://a/c/")
+
+    (URI.parse('http://a/b/c/../../../') + ".").should == URI("http://a/")
+  end
+
+  it "doesn't conconicalize the path when adding to the empty string" do
+    (URI.parse('http://a/b/c/../') + "").should == URI("http://a/b/c/../")
+  end
+
+  it "raises a URI::BadURIError when adding two relative URIs" do
+    lambda {URI.parse('a/b/c') + "d"}.should raise_error(URI::BadURIError)
+  end
+
+  #Todo: make more BDD?
+  it "conforms to the merge specifications from rfc 2396" do
+    @url = 'http://a/b/c/d;p?q'
+    @base_url = URI.parse(@url)
+
+#  http://a/b/c/d;p?q
+#        g:h           =  g:h
+    url = @base_url.merge('g:h')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should == 'g:h'
+    url = @base_url.route_to('g:h')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should == 'g:h'
+
+#  http://a/b/c/d;p?q
+#        g             =  http://a/b/c/g
+    url = @base_url.merge('g')
+    url.should be_kind_of(URI::HTTP)
+    url.to_s.should == 'http://a/b/c/g'
+    url = @base_url.route_to('http://a/b/c/g')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should == 'g'
+
+#  http://a/b/c/d;p?q
+#        ./g           =  http://a/b/c/g
+    url = @base_url.merge('./g')
+    url.should be_kind_of(URI::HTTP)
+    url.to_s.should == 'http://a/b/c/g'
+    url = @base_url.route_to('http://a/b/c/g')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should_not == './g' # ok
+    url.to_s.should == 'g'
+
+#  http://a/b/c/d;p?q
+#        g/            =  http://a/b/c/g/
+    url = @base_url.merge('g/')
+    url.should be_kind_of(URI::HTTP)
+    url.to_s.should == 'http://a/b/c/g/'
+    url = @base_url.route_to('http://a/b/c/g/')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should == 'g/'
+
+#  http://a/b/c/d;p?q
+#        /g            =  http://a/g
+    url = @base_url.merge('/g')
+    url.should be_kind_of(URI::HTTP)
+    url.to_s.should == 'http://a/g'
+    url = @base_url.route_to('http://a/g')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should_not == '/g' # ok
+    url.to_s.should == '../../g'
+
+#  http://a/b/c/d;p?q
+#        //g           =  http://g
+    url = @base_url.merge('//g')
+    url.should be_kind_of(URI::HTTP)
+    url.to_s.should == 'http://g'
+    url = @base_url.route_to('http://g')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should == '//g'
+
+#  http://a/b/c/d;p?q
+#        ?y            =  http://a/b/c/?y
+    url = @base_url.merge('?y')
+    url.should be_kind_of(URI::HTTP)
+
+    url.to_s.should == 'http://a/b/c/d;p?y'
+
+    url = @base_url.route_to('http://a/b/c/?y')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should == '?y'
+
+#  http://a/b/c/d;p?q
+#        g?y           =  http://a/b/c/g?y
+    url = @base_url.merge('g?y')
+    url.should be_kind_of(URI::HTTP)
+    url.to_s.should == 'http://a/b/c/g?y'
+    url = @base_url.route_to('http://a/b/c/g?y')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should == 'g?y'
+
+#  http://a/b/c/d;p?q
+#        #s            =  (current document)#s
+    url = @base_url.merge('#s')
+    url.should be_kind_of(URI::HTTP)
+    url.to_s.should == @base_url.to_s + '#s'
+    url = @base_url.route_to(@base_url.to_s + '#s')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should == '#s'
+
+#  http://a/b/c/d;p?q
+#        g#s           =  http://a/b/c/g#s
+    url = @base_url.merge('g#s')
+    url.should be_kind_of(URI::HTTP)
+    url.to_s.should == 'http://a/b/c/g#s'
+    url = @base_url.route_to('http://a/b/c/g#s')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should == 'g#s'
+
+#  http://a/b/c/d;p?q
+#        g?y#s         =  http://a/b/c/g?y#s
+    url = @base_url.merge('g?y#s')
+    url.should be_kind_of(URI::HTTP)
+    url.to_s.should == 'http://a/b/c/g?y#s'
+    url = @base_url.route_to('http://a/b/c/g?y#s')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should == 'g?y#s'
+
+#  http://a/b/c/d;p?q
+#        ;x            =  http://a/b/c/;x
+    url = @base_url.merge(';x')
+    url.should be_kind_of(URI::HTTP)
+    url.to_s.should == 'http://a/b/c/;x'
+    url = @base_url.route_to('http://a/b/c/;x')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should == ';x'
+
+#  http://a/b/c/d;p?q
+#        g;x           =  http://a/b/c/g;x
+    url = @base_url.merge('g;x')
+    url.should be_kind_of(URI::HTTP)
+    url.to_s.should == 'http://a/b/c/g;x'
+    url = @base_url.route_to('http://a/b/c/g;x')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should == 'g;x'
+
+#  http://a/b/c/d;p?q
+#        g;x?y#s       =  http://a/b/c/g;x?y#s
+    url = @base_url.merge('g;x?y#s')
+    url.should be_kind_of(URI::HTTP)
+    url.to_s.should == 'http://a/b/c/g;x?y#s'
+    url = @base_url.route_to('http://a/b/c/g;x?y#s')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should == 'g;x?y#s'
+
+#  http://a/b/c/d;p?q
+#        .             =  http://a/b/c/
+    url = @base_url.merge('.')
+    url.should be_kind_of(URI::HTTP)
+    url.to_s.should == 'http://a/b/c/'
+    url = @base_url.route_to('http://a/b/c/')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should_not == '.' # ok
+    url.to_s.should == './'
+
+#  http://a/b/c/d;p?q
+#        ./            =  http://a/b/c/
+    url = @base_url.merge('./')
+    url.should be_kind_of(URI::HTTP)
+    url.to_s.should == 'http://a/b/c/'
+    url = @base_url.route_to('http://a/b/c/')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should == './'
+
+#  http://a/b/c/d;p?q
+#        ..            =  http://a/b/
+    url = @base_url.merge('..')
+    url.should be_kind_of(URI::HTTP)
+    url.to_s.should == 'http://a/b/'
+    url = @base_url.route_to('http://a/b/')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should_not == '..' # ok
+    url.to_s.should == '../'
+
+#  http://a/b/c/d;p?q
+#        ../           =  http://a/b/
+    url = @base_url.merge('../')
+    url.should be_kind_of(URI::HTTP)
+    url.to_s.should == 'http://a/b/'
+    url = @base_url.route_to('http://a/b/')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should == '../'
+
+#  http://a/b/c/d;p?q
+#        ../g          =  http://a/b/g
+    url = @base_url.merge('../g')
+    url.should be_kind_of(URI::HTTP)
+    url.to_s.should == 'http://a/b/g'
+    url = @base_url.route_to('http://a/b/g')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should == '../g'
+
+#  http://a/b/c/d;p?q
+#        ../..         =  http://a/
+    url = @base_url.merge('../..')
+    url.should be_kind_of(URI::HTTP)
+    url.to_s.should == 'http://a/'
+    url = @base_url.route_to('http://a/')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should_not == '../..' # ok
+    url.to_s.should == '../../'
+
+#  http://a/b/c/d;p?q
+#        ../../        =  http://a/
+    url = @base_url.merge('../../')
+    url.should be_kind_of(URI::HTTP)
+    url.to_s.should == 'http://a/'
+    url = @base_url.route_to('http://a/')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should == '../../'
+
+#  http://a/b/c/d;p?q
+#        ../../g       =  http://a/g
+    url = @base_url.merge('../../g')
+    url.should be_kind_of(URI::HTTP)
+    url.to_s.should == 'http://a/g'
+    url = @base_url.route_to('http://a/g')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should == '../../g'
+
+#  http://a/b/c/d;p?q
+#        <>            =  (current document)
+    url = @base_url.merge('')
+    url.should be_kind_of(URI::HTTP)
+    url.to_s.should == 'http://a/b/c/d;p?q'
+    url = @base_url.route_to('http://a/b/c/d;p?q')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should == ''
+
+#  http://a/b/c/d;p?q
+#        /./g          =  http://a/./g
+    url = @base_url.merge('/./g')
+    url.should be_kind_of(URI::HTTP)
+
+    url.to_s.should == 'http://a/g'
+
+    url = @base_url.route_to('http://a/./g')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should == '/./g'
+
+#  http://a/b/c/d;p?q
+#        /../g         =  http://a/../g
+    url = @base_url.merge('/../g')
+    url.should be_kind_of(URI::HTTP)
+
+    url.to_s.should == 'http://a/g'
+
+    url = @base_url.route_to('http://a/../g')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should == '/../g'
+
+#  http://a/b/c/d;p?q
+#        g.            =  http://a/b/c/g.
+    url = @base_url.merge('g.')
+    url.should be_kind_of(URI::HTTP)
+    url.to_s.should == 'http://a/b/c/g.'
+    url = @base_url.route_to('http://a/b/c/g.')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should == 'g.'
+
+#  http://a/b/c/d;p?q
+#        .g            =  http://a/b/c/.g
+    url = @base_url.merge('.g')
+    url.should be_kind_of(URI::HTTP)
+    url.to_s.should == 'http://a/b/c/.g'
+    url = @base_url.route_to('http://a/b/c/.g')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should == '.g'
+
+#  http://a/b/c/d;p?q
+#        g..           =  http://a/b/c/g..
+    url = @base_url.merge('g..')
+    url.should be_kind_of(URI::HTTP)
+    url.to_s.should == 'http://a/b/c/g..'
+    url = @base_url.route_to('http://a/b/c/g..')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should == 'g..'
+
+#  http://a/b/c/d;p?q
+#        ..g           =  http://a/b/c/..g
+    url = @base_url.merge('..g')
+    url.should be_kind_of(URI::HTTP)
+    url.to_s.should == 'http://a/b/c/..g'
+    url = @base_url.route_to('http://a/b/c/..g')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should == '..g'
+
+#  http://a/b/c/d;p?q
+#        ../../../g    =  http://a/../g
+    url = @base_url.merge('../../../g')
+    url.should be_kind_of(URI::HTTP)
+
+    url.to_s.should == 'http://a/g'
+
+    url = @base_url.route_to('http://a/../g')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should_not == '../../../g' # ok? yes, it confuses you
+    url.to_s.should == '/../g'  # and it is clearly
+
+#  http://a/b/c/d;p?q
+#        ../../../../g =  http://a/../../g
+    url = @base_url.merge('../../../../g')
+    url.should be_kind_of(URI::HTTP)
+
+    url.to_s.should == 'http://a/g'
+
+    url = @base_url.route_to('http://a/../../g')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should_not == '../../../../g' # ok? yes, it confuses you
+    url.to_s.should == '/../../g'  # and it is clearly
+
+#  http://a/b/c/d;p?q
+#        ./../g        =  http://a/b/g
+    url = @base_url.merge('./../g')
+    url.should be_kind_of(URI::HTTP)
+    url.to_s.should == 'http://a/b/g'
+    url = @base_url.route_to('http://a/b/g')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should_not == './../g' # ok
+    url.to_s.should == '../g'
+
+#  http://a/b/c/d;p?q
+#        ./g/.         =  http://a/b/c/g/
+    url = @base_url.merge('./g/.')
+    url.should be_kind_of(URI::HTTP)
+    url.to_s.should == 'http://a/b/c/g/'
+    url = @base_url.route_to('http://a/b/c/g/')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should_not == './g/.' # ok
+    url.to_s.should == 'g/'
+
+#  http://a/b/c/d;p?q
+#        g/./h         =  http://a/b/c/g/h
+    url = @base_url.merge('g/./h')
+    url.should be_kind_of(URI::HTTP)
+    url.to_s.should == 'http://a/b/c/g/h'
+    url = @base_url.route_to('http://a/b/c/g/h')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should_not == 'g/./h' # ok
+    url.to_s.should == 'g/h'
+
+#  http://a/b/c/d;p?q
+#        g/../h        =  http://a/b/c/h
+    url = @base_url.merge('g/../h')
+    url.should be_kind_of(URI::HTTP)
+    url.to_s.should == 'http://a/b/c/h'
+    url = @base_url.route_to('http://a/b/c/h')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should_not == 'g/../h' # ok
+    url.to_s.should == 'h'
+
+#  http://a/b/c/d;p?q
+#        g;x=1/./y     =  http://a/b/c/g;x=1/y
+    url = @base_url.merge('g;x=1/./y')
+    url.should be_kind_of(URI::HTTP)
+    url.to_s.should == 'http://a/b/c/g;x=1/y'
+    url = @base_url.route_to('http://a/b/c/g;x=1/y')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should_not == 'g;x=1/./y' # ok
+    url.to_s.should == 'g;x=1/y'
+
+#  http://a/b/c/d;p?q
+#        g;x=1/../y    =  http://a/b/c/y
+    url = @base_url.merge('g;x=1/../y')
+    url.should be_kind_of(URI::HTTP)
+    url.to_s.should == 'http://a/b/c/y'
+    url = @base_url.route_to('http://a/b/c/y')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should_not == 'g;x=1/../y' # ok
+    url.to_s.should == 'y'
+
+#  http://a/b/c/d;p?q
+#        g?y/./x       =  http://a/b/c/g?y/./x
+    url = @base_url.merge('g?y/./x')
+    url.should be_kind_of(URI::HTTP)
+    url.to_s.should == 'http://a/b/c/g?y/./x'
+    url = @base_url.route_to('http://a/b/c/g?y/./x')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should == 'g?y/./x'
+
+#  http://a/b/c/d;p?q
+#        g?y/../x      =  http://a/b/c/g?y/../x
+    url = @base_url.merge('g?y/../x')
+    url.should be_kind_of(URI::HTTP)
+    url.to_s.should == 'http://a/b/c/g?y/../x'
+    url = @base_url.route_to('http://a/b/c/g?y/../x')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should == 'g?y/../x'
+
+#  http://a/b/c/d;p?q
+#        g#s/./x       =  http://a/b/c/g#s/./x
+    url = @base_url.merge('g#s/./x')
+    url.should be_kind_of(URI::HTTP)
+    url.to_s.should == 'http://a/b/c/g#s/./x'
+    url = @base_url.route_to('http://a/b/c/g#s/./x')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should == 'g#s/./x'
+
+#  http://a/b/c/d;p?q
+#        g#s/../x      =  http://a/b/c/g#s/../x
+    url = @base_url.merge('g#s/../x')
+    url.should be_kind_of(URI::HTTP)
+    url.to_s.should == 'http://a/b/c/g#s/../x'
+    url = @base_url.route_to('http://a/b/c/g#s/../x')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should == 'g#s/../x'
+
+#  http://a/b/c/d;p?q
+#        http:g        =  http:g           ; for validating parsers
+#                      |  http://a/b/c/g   ; for backwards compatibility
+    url = @base_url.merge('http:g')
+    url.should be_kind_of(URI::HTTP)
+    url.to_s.should == 'http:g'
+    url = @base_url.route_to('http:g')
+    url.should be_kind_of(URI::Generic)
+    url.to_s.should == 'http:g'
+  end
+end
+
+#TODO: incorporate these tests:
+#
+# u = URI.parse('http://foo/bar/baz')
+# assert_equal(nil, u.merge!(""))
+# assert_equal(nil, u.merge!(u))
+# assert(nil != u.merge!("."))
+# assert_equal('http://foo/bar/', u.to_s)
+# assert(nil != u.merge!("../baz"))
+# assert_equal('http://foo/baz', u.to_s)

--- a/mruby/src/extn/stdlib/spec/uri/regexp_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/regexp_spec.rb
@@ -1,0 +1,18 @@
+require_relative '../../spec_helper'
+require 'uri'
+
+#I'm more or less ok with these limited tests, as the more extensive extract tests
+#use URI.regexp
+describe "URI.regexp" do
+  it "behaves according to the MatzRuby tests" do
+    URI.regexp.should == URI.regexp
+    'x http:// x'.slice(URI.regexp).should == 'http://'
+    'x http:// x'.slice(URI.regexp(['http'])).should == 'http://'
+    'x http:// x ftp://'.slice(URI.regexp(['http'])).should == 'http://'
+    'http://'.slice(URI.regexp([])).should == nil
+    ''.slice(URI.regexp).should == nil
+    'xxxx'.slice(URI.regexp).should == nil
+    ':'.slice(URI.regexp).should == nil
+    'From:'.slice(URI.regexp).should == 'From:'
+  end
+end

--- a/mruby/src/extn/stdlib/spec/uri/route_from_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/route_from_spec.rb
@@ -1,0 +1,23 @@
+require_relative '../../spec_helper'
+require 'uri'
+
+describe "URI#route_from" do
+
+  #this could be split out a good bit better
+  it "gives the minimal difference between the current URI and the target" do
+    URI("http://example.com/a.html").route_from('http://example.com/a.html').to_s.should == ""
+    URI("http://example.com/a.html").route_from('http://example.com/b.html').to_s.should == "a.html"
+    URI("http://example.com/a/").route_from('http://example.com/b/').to_s.should == "../a/"
+    URI("http://example.com/b/").route_from('http://example.com/a/c').to_s.should == "../b/"
+    URI("http://example.com/b/").route_from('http://example.com/a/b/').to_s.should == "../../b/"
+    URI("http://example.com/b/").route_from('http://EXAMPLE.cOm/a/b/').to_s.should == "../../b/"
+    URI("http://example.net/b/").route_from('http://example.com/a/b/').to_s.should == "//example.net/b/"
+    URI("mailto:foo@example.com#bar").route_from('mailto:foo@example.com').to_s.should == "#bar"
+  end
+
+  it "accepts a string-like argument" do
+    str = mock('string-like')
+    str.should_receive(:to_str).and_return("http://example.com/b.html")
+    URI("http://example.com/a.html").route_from(str).to_s.should == "a.html"
+  end
+end

--- a/mruby/src/extn/stdlib/spec/uri/route_to_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/route_to_spec.rb
@@ -1,0 +1,26 @@
+require_relative '../../spec_helper'
+require 'uri'
+
+describe "URI#route_to" do
+
+  #this could be split out a good bit better
+  it "gives the minimal difference between the current URI and the target" do
+    URI("http://example.com/a.html").route_to('http://example.com/a.html').to_s.should == ""
+    URI("http://example.com/a.html").route_to('http://example.com/b.html').to_s.should == "b.html"
+    URI("http://example.com/a/").route_to('http://example.com/b/').to_s.should == "../b/"
+    URI("http://example.com/a/c").route_to('http://example.com/b/').to_s.should == "../b/"
+    URI("http://example.com/a/b/").route_to('http://example.com/b/').to_s.should == "../../b/"
+    URI("http://example.com/a/b/").route_to('http://EXAMPLE.cOm/b/').to_s.should == "../../b/"
+    URI("http://example.com/a/b/").route_to('http://example.net/b/').to_s.should == "//example.net/b/"
+    URI("mailto:foo@example.com").route_to('mailto:foo@example.com#bar').to_s.should == "#bar"
+
+    #this was a little surprising to me
+    URI("mailto:foo@example.com#bar").route_to('mailto:foo@example.com').to_s.should == ""
+  end
+
+  it "accepts a string-like argument" do
+    str = mock('string-like')
+    str.should_receive(:to_str).and_return("http://example.com/b.html")
+    URI("http://example.com/a.html").route_to(str).to_s.should == "b.html"
+  end
+end

--- a/mruby/src/extn/stdlib/spec/uri/select_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/select_spec.rb
@@ -1,0 +1,31 @@
+require_relative '../../spec_helper'
+require 'uri'
+
+describe "URI#select" do
+  it "takes any number of component names as symbols, and returns an array of those components" do
+    URI("http://host:8080/path/").select.should == []
+    URI("http://host:8080/path/").select(:scheme,:host,:port,:path).should == [
+      "http","host",8080,"/path/"]
+  end
+
+  it "returns nil for any valid component that isn't set and doesn't have a default" do
+    uri = URI("http://host")
+    uri.select(:userinfo, :query, :fragment).should == [nil] * 3
+    uri.select(:port, :path).should == [80, '']
+  end
+
+  it "raises an ArgumentError if a component is requested that isn't valid under the given scheme" do
+    [
+      lambda {URI("mailto:spam@mailinator.com").select(:path)},
+      lambda {URI("http://blog.blag.web").select(:typecode)},
+    ].each do |select_lambda|
+      select_lambda.should raise_error(ArgumentError)
+    end
+  end
+
+  it "raises an ArgumentError if given strings rather than symbols" do
+    lambda {
+      URI("http://host:8080/path/").select("scheme","host","port",'path')
+    }.should raise_error(ArgumentError)
+  end
+end

--- a/mruby/src/extn/stdlib/spec/uri/set_component_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/set_component_spec.rb
@@ -1,0 +1,45 @@
+require_relative '../../spec_helper'
+require 'uri'
+
+#TODO: make this more BDD
+describe "URI#select" do
+  it "conforms to the MatzRuby tests" do
+    uri = URI.parse('http://foo:bar@baz')
+    (uri.user = 'oof').should == 'oof'
+    uri.to_s.should == 'http://oof:bar@baz'
+    (uri.password = 'rab').should == 'rab'
+    uri.to_s.should == 'http://oof:rab@baz'
+    (uri.userinfo = 'foo').should == 'foo'
+    uri.to_s.should == 'http://foo:rab@baz'
+    (uri.userinfo = ['foo', 'bar']).should == ['foo', 'bar']
+    uri.to_s.should == 'http://foo:bar@baz'
+    (uri.userinfo = ['foo']).should == ['foo']
+    uri.to_s.should == 'http://foo:bar@baz'
+    (uri.host = 'zab').should == 'zab'
+    uri.to_s.should == 'http://foo:bar@zab'
+    (uri.port = 8080).should == 8080
+    uri.to_s.should == 'http://foo:bar@zab:8080'
+    (uri.path = '/').should == '/'
+    uri.to_s.should == 'http://foo:bar@zab:8080/'
+    (uri.query = 'a=1').should == 'a=1'
+    uri.to_s.should == 'http://foo:bar@zab:8080/?a=1'
+    (uri.fragment = 'b123').should == 'b123'
+    uri.to_s.should == 'http://foo:bar@zab:8080/?a=1#b123'
+
+    uri = URI.parse('http://example.com')
+    lambda { uri.password = 'bar' }.should raise_error(URI::InvalidURIError)
+    uri.userinfo = 'foo:bar'
+    uri.to_s.should == 'http://foo:bar@example.com'
+    lambda { uri.registry = 'bar' }.should raise_error(URI::InvalidURIError)
+    lambda { uri.opaque = 'bar' }.should raise_error(URI::InvalidURIError)
+
+    uri = URI.parse('mailto:foo@example.com')
+    lambda { uri.user = 'bar' }.should raise_error(URI::InvalidURIError)
+    lambda { uri.password = 'bar' }.should raise_error(URI::InvalidURIError)
+    lambda { uri.userinfo = ['bar', 'baz'] }.should raise_error(URI::InvalidURIError)
+    lambda { uri.host = 'bar' }.should raise_error(URI::InvalidURIError)
+    lambda { uri.port = 'bar' }.should raise_error(URI::InvalidURIError)
+    lambda { uri.path = 'bar' }.should raise_error(URI::InvalidURIError)
+    lambda { uri.query = 'bar' }.should raise_error(URI::InvalidURIError)
+  end
+end

--- a/mruby/src/extn/stdlib/spec/uri/shared/eql.rb
+++ b/mruby/src/extn/stdlib/spec/uri/shared/eql.rb
@@ -1,0 +1,17 @@
+describe :uri_eql, shared: true do
+  it "returns false if the normalized forms are different" do
+    URISpec::NORMALIZED_FORMS.each do |form|
+      normal_uri = URI(form[:normalized])
+      form[:different].each do |other|
+        URI(other).send(@method, normal_uri).should be_false
+      end
+    end
+  end
+end
+
+describe :uri_eql_against_other_types, shared: true do
+  it "returns false for when compared to non-uri objects" do
+    URI("http://example.com/").send(@method, "http://example.com/").should be_false
+    URI("http://example.com/").send(@method, nil).should be_false
+  end
+end

--- a/mruby/src/extn/stdlib/spec/uri/shared/extract.rb
+++ b/mruby/src/extn/stdlib/spec/uri/shared/extract.rb
@@ -1,0 +1,83 @@
+describe :uri_extract, shared: true do
+  it "behaves according to its documentation" do
+    @object.extract("text here http://foo.example.org/bla and here mailto:test@example.com and here also.").should == ["http://foo.example.org/bla", "mailto:test@example.com"]
+  end
+
+  it "treats contiguous URIs as a single URI" do
+    @object.extract('http://example.jphttp://example.jp').should == ['http://example.jphttp://example.jp']
+  end
+
+  it "treats pretty much anything with a colon as a URI" do
+    @object.extract('From: XXX [mailto:xxx@xxx.xxx.xxx]').should == ['From:', 'mailto:xxx@xxx.xxx.xxx]']
+  end
+
+  it "wraps a URI string in an array" do
+    @object.extract("http://github.com/brixen/rubyspec/tree/master").should == ["http://github.com/brixen/rubyspec/tree/master"]
+  end
+
+  it "pulls a variety of protocol URIs from a string" do
+    @object.extract("this is a string, it has http://rubini.us/ in it").should == ["http://rubini.us/"]
+    @object.extract("mailto:spambait@example.com").should == ["mailto:spambait@example.com"]
+    @object.extract("ftp://ruby-lang.org/").should == ["ftp://ruby-lang.org/"]
+    @object.extract("https://mail.google.com").should == ["https://mail.google.com"]
+    @object.extract("anything://example.com/").should == ["anything://example.com/"]
+  end
+
+  it "pulls all URIs within a string in order into an array when a block is not given" do
+    @object.extract("1.3. Example URI
+
+       The following examples illustrate URI that are in common use.
+
+       ftp://ftp.is.co.za/rfc/rfc1808.txt
+          -- ftp scheme for File Transfer Protocol services
+
+       gopher://spinaltap.micro.umn.edu/00/Weather/California/Los%20Angeles
+          -- gopher scheme for Gopher and Gopher+ Protocol services
+
+       http://www.math.uio.no/faq/compression-faq/part1.html
+          -- http scheme for Hypertext Transfer Protocol services
+
+       mailto:mduerst@ifi.unizh.ch
+          -- mailto scheme for electronic mail addresses
+
+       news:comp.infosystems.www.servers.unix
+          -- news scheme for USENET news groups and articles
+
+       telnet://melvyl.ucop.edu/
+          -- telnet scheme for interactive services via the TELNET Protocol
+    ").should == ["ftp://ftp.is.co.za/rfc/rfc1808.txt","gopher://spinaltap.micro.umn.edu/00/Weather/California/Los%20Angeles","http://www.math.uio.no/faq/compression-faq/part1.html","mailto:mduerst@ifi.unizh.ch","news:comp.infosystems.www.servers.unix","telnet://melvyl.ucop.edu/"]
+  end
+
+  it "yields each URI in the given string in order to a block, if given, and returns nil" do
+    results = ["http://foo.example.org/bla", "mailto:test@example.com"]
+    @object.extract("text here http://foo.example.org/bla and here mailto:test@example.com and here also.") {|uri|
+      uri.should == results.shift
+    }.should == nil
+    results.should == []
+  end
+
+  it "allows the user to specify a list of acceptable protocols of URIs to scan for" do
+    @object.extract("1.3. Example URI
+
+       The following examples illustrate URI that are in common use.
+
+       ftp://ftp.is.co.za/rfc/rfc1808.txt
+          -- ftp scheme for File Transfer Protocol services
+
+       gopher://spinaltap.micro.umn.edu/00/Weather/California/Los%20Angeles
+          -- gopher scheme for Gopher and Gopher+ Protocol services
+
+       http://www.math.uio.no/faq/compression-faq/part1.html
+          -- http scheme for Hypertext Transfer Protocol services
+
+       mailto:mduerst@ifi.unizh.ch
+          -- mailto scheme for electronic mail addresses
+
+       news:comp.infosystems.www.servers.unix
+          -- news scheme for USENET news groups and articles
+
+       telnet://melvyl.ucop.edu/
+          -- telnet scheme for interactive services via the TELNET Protocol
+    ", ["http","ftp","mailto"]).should == ["ftp://ftp.is.co.za/rfc/rfc1808.txt","http://www.math.uio.no/faq/compression-faq/part1.html","mailto:mduerst@ifi.unizh.ch"]
+  end
+end

--- a/mruby/src/extn/stdlib/spec/uri/shared/join.rb
+++ b/mruby/src/extn/stdlib/spec/uri/shared/join.rb
@@ -1,0 +1,56 @@
+describe :uri_join, shared: true do
+  it "returns a URI object of the concatenation of a protocol and domain, and a path" do
+    @object.join("http://localhost/","main.rbx").should == URI.parse("http://localhost/main.rbx")
+  end
+
+  it "accepts URI objects" do
+    @object.join(URI("http://localhost/"),"main.rbx").should == URI.parse("http://localhost/main.rbx")
+    @object.join("http://localhost/",URI("main.rbx")).should == URI.parse("http://localhost/main.rbx")
+    @object.join(URI("http://localhost/"),URI("main.rbx")).should == URI.parse("http://localhost/main.rbx")
+  end
+
+  it "accepts string-like arguments with to_str" do
+    str = mock('string-like')
+    str.should_receive(:to_str).and_return("http://ruby-lang.org")
+    str2 = mock('string-like also')
+    str2.should_receive(:to_str).and_return("foo/bar")
+    @object.join(str, str2).should == URI.parse("http://ruby-lang.org/foo/bar")
+  end
+
+  it "raises an error if given no argument" do
+    lambda {
+      @object.join
+    }.should raise_error(ArgumentError)
+  end
+
+  it "doesn't create redundant '/'s" do
+    @object.join("http://localhost/", "/main.rbx").should == URI.parse("http://localhost/main.rbx")
+  end
+
+  it "discards arguments given before an absolute uri" do
+    @object.join("http://localhost/a/b/c/d", "http://ruby-lang.com/foo", "bar").should == URI.parse("http://ruby-lang.com/bar")
+  end
+
+  it "resolves .. in paths" do
+    @object.join("http://localhost/a/b/c/d", "../../e/f", "g/h/../i").to_s.should == "http://localhost/a/e/g/i"
+  end
+end
+
+
+# assert_equal(URI.parse('http://foo/bar'), URI.join('http://foo/bar'))
+# assert_equal(URI.parse('http://foo/bar'), URI.join('http://foo', 'bar'))
+# assert_equal(URI.parse('http://foo/bar/'), URI.join('http://foo', 'bar/'))
+#
+# assert_equal(URI.parse('http://foo/baz'), URI.join('http://foo', 'bar', 'baz'))
+# assert_equal(URI.parse('http://foo/baz'), URI.join('http://foo', 'bar', '/baz'))
+# assert_equal(URI.parse('http://foo/baz/'), URI.join('http://foo', 'bar', '/baz/'))
+# assert_equal(URI.parse('http://foo/bar/baz'), URI.join('http://foo', 'bar/', 'baz'))
+# assert_equal(URI.parse('http://foo/hoge'), URI.join('http://foo', 'bar', 'baz', 'hoge'))
+#
+# assert_equal(URI.parse('http://foo/bar/baz'), URI.join('http://foo', 'bar/baz'))
+# assert_equal(URI.parse('http://foo/bar/hoge'), URI.join('http://foo', 'bar/baz', 'hoge'))
+# assert_equal(URI.parse('http://foo/bar/baz/hoge'), URI.join('http://foo', 'bar/baz/', 'hoge'))
+# assert_equal(URI.parse('http://foo/hoge'), URI.join('http://foo', 'bar/baz', '/hoge'))
+# assert_equal(URI.parse('http://foo/bar/hoge'), URI.join('http://foo', 'bar/baz', 'hoge'))
+# assert_equal(URI.parse('http://foo/bar/baz/hoge'), URI.join('http://foo', 'bar/baz/', 'hoge'))
+# assert_equal(URI.parse('http://foo/hoge'), URI.join('http://foo', 'bar/baz', '/hoge'))

--- a/mruby/src/extn/stdlib/spec/uri/shared/parse.rb
+++ b/mruby/src/extn/stdlib/spec/uri/shared/parse.rb
@@ -1,0 +1,199 @@
+describe :uri_parse, shared: true do
+  it "returns a URI::HTTP object when parsing an HTTP URI" do
+    @object.parse("http://www.example.com/").should be_kind_of(URI::HTTP)
+  end
+
+  it "populates the components of a parsed URI::HTTP, setting the port to 80 by default" do
+    # general case
+    URISpec.components(@object.parse("http://user:pass@example.com/path/?query=val&q2=val2#fragment")).should == {
+      scheme: "http",
+      userinfo: "user:pass",
+      host: "example.com",
+      port: 80,
+      path: "/path/",
+      query: "query=val&q2=val2",
+      fragment: "fragment"
+    }
+
+    # multiple paths
+    URISpec.components(@object.parse("http://a/b/c/d;p?q")).should == {
+      scheme: "http",
+      userinfo: nil,
+      host: "a",
+      port: 80,
+      path: "/b/c/d;p",
+      query: "q",
+      fragment: nil
+    }
+
+    # multi-level domain
+    URISpec.components(@object.parse('http://www.math.uio.no/faq/compression-faq/part1.html')).should == {
+      scheme: "http",
+      userinfo: nil,
+      host: "www.math.uio.no",
+      port: 80,
+      path: "/faq/compression-faq/part1.html",
+      query: nil,
+      fragment: nil
+    }
+  end
+
+  it "parses out the port number of a URI, when given" do
+    @object.parse("http://example.com:8080/").port.should == 8080
+  end
+
+  it "returns a URI::HTTPS object when parsing an HTTPS URI" do
+    @object.parse("https://important-intern-net.net").should be_kind_of(URI::HTTPS)
+  end
+
+  it "sets the port of a parsed https URI to 443 by default" do
+    @object.parse("https://example.com/").port.should == 443
+  end
+
+  it "populates the components of a parsed URI::FTP object" do
+    # generic, empty password.
+    url = @object.parse("ftp://anonymous@ruby-lang.org/pub/ruby/1.8/ruby-1.8.6.tar.bz2;type=i")
+    url.should be_kind_of(URI::FTP)
+    URISpec.components(url).should == {
+      scheme: "ftp",
+      userinfo: "anonymous",
+      host: "ruby-lang.org",
+      port: 21,
+      path: "pub/ruby/1.8/ruby-1.8.6.tar.bz2",
+      typecode: "i"
+    }
+
+    # multidomain, no user or password
+    url = @object.parse('ftp://ftp.is.co.za/rfc/rfc1808.txt')
+    url.should be_kind_of(URI::FTP)
+    URISpec.components(url).should == {
+      scheme: "ftp",
+      userinfo: nil,
+      host: "ftp.is.co.za",
+      port: 21,
+      path: "rfc/rfc1808.txt",
+      typecode: nil
+    }
+
+    # empty user
+    url = @object.parse('ftp://:pass@localhost/')
+    url.should be_kind_of(URI::FTP)
+    URISpec.components(url).should == {
+      scheme: "ftp",
+      userinfo: ":pass",
+      host: "localhost",
+      port: 21,
+      path: "",
+      typecode: nil
+    }
+    url.password.should == "pass"
+  end
+
+  it "returns a URI::LDAP object when parsing an LDAP URI" do
+    #taken from http://www.faqs.org/rfcs/rfc2255.html 'cause I don't really know what an LDAP url looks like
+    ldap_uris = %w{ ldap:///o=University%20of%20Michigan,c=US ldap://ldap.itd.umich.edu/o=University%20of%20Michigan,c=US ldap://ldap.itd.umich.edu/o=University%20of%20Michigan,c=US?postalAddress ldap://host.com:6666/o=University%20of%20Michigan,c=US??sub?(cn=Babs%20Jensen) ldap://ldap.itd.umich.edu/c=GB?objectClass?one ldap://ldap.question.com/o=Question%3f,c=US?mail ldap://ldap.netscape.com/o=Babsco,c=US??(int=%5c00%5c00%5c00%5c04) ldap:///??sub??bindname=cn=Manager%2co=Foo ldap:///??sub??!bindname=cn=Manager%2co=Foo }
+    ldap_uris.each do |ldap_uri|
+      @object.parse(ldap_uri).should be_kind_of(URI::LDAP)
+    end
+  end
+
+  it "populates the components of a parsed URI::LDAP object" do
+    URISpec.components(@object.parse("ldap://ldap.itd.umich.edu/o=University%20of%20Michigan,c=US?postalAddress?scope?filter?extensions")).should == {
+      scheme: "ldap",
+      host: "ldap.itd.umich.edu",
+      port: 389,
+      dn: "o=University%20of%20Michigan,c=US",
+      attributes: "postalAddress",
+      scope: "scope",
+      filter: "filter",
+      extensions: "extensions"
+    }
+  end
+
+  it "returns a URI::MailTo object when passed a mailto URI" do
+    @object.parse("mailto:spam@mailinator.com").should be_kind_of(URI::MailTo)
+  end
+
+  it "populates the components of a parsed URI::MailTo object" do
+    URISpec.components(@object.parse("mailto:spam@mailinator.com?subject=Discounts%20On%20Imported%20methods!!!&body=Exciting%20offer")).should == {
+      scheme: "mailto",
+      to: "spam@mailinator.com",
+      headers: [["subject","Discounts%20On%20Imported%20methods!!!"],
+                   ["body", "Exciting%20offer"]]
+    }
+  end
+
+  # TODO
+  # Test registry
+  it "does its best to extract components from URI::Generic objects" do
+    # generic
+    URISpec.components(URI("scheme://userinfo@host/path?query#fragment")).should == {
+      scheme: "scheme",
+      userinfo: "userinfo",
+      host: "host",
+      port: nil,
+      path: "/path",
+      query: "query",
+      fragment: "fragment",
+      registry: nil,
+      opaque: nil
+    }
+
+    # gopher
+    gopher = @object.parse('gopher://spinaltap.micro.umn.edu/00/Weather/California/Los%20Angeles')
+    gopher.should be_kind_of(URI::Generic)
+
+    URISpec.components(gopher).should == {
+      scheme: "gopher",
+      userinfo: nil,
+      host: "spinaltap.micro.umn.edu",
+      port: nil,
+      path: "/00/Weather/California/Los%20Angeles",
+      query: nil,
+      fragment: nil,
+      registry: nil,
+      opaque: nil
+    }
+
+    # news
+    news = @object.parse('news:comp.infosystems.www.servers.unix')
+    news.should be_kind_of(URI::Generic)
+    URISpec.components(news).should == {
+      scheme: "news",
+      userinfo: nil,
+      host: nil,
+      port: nil,
+      path: nil,
+      query: nil,
+      fragment: nil,
+      registry: nil,
+      opaque: "comp.infosystems.www.servers.unix"
+    }
+
+    # telnet
+    telnet = @object.parse('telnet://melvyl.ucop.edu/')
+    telnet.should be_kind_of(URI::Generic)
+    URISpec.components(telnet).should == {
+      scheme: "telnet",
+      userinfo: nil,
+      host: "melvyl.ucop.edu",
+      port: nil,
+      path: "/",
+      query: nil,
+      fragment: nil,
+      registry: nil,
+      opaque: nil
+    }
+
+    # files
+    file_l = @object.parse('file:///foo/bar.txt')
+    file_l.should be_kind_of(URI::Generic)
+    file = @object.parse('file:/foo/bar.txt')
+    file.should be_kind_of(URI::Generic)
+  end
+
+  it "raises errors on malformed URIs" do
+    lambda { @object.parse('http://a_b:80/') }.should raise_error(URI::InvalidURIError)
+    lambda { @object.parse('http://a_b/') }.should raise_error(URI::InvalidURIError)
+  end
+end

--- a/mruby/src/extn/stdlib/spec/uri/split_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/split_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../spec_helper'
+require 'uri'
+
+describe "URI.split" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri/uri_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/uri_spec.rb
@@ -1,0 +1,29 @@
+require_relative '../../spec_helper'
+require 'uri'
+
+#the testing is light here as this is an alias for URI.parse
+
+#we're just testing that the method ends up in the right place
+describe "the URI method" do
+  it "parses a given URI, returning a URI object" do
+    result = URI.parse("http://ruby-lang.org")
+    URI("http://ruby-lang.org").should == result
+    Kernel::URI("http://ruby-lang.org").should == result
+  end
+
+  it "converts its argument with to_str" do
+    str = mock('string-like')
+    str.should_receive(:to_str).and_return("http://ruby-lang.org")
+    URI(str).should == URI.parse("http://ruby-lang.org")
+  end
+
+  it "returns the argument if it is a URI object" do
+    result = URI.parse("http://ruby-lang.org")
+    URI(result).should equal(result)
+  end
+
+  #apparently this was a concern?  imported from MRI tests
+  it "does not add a URI method to Object instances" do
+    lambda {Object.new.URI("http://ruby-lang.org/")}.should raise_error(NoMethodError)
+  end
+end

--- a/mruby/src/extn/stdlib/spec/uri/uri_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/uri_spec.rb
@@ -22,8 +22,10 @@ describe "the URI method" do
     URI(result).should equal(result)
   end
 
-  #apparently this was a concern?  imported from MRI tests
-  it "does not add a URI method to Object instances" do
-    lambda {Object.new.URI("http://ruby-lang.org/")}.should raise_error(NoMethodError)
+  not_supported_on :mruby do
+    #apparently this was a concern?  imported from MRI tests
+    it "does not add a URI method to Object instances" do
+      lambda {Object.new.URI("http://ruby-lang.org/")}.should raise_error(NoMethodError)
+    end
   end
 end

--- a/mruby/src/extn/stdlib/spec/uri/util/make_components_hash_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri/util/make_components_hash_spec.rb
@@ -1,0 +1,6 @@
+require_relative '../../../spec_helper'
+require 'uri'
+
+describe "URI::Util.make_components_hash" do
+  it "needs to be reviewed for spec completeness"
+end

--- a/mruby/src/extn/stdlib/spec/uri_doc_spec.rb
+++ b/mruby/src/extn/stdlib/spec/uri_doc_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'uri'
+
+module URI
+  class RSYNC < Generic
+    DEFAULT_PORT = 873
+  end
+  @@schemes['RSYNC'] = RSYNC
+end
+
+describe URI do
+  it 'completes a basic example' do
+    uri = URI('http://foo.com/posts?id=30&limit=5#time=1305298413')
+    uri.inspect.should eql('#<URI::HTTP http://foo.com/posts?id=30&limit=5#time=1305298413>')
+    uri.scheme.should eql('http')
+    uri.host.should eql('foo.com')
+    uri.path.should eql('/posts')
+    uri.query.should eql('id=30&limit=5')
+    uri.fragment.should eql('time=1305298413')
+    uri.to_s.should eql('http://foo.com/posts?id=30&limit=5#time=1305298413')
+  end
+
+  it 'adds custom urls' do
+    expected_scheme_list = {
+      'FILE' => URI::File,
+      'FTP' => URI::FTP,
+      'HTTP' => URI::HTTP,
+      'HTTPS' => URI::HTTPS,
+      'LDAP' => URI::LDAP,
+      'LDAPS' => URI::LDAPS,
+      'MAILTO' => URI::MailTo,
+      'RSYNC' => URI::RSYNC
+    }
+    URI.scheme_list.should eql(expected_scheme_list)
+    uri = URI('rsync://rsync.foo.com')
+    uri.inspect.should eql('#<URI::RSYNC rsync://rsync.foo.com>')
+  end
+
+  it 'URI#decode_www_form' do
+    ary = URI.decode_www_form('a=1&a=2&b=3')
+    ary.should eql([%w[a 1], %w[a 2], %w[b 3]])
+    ary.assoc('a').last.should eql('1')
+    ary.assoc('b').last.should eql('3')
+    # this line fails on YARV
+    # ary.rassoc('a').last.should eql('2')
+    Hash[ary].should eql('a' => '2', 'b' => '3')
+  end
+
+  it 'URI#encode_www_form' do
+    URI.encode_www_form([%w[q ruby], %w[lang en]]).should eql('q=ruby&lang=en')
+    URI.encode_www_form('q' => 'ruby', 'lang' => 'en').should eql('q=ruby&lang=en')
+    URI.encode_www_form('q' => %w[ruby perl], 'lang' => 'en').should eql('q=ruby&q=perl&lang=en')
+    URI.encode_www_form([%w[q ruby], %w[q perl], %w[lang en]]).should eql('q=ruby&q=perl&lang=en')
+  end
+
+  it 'URI#extract' do
+    uris = URI.extract('text here http://foo.example.org/bla and here mailto:test@example.com and here also.')
+    uris.should eql(['http://foo.example.org/bla', 'mailto:test@example.com'])
+  end
+
+  it 'URI#join' do
+    URI.join('http://example.com/', 'main.rbx').inspect.should eql('#<URI::HTTP http://example.com/main.rbx>')
+    URI.join('http://example.com/', 'foo').inspect.should eql('#<URI::HTTP http://example.com/foo>')
+    URI.join('http://example.com/', '/foo', '/bar').inspect.should eql('#<URI::HTTP http://example.com/bar>')
+    URI.join('http://example.com/', '/foo', 'bar').inspect.should eql('#<URI::HTTP http://example.com/bar>')
+    URI.join('http://example.com/', '/foo/', 'bar').inspect.should eql('#<URI::HTTP http://example.com/foo/bar>')
+  end
+
+  it 'URI#parse' do
+    uri = URI.parse('http://www.ruby-lang.org/')
+    uri.inspect.should eql('#<URI::HTTP http://www.ruby-lang.org/>')
+    uri.scheme.should eql('http')
+    uri.host.should eql('www.ruby-lang.org')
+  end
+
+  # it 'URI#regexp' do
+  #   # # extract first URI from html_string
+  #   # html_string.slice(URI.regexp)
+  #   #
+  #   # # remove ftp URIs
+  #   # html_string.sub(URI.regexp(['ftp']), '')
+  #   #
+  #   # # You should not rely on the number of parentheses
+  #   # html_string.scan(URI.regexp) do |*matches|
+  #   #   p $&
+  #   # end
+  # end
+
+  it 'URI#split' do
+    expected_split = ['http', nil, 'www.ruby-lang.org', nil, nil, '/', nil, nil, nil]
+    URI.split('http://www.ruby-lang.org/').should eql(expected_split)
+  end
+end

--- a/mruby/src/extn/stdlib/uri.rb
+++ b/mruby/src/extn/stdlib/uri.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: false
+# URI is a module providing classes to handle Uniform Resource Identifiers
+# (RFC2396[http://tools.ietf.org/html/rfc2396]).
+#
+# == Features
+#
+# * Uniform way of handling URIs.
+# * Flexibility to introduce custom URI schemes.
+# * Flexibility to have an alternate URI::Parser (or just different patterns
+#   and regexp's).
+#
+# == Basic example
+#
+#   require 'uri'
+#
+#   uri = URI("http://foo.com/posts?id=30&limit=5#time=1305298413")
+#   #=> #<URI::HTTP http://foo.com/posts?id=30&limit=5#time=1305298413>
+#
+#   uri.scheme    #=> "http"
+#   uri.host      #=> "foo.com"
+#   uri.path      #=> "/posts"
+#   uri.query     #=> "id=30&limit=5"
+#   uri.fragment  #=> "time=1305298413"
+#
+#   uri.to_s      #=> "http://foo.com/posts?id=30&limit=5#time=1305298413"
+#
+# == Adding custom URIs
+#
+#   module URI
+#     class RSYNC < Generic
+#       DEFAULT_PORT = 873
+#     end
+#     @@schemes['RSYNC'] = RSYNC
+#   end
+#   #=> URI::RSYNC
+#
+#   URI.scheme_list
+#   #=> {"FILE"=>URI::File, "FTP"=>URI::FTP, "HTTP"=>URI::HTTP,
+#   #    "HTTPS"=>URI::HTTPS, "LDAP"=>URI::LDAP, "LDAPS"=>URI::LDAPS,
+#   #    "MAILTO"=>URI::MailTo, "RSYNC"=>URI::RSYNC}
+#
+#   uri = URI("rsync://rsync.foo.com")
+#   #=> #<URI::RSYNC rsync://rsync.foo.com>
+#
+# == RFC References
+#
+# A good place to view an RFC spec is http://www.ietf.org/rfc.html.
+#
+# Here is a list of all related RFC's:
+# - RFC822[http://tools.ietf.org/html/rfc822]
+# - RFC1738[http://tools.ietf.org/html/rfc1738]
+# - RFC2255[http://tools.ietf.org/html/rfc2255]
+# - RFC2368[http://tools.ietf.org/html/rfc2368]
+# - RFC2373[http://tools.ietf.org/html/rfc2373]
+# - RFC2396[http://tools.ietf.org/html/rfc2396]
+# - RFC2732[http://tools.ietf.org/html/rfc2732]
+# - RFC3986[http://tools.ietf.org/html/rfc3986]
+#
+# == Class tree
+#
+# - URI::Generic (in uri/generic.rb)
+#   - URI::File - (in uri/file.rb)
+#   - URI::FTP - (in uri/ftp.rb)
+#   - URI::HTTP - (in uri/http.rb)
+#     - URI::HTTPS - (in uri/https.rb)
+#   - URI::LDAP - (in uri/ldap.rb)
+#     - URI::LDAPS - (in uri/ldaps.rb)
+#   - URI::MailTo - (in uri/mailto.rb)
+# - URI::Parser - (in uri/common.rb)
+# - URI::REGEXP - (in uri/common.rb)
+#   - URI::REGEXP::PATTERN - (in uri/common.rb)
+# - URI::Util - (in uri/common.rb)
+# - URI::Escape - (in uri/common.rb)
+# - URI::Error - (in uri/common.rb)
+#   - URI::InvalidURIError - (in uri/common.rb)
+#   - URI::InvalidComponentError - (in uri/common.rb)
+#   - URI::BadURIError - (in uri/common.rb)
+#
+# == Copyright Info
+#
+# Author:: Akira Yamada <akira@ruby-lang.org>
+# Documentation::
+#   Akira Yamada <akira@ruby-lang.org>
+#   Dmitry V. Sabanin <sdmitry@lrn.ru>
+#   Vincent Batts <vbatts@hashbangbash.com>
+# License::
+#  Copyright (c) 2001 akira yamada <akira@ruby-lang.org>
+#  You can redistribute it and/or modify it under the same term as Ruby.
+# Revision:: $Id$
+#
+
+module URI
+  # :stopdoc:
+  VERSION_CODE = '001000'.freeze
+  VERSION = VERSION_CODE.scan(/../).collect{|n| n.to_i}.join('.').freeze
+  # :startdoc:
+
+end
+
+require 'uri/common'
+require 'uri/generic'
+require 'uri/file'
+require 'uri/ftp'
+require 'uri/http'
+require 'uri/https'
+require 'uri/ldap'
+require 'uri/ldaps'
+require 'uri/mailto'

--- a/mruby/src/extn/stdlib/uri.rs
+++ b/mruby/src/extn/stdlib/uri.rs
@@ -26,18 +26,34 @@ pub fn init(interp: &Mrb) -> Result<(), MrbError> {
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
+
     use crate::extn::test::mspec::MSpec;
     use crate::interpreter::Interpreter;
 
-    // URI tests from Ruby stdlib docs
-    // https://ruby-doc.org/stdlib-2.6.3/libdoc/uri/rdoc/URI.html
+    #[derive(RustEmbed)]
+    #[folder = "mruby/src/extn/stdlib/spec/uri/"]
+    pub struct Specs;
+
     #[test]
-    fn uri_spec() {
+    fn uri_doc_spec() {
         let interp = Interpreter::create().expect("mrb init");
         let mut runner = MSpec::runner(interp);
         runner
             .add_spec("uri_doc_spec.rb", include_str!("spec/uri_doc_spec.rb"))
             .unwrap();
+        runner.run();
+    }
+
+    #[test]
+    fn uri_ruby_spec() {
+        let interp = Interpreter::create().expect("mrb init");
+        let mut runner = MSpec::runner(interp);
+        for source in Specs::iter() {
+            let content = Specs::get(&source).map(Cow::into_owned).unwrap();
+            let source = format!("uri/{}", source);
+            runner.add_spec(&source, content).unwrap();
+        }
         runner.run();
     }
 }

--- a/mruby/src/extn/stdlib/uri.rs
+++ b/mruby/src/extn/stdlib/uri.rs
@@ -13,7 +13,31 @@ pub fn init(interp: &Mrb) -> Result<(), MrbError> {
     interp.def_rb_source_file("uri/ldap.rb", include_str!("uri/ldap.rb"))?;
     interp.def_rb_source_file("uri/ldaps.rb", include_str!("uri/ldaps.rb"))?;
     interp.def_rb_source_file("uri/mailto.rb", include_str!("uri/mailto.rb"))?;
-    interp.def_rb_source_file("uri/rfc2396_parser.rb", include_str!("uri/rfc2396_parser.rb"))?;
-    interp.def_rb_source_file("uri/rfc3986_parser.rb", include_str!("uri/rfc3986_parser.rb"))?;
+    interp.def_rb_source_file(
+        "uri/rfc2396_parser.rb",
+        include_str!("uri/rfc2396_parser.rb"),
+    )?;
+    interp.def_rb_source_file(
+        "uri/rfc3986_parser.rb",
+        include_str!("uri/rfc3986_parser.rb"),
+    )?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::extn::test::mspec::MSpec;
+    use crate::interpreter::Interpreter;
+
+    // URI tests from Ruby stdlib docs
+    // https://ruby-doc.org/stdlib-2.6.3/libdoc/uri/rdoc/URI.html
+    #[test]
+    fn uri_spec() {
+        let interp = Interpreter::create().expect("mrb init");
+        let mut runner = MSpec::runner(interp);
+        runner
+            .add_spec("uri_doc_spec.rb", include_str!("spec/uri_doc_spec.rb"))
+            .unwrap();
+        runner.run();
+    }
 }

--- a/mruby/src/extn/stdlib/uri.rs
+++ b/mruby/src/extn/stdlib/uri.rs
@@ -1,0 +1,19 @@
+use crate::interpreter::Mrb;
+use crate::load::MrbLoadSources;
+use crate::MrbError;
+
+pub fn init(interp: &Mrb) -> Result<(), MrbError> {
+    interp.def_rb_source_file("uri.rb", include_str!("uri.rb"))?;
+    interp.def_rb_source_file("uri/common.rb", include_str!("uri/common.rb"))?;
+    interp.def_rb_source_file("uri/file.rb", include_str!("uri/file.rb"))?;
+    interp.def_rb_source_file("uri/ftp.rb", include_str!("uri/ftp.rb"))?;
+    interp.def_rb_source_file("uri/generic.rb", include_str!("uri/generic.rb"))?;
+    interp.def_rb_source_file("uri/http.rb", include_str!("uri/http.rb"))?;
+    interp.def_rb_source_file("uri/https.rb", include_str!("uri/https.rb"))?;
+    interp.def_rb_source_file("uri/ldap.rb", include_str!("uri/ldap.rb"))?;
+    interp.def_rb_source_file("uri/ldaps.rb", include_str!("uri/ldaps.rb"))?;
+    interp.def_rb_source_file("uri/mailto.rb", include_str!("uri/mailto.rb"))?;
+    interp.def_rb_source_file("uri/rfc2396_parser.rb", include_str!("uri/rfc2396_parser.rb"))?;
+    interp.def_rb_source_file("uri/rfc3986_parser.rb", include_str!("uri/rfc3986_parser.rb"))?;
+    Ok(())
+}

--- a/mruby/src/extn/stdlib/uri/common.rb
+++ b/mruby/src/extn/stdlib/uri/common.rb
@@ -1,0 +1,744 @@
+# frozen_string_literal: true
+#--
+# = uri/common.rb
+#
+# Author:: Akira Yamada <akira@ruby-lang.org>
+# Revision:: $Id$
+# License::
+#   You can redistribute it and/or modify it under the same term as Ruby.
+#
+# See URI for general documentation
+#
+
+require_relative "rfc2396_parser"
+require_relative "rfc3986_parser"
+
+module URI
+  REGEXP = RFC2396_REGEXP
+  Parser = RFC2396_Parser
+  RFC3986_PARSER = RFC3986_Parser.new
+
+  # URI::Parser.new
+  DEFAULT_PARSER = Parser.new
+  DEFAULT_PARSER.pattern.each_pair do |sym, str|
+    unless REGEXP::PATTERN.const_defined?(sym)
+      REGEXP::PATTERN.const_set(sym, str)
+    end
+  end
+  DEFAULT_PARSER.regexp.each_pair do |sym, str|
+    const_set(sym, str)
+  end
+
+  module Util # :nodoc:
+    def make_components_hash(klass, array_hash)
+      tmp = {}
+      if array_hash.kind_of?(Array) &&
+          array_hash.size == klass.component.size - 1
+        klass.component[1..-1].each_index do |i|
+          begin
+            tmp[klass.component[i + 1]] = array_hash[i].clone
+          rescue TypeError
+            tmp[klass.component[i + 1]] = array_hash[i]
+          end
+        end
+
+      elsif array_hash.kind_of?(Hash)
+        array_hash.each do |key, value|
+          begin
+            tmp[key] = value.clone
+          rescue TypeError
+            tmp[key] = value
+          end
+        end
+      else
+        raise ArgumentError,
+          "expected Array of or Hash of components of #{klass} (#{klass.component[1..-1].join(', ')})"
+      end
+      tmp[:scheme] = klass.to_s.sub(/\A.*::/, '').downcase
+
+      return tmp
+    end
+    module_function :make_components_hash
+  end
+
+  # Module for escaping unsafe characters with codes.
+  module Escape
+    #
+    # == Synopsis
+    #
+    #   URI.escape(str [, unsafe])
+    #
+    # == Args
+    #
+    # +str+::
+    #   String to replaces in.
+    # +unsafe+::
+    #   Regexp that matches all symbols that must be replaced with codes.
+    #   By default uses <tt>UNSAFE</tt>.
+    #   When this argument is a String, it represents a character set.
+    #
+    # == Description
+    #
+    # Escapes the string, replacing all unsafe characters with codes.
+    #
+    # This method is obsolete and should not be used. Instead, use
+    # CGI.escape, URI.encode_www_form or URI.encode_www_form_component
+    # depending on your specific use case.
+    #
+    # == Usage
+    #
+    #   require 'uri'
+    #
+    #   enc_uri = URI.escape("http://example.com/?a=\11\15")
+    #   # => "http://example.com/?a=%09%0D"
+    #
+    #   URI.unescape(enc_uri)
+    #   # => "http://example.com/?a=\t\r"
+    #
+    #   URI.escape("@?@!", "!?")
+    #   # => "@%3F@%21"
+    #
+    def escape(*arg)
+      warn "URI.escape is obsolete", uplevel: 1 if $VERBOSE
+      DEFAULT_PARSER.escape(*arg)
+    end
+    alias encode escape
+    #
+    # == Synopsis
+    #
+    #   URI.unescape(str)
+    #
+    # == Args
+    #
+    # +str+::
+    #   String to unescape.
+    #
+    # == Description
+    #
+    # This method is obsolete and should not be used. Instead, use
+    # CGI.unescape, URI.decode_www_form or URI.decode_www_form_component
+    # depending on your specific use case.
+    #
+    # == Usage
+    #
+    #   require 'uri'
+    #
+    #   enc_uri = URI.escape("http://example.com/?a=\11\15")
+    #   # => "http://example.com/?a=%09%0D"
+    #
+    #   URI.unescape(enc_uri)
+    #   # => "http://example.com/?a=\t\r"
+    #
+    def unescape(*arg)
+      warn "URI.unescape is obsolete", uplevel: 1 if $VERBOSE
+      DEFAULT_PARSER.unescape(*arg)
+    end
+    alias decode unescape
+  end # module Escape
+
+  extend Escape
+  include REGEXP
+
+  @@schemes = {}
+  # Returns a Hash of the defined schemes.
+  def self.scheme_list
+    @@schemes
+  end
+
+  #
+  # Base class for all URI exceptions.
+  #
+  class Error < StandardError; end
+  #
+  # Not a URI.
+  #
+  class InvalidURIError < Error; end
+  #
+  # Not a URI component.
+  #
+  class InvalidComponentError < Error; end
+  #
+  # URI is valid, bad usage is not.
+  #
+  class BadURIError < Error; end
+
+  #
+  # == Synopsis
+  #
+  #   URI::split(uri)
+  #
+  # == Args
+  #
+  # +uri+::
+  #   String with URI.
+  #
+  # == Description
+  #
+  # Splits the string on following parts and returns array with result:
+  #
+  # * Scheme
+  # * Userinfo
+  # * Host
+  # * Port
+  # * Registry
+  # * Path
+  # * Opaque
+  # * Query
+  # * Fragment
+  #
+  # == Usage
+  #
+  #   require 'uri'
+  #
+  #   URI.split("http://www.ruby-lang.org/")
+  #   # => ["http", nil, "www.ruby-lang.org", nil, nil, "/", nil, nil, nil]
+  #
+  def self.split(uri)
+    RFC3986_PARSER.split(uri)
+  end
+
+  #
+  # == Synopsis
+  #
+  #   URI::parse(uri_str)
+  #
+  # == Args
+  #
+  # +uri_str+::
+  #   String with URI.
+  #
+  # == Description
+  #
+  # Creates one of the URI's subclasses instance from the string.
+  #
+  # == Raises
+  #
+  # URI::InvalidURIError::
+  #   Raised if URI given is not a correct one.
+  #
+  # == Usage
+  #
+  #   require 'uri'
+  #
+  #   uri = URI.parse("http://www.ruby-lang.org/")
+  #   # => #<URI::HTTP http://www.ruby-lang.org/>
+  #   uri.scheme
+  #   # => "http"
+  #   uri.host
+  #   # => "www.ruby-lang.org"
+  #
+  # It's recommended to first ::escape the provided +uri_str+ if there are any
+  # invalid URI characters.
+  #
+  def self.parse(uri)
+    RFC3986_PARSER.parse(uri)
+  end
+
+  #
+  # == Synopsis
+  #
+  #   URI::join(str[, str, ...])
+  #
+  # == Args
+  #
+  # +str+::
+  #   String(s) to work with, will be converted to RFC3986 URIs before merging.
+  #
+  # == Description
+  #
+  # Joins URIs.
+  #
+  # == Usage
+  #
+  #   require 'uri'
+  #
+  #   URI.join("http://example.com/","main.rbx")
+  #   # => #<URI::HTTP http://example.com/main.rbx>
+  #
+  #   URI.join('http://example.com', 'foo')
+  #   # => #<URI::HTTP http://example.com/foo>
+  #
+  #   URI.join('http://example.com', '/foo', '/bar')
+  #   # => #<URI::HTTP http://example.com/bar>
+  #
+  #   URI.join('http://example.com', '/foo', 'bar')
+  #   # => #<URI::HTTP http://example.com/bar>
+  #
+  #   URI.join('http://example.com', '/foo/', 'bar')
+  #   # => #<URI::HTTP http://example.com/foo/bar>
+  #
+  def self.join(*str)
+    RFC3986_PARSER.join(*str)
+  end
+
+  #
+  # == Synopsis
+  #
+  #   URI::extract(str[, schemes][,&blk])
+  #
+  # == Args
+  #
+  # +str+::
+  #   String to extract URIs from.
+  # +schemes+::
+  #   Limit URI matching to specific schemes.
+  #
+  # == Description
+  #
+  # Extracts URIs from a string. If block given, iterates through all matched URIs.
+  # Returns nil if block given or array with matches.
+  #
+  # == Usage
+  #
+  #   require "uri"
+  #
+  #   URI.extract("text here http://foo.example.org/bla and here mailto:test@example.com and here also.")
+  #   # => ["http://foo.example.com/bla", "mailto:test@example.com"]
+  #
+  def self.extract(str, schemes = nil, &block)
+    warn "URI.extract is obsolete", uplevel: 1 if $VERBOSE
+    DEFAULT_PARSER.extract(str, schemes, &block)
+  end
+
+  #
+  # == Synopsis
+  #
+  #   URI::regexp([match_schemes])
+  #
+  # == Args
+  #
+  # +match_schemes+::
+  #   Array of schemes. If given, resulting regexp matches to URIs
+  #   whose scheme is one of the match_schemes.
+  #
+  # == Description
+  #
+  # Returns a Regexp object which matches to URI-like strings.
+  # The Regexp object returned by this method includes arbitrary
+  # number of capture group (parentheses).  Never rely on it's number.
+  #
+  # == Usage
+  #
+  #   require 'uri'
+  #
+  #   # extract first URI from html_string
+  #   html_string.slice(URI.regexp)
+  #
+  #   # remove ftp URIs
+  #   html_string.sub(URI.regexp(['ftp']), '')
+  #
+  #   # You should not rely on the number of parentheses
+  #   html_string.scan(URI.regexp) do |*matches|
+  #     p $&
+  #   end
+  #
+  def self.regexp(schemes = nil)
+    warn "URI.regexp is obsolete", uplevel: 1 if $VERBOSE
+    DEFAULT_PARSER.make_regexp(schemes)
+  end
+
+  TBLENCWWWCOMP_ = {} # :nodoc:
+  256.times do |i|
+    TBLENCWWWCOMP_[-i.chr] = -('%%%02X' % i)
+  end
+  TBLENCWWWCOMP_[' '] = '+'
+  TBLENCWWWCOMP_.freeze
+  TBLDECWWWCOMP_ = {} # :nodoc:
+  256.times do |i|
+    h, l = i>>4, i&15
+    TBLDECWWWCOMP_[-('%%%X%X' % [h, l])] = -i.chr
+    TBLDECWWWCOMP_[-('%%%x%X' % [h, l])] = -i.chr
+    TBLDECWWWCOMP_[-('%%%X%x' % [h, l])] = -i.chr
+    TBLDECWWWCOMP_[-('%%%x%x' % [h, l])] = -i.chr
+  end
+  TBLDECWWWCOMP_['+'] = ' '
+  TBLDECWWWCOMP_.freeze
+
+  # Encodes given +str+ to URL-encoded form data.
+  #
+  # This method doesn't convert *, -, ., 0-9, A-Z, _, a-z, but does convert SP
+  # (ASCII space) to + and converts others to %XX.
+  #
+  # If +enc+ is given, convert +str+ to the encoding before percent encoding.
+  #
+  # This is an implementation of
+  # http://www.w3.org/TR/2013/CR-html5-20130806/forms.html#url-encoded-form-data.
+  #
+  # See URI.decode_www_form_component, URI.encode_www_form.
+  def self.encode_www_form_component(str, enc=nil)
+    str = str.to_s.dup
+    if str.encoding != Encoding::ASCII_8BIT
+      if enc && enc != Encoding::ASCII_8BIT
+        str.encode!(Encoding::UTF_8, invalid: :replace, undef: :replace)
+        str.encode!(enc, fallback: ->(x){"&#{x.ord};"})
+      end
+      str.force_encoding(Encoding::ASCII_8BIT)
+    end
+    str.gsub!(/[^*\-.0-9A-Z_a-z]/, TBLENCWWWCOMP_)
+    str.force_encoding(Encoding::US_ASCII)
+  end
+
+  # Decodes given +str+ of URL-encoded form data.
+  #
+  # This decodes + to SP.
+  #
+  # See URI.encode_www_form_component, URI.decode_www_form.
+  def self.decode_www_form_component(str, enc=Encoding::UTF_8)
+    raise ArgumentError, "invalid %-encoding (#{str})" if /%(?!\h\h)/ =~ str
+    str.b.gsub(/\+|%\h\h/, TBLDECWWWCOMP_).force_encoding(enc)
+  end
+
+  # Generates URL-encoded form data from given +enum+.
+  #
+  # This generates application/x-www-form-urlencoded data defined in HTML5
+  # from given an Enumerable object.
+  #
+  # This internally uses URI.encode_www_form_component(str).
+  #
+  # This method doesn't convert the encoding of given items, so convert them
+  # before calling this method if you want to send data as other than original
+  # encoding or mixed encoding data. (Strings which are encoded in an HTML5
+  # ASCII incompatible encoding are converted to UTF-8.)
+  #
+  # This method doesn't handle files.  When you send a file, use
+  # multipart/form-data.
+  #
+  # This refers http://url.spec.whatwg.org/#concept-urlencoded-serializer
+  #
+  #    URI.encode_www_form([["q", "ruby"], ["lang", "en"]])
+  #    #=> "q=ruby&lang=en"
+  #    URI.encode_www_form("q" => "ruby", "lang" => "en")
+  #    #=> "q=ruby&lang=en"
+  #    URI.encode_www_form("q" => ["ruby", "perl"], "lang" => "en")
+  #    #=> "q=ruby&q=perl&lang=en"
+  #    URI.encode_www_form([["q", "ruby"], ["q", "perl"], ["lang", "en"]])
+  #    #=> "q=ruby&q=perl&lang=en"
+  #
+  # See URI.encode_www_form_component, URI.decode_www_form.
+  def self.encode_www_form(enum, enc=nil)
+    enum.map do |k,v|
+      if v.nil?
+        encode_www_form_component(k, enc)
+      elsif v.respond_to?(:to_ary)
+        v.to_ary.map do |w|
+          str = encode_www_form_component(k, enc)
+          unless w.nil?
+            str << '='
+            str << encode_www_form_component(w, enc)
+          end
+        end.join('&')
+      else
+        str = encode_www_form_component(k, enc)
+        str << '='
+        str << encode_www_form_component(v, enc)
+      end
+    end.join('&')
+  end
+
+  # Decodes URL-encoded form data from given +str+.
+  #
+  # This decodes application/x-www-form-urlencoded data
+  # and returns an array of key-value arrays.
+  #
+  # This refers http://url.spec.whatwg.org/#concept-urlencoded-parser,
+  # so this supports only &-separator, and doesn't support ;-separator.
+  #
+  #    ary = URI.decode_www_form("a=1&a=2&b=3")
+  #    ary                   #=> [['a', '1'], ['a', '2'], ['b', '3']]
+  #    ary.assoc('a').last   #=> '1'
+  #    ary.assoc('b').last   #=> '3'
+  #    ary.rassoc('a').last  #=> '2'
+  #    Hash[ary]             #=> {"a"=>"2", "b"=>"3"}
+  #
+  # See URI.decode_www_form_component, URI.encode_www_form.
+  def self.decode_www_form(str, enc=Encoding::UTF_8, separator: '&', use__charset_: false, isindex: false)
+    raise ArgumentError, "the input of #{self.name}.#{__method__} must be ASCII only string" unless str.ascii_only?
+    ary = []
+    return ary if str.empty?
+    enc = Encoding.find(enc)
+    str.b.each_line(separator) do |string|
+      string.chomp!(separator)
+      key, sep, val = string.partition('=')
+      if isindex
+        if sep.empty?
+          val = key
+          key = +''
+        end
+        isindex = false
+      end
+
+      if use__charset_ and key == '_charset_' and e = get_encoding(val)
+        enc = e
+        use__charset_ = false
+      end
+
+      key.gsub!(/\+|%\h\h/, TBLDECWWWCOMP_)
+      if val
+        val.gsub!(/\+|%\h\h/, TBLDECWWWCOMP_)
+      else
+        val = +''
+      end
+
+      ary << [key, val]
+    end
+    ary.each do |k, v|
+      k.force_encoding(enc)
+      k.scrub!
+      v.force_encoding(enc)
+      v.scrub!
+    end
+    ary
+  end
+
+  private
+=begin command for WEB_ENCODINGS_
+  curl https://encoding.spec.whatwg.org/encodings.json|
+  ruby -rjson -e 'H={}
+  h={
+    "shift_jis"=>"Windows-31J",
+    "euc-jp"=>"cp51932",
+    "iso-2022-jp"=>"cp50221",
+    "x-mac-cyrillic"=>"macCyrillic",
+  }
+  JSON($<.read).map{|x|x["encodings"]}.flatten.each{|x|
+    Encoding.find(n=h.fetch(n=x["name"].downcase,n))rescue next
+    x["labels"].each{|y|H[y]=n}
+  }
+  puts "{"
+  H.each{|k,v|puts %[  #{k.dump}=>#{v.dump},]}
+  puts "}"
+'
+=end
+  WEB_ENCODINGS_ = {
+    "unicode-1-1-utf-8"=>"utf-8",
+    "utf-8"=>"utf-8",
+    "utf8"=>"utf-8",
+    "866"=>"ibm866",
+    "cp866"=>"ibm866",
+    "csibm866"=>"ibm866",
+    "ibm866"=>"ibm866",
+    "csisolatin2"=>"iso-8859-2",
+    "iso-8859-2"=>"iso-8859-2",
+    "iso-ir-101"=>"iso-8859-2",
+    "iso8859-2"=>"iso-8859-2",
+    "iso88592"=>"iso-8859-2",
+    "iso_8859-2"=>"iso-8859-2",
+    "iso_8859-2:1987"=>"iso-8859-2",
+    "l2"=>"iso-8859-2",
+    "latin2"=>"iso-8859-2",
+    "csisolatin3"=>"iso-8859-3",
+    "iso-8859-3"=>"iso-8859-3",
+    "iso-ir-109"=>"iso-8859-3",
+    "iso8859-3"=>"iso-8859-3",
+    "iso88593"=>"iso-8859-3",
+    "iso_8859-3"=>"iso-8859-3",
+    "iso_8859-3:1988"=>"iso-8859-3",
+    "l3"=>"iso-8859-3",
+    "latin3"=>"iso-8859-3",
+    "csisolatin4"=>"iso-8859-4",
+    "iso-8859-4"=>"iso-8859-4",
+    "iso-ir-110"=>"iso-8859-4",
+    "iso8859-4"=>"iso-8859-4",
+    "iso88594"=>"iso-8859-4",
+    "iso_8859-4"=>"iso-8859-4",
+    "iso_8859-4:1988"=>"iso-8859-4",
+    "l4"=>"iso-8859-4",
+    "latin4"=>"iso-8859-4",
+    "csisolatincyrillic"=>"iso-8859-5",
+    "cyrillic"=>"iso-8859-5",
+    "iso-8859-5"=>"iso-8859-5",
+    "iso-ir-144"=>"iso-8859-5",
+    "iso8859-5"=>"iso-8859-5",
+    "iso88595"=>"iso-8859-5",
+    "iso_8859-5"=>"iso-8859-5",
+    "iso_8859-5:1988"=>"iso-8859-5",
+    "arabic"=>"iso-8859-6",
+    "asmo-708"=>"iso-8859-6",
+    "csiso88596e"=>"iso-8859-6",
+    "csiso88596i"=>"iso-8859-6",
+    "csisolatinarabic"=>"iso-8859-6",
+    "ecma-114"=>"iso-8859-6",
+    "iso-8859-6"=>"iso-8859-6",
+    "iso-8859-6-e"=>"iso-8859-6",
+    "iso-8859-6-i"=>"iso-8859-6",
+    "iso-ir-127"=>"iso-8859-6",
+    "iso8859-6"=>"iso-8859-6",
+    "iso88596"=>"iso-8859-6",
+    "iso_8859-6"=>"iso-8859-6",
+    "iso_8859-6:1987"=>"iso-8859-6",
+    "csisolatingreek"=>"iso-8859-7",
+    "ecma-118"=>"iso-8859-7",
+    "elot_928"=>"iso-8859-7",
+    "greek"=>"iso-8859-7",
+    "greek8"=>"iso-8859-7",
+    "iso-8859-7"=>"iso-8859-7",
+    "iso-ir-126"=>"iso-8859-7",
+    "iso8859-7"=>"iso-8859-7",
+    "iso88597"=>"iso-8859-7",
+    "iso_8859-7"=>"iso-8859-7",
+    "iso_8859-7:1987"=>"iso-8859-7",
+    "sun_eu_greek"=>"iso-8859-7",
+    "csiso88598e"=>"iso-8859-8",
+    "csisolatinhebrew"=>"iso-8859-8",
+    "hebrew"=>"iso-8859-8",
+    "iso-8859-8"=>"iso-8859-8",
+    "iso-8859-8-e"=>"iso-8859-8",
+    "iso-ir-138"=>"iso-8859-8",
+    "iso8859-8"=>"iso-8859-8",
+    "iso88598"=>"iso-8859-8",
+    "iso_8859-8"=>"iso-8859-8",
+    "iso_8859-8:1988"=>"iso-8859-8",
+    "visual"=>"iso-8859-8",
+    "csisolatin6"=>"iso-8859-10",
+    "iso-8859-10"=>"iso-8859-10",
+    "iso-ir-157"=>"iso-8859-10",
+    "iso8859-10"=>"iso-8859-10",
+    "iso885910"=>"iso-8859-10",
+    "l6"=>"iso-8859-10",
+    "latin6"=>"iso-8859-10",
+    "iso-8859-13"=>"iso-8859-13",
+    "iso8859-13"=>"iso-8859-13",
+    "iso885913"=>"iso-8859-13",
+    "iso-8859-14"=>"iso-8859-14",
+    "iso8859-14"=>"iso-8859-14",
+    "iso885914"=>"iso-8859-14",
+    "csisolatin9"=>"iso-8859-15",
+    "iso-8859-15"=>"iso-8859-15",
+    "iso8859-15"=>"iso-8859-15",
+    "iso885915"=>"iso-8859-15",
+    "iso_8859-15"=>"iso-8859-15",
+    "l9"=>"iso-8859-15",
+    "iso-8859-16"=>"iso-8859-16",
+    "cskoi8r"=>"koi8-r",
+    "koi"=>"koi8-r",
+    "koi8"=>"koi8-r",
+    "koi8-r"=>"koi8-r",
+    "koi8_r"=>"koi8-r",
+    "koi8-ru"=>"koi8-u",
+    "koi8-u"=>"koi8-u",
+    "dos-874"=>"windows-874",
+    "iso-8859-11"=>"windows-874",
+    "iso8859-11"=>"windows-874",
+    "iso885911"=>"windows-874",
+    "tis-620"=>"windows-874",
+    "windows-874"=>"windows-874",
+    "cp1250"=>"windows-1250",
+    "windows-1250"=>"windows-1250",
+    "x-cp1250"=>"windows-1250",
+    "cp1251"=>"windows-1251",
+    "windows-1251"=>"windows-1251",
+    "x-cp1251"=>"windows-1251",
+    "ansi_x3.4-1968"=>"windows-1252",
+    "ascii"=>"windows-1252",
+    "cp1252"=>"windows-1252",
+    "cp819"=>"windows-1252",
+    "csisolatin1"=>"windows-1252",
+    "ibm819"=>"windows-1252",
+    "iso-8859-1"=>"windows-1252",
+    "iso-ir-100"=>"windows-1252",
+    "iso8859-1"=>"windows-1252",
+    "iso88591"=>"windows-1252",
+    "iso_8859-1"=>"windows-1252",
+    "iso_8859-1:1987"=>"windows-1252",
+    "l1"=>"windows-1252",
+    "latin1"=>"windows-1252",
+    "us-ascii"=>"windows-1252",
+    "windows-1252"=>"windows-1252",
+    "x-cp1252"=>"windows-1252",
+    "cp1253"=>"windows-1253",
+    "windows-1253"=>"windows-1253",
+    "x-cp1253"=>"windows-1253",
+    "cp1254"=>"windows-1254",
+    "csisolatin5"=>"windows-1254",
+    "iso-8859-9"=>"windows-1254",
+    "iso-ir-148"=>"windows-1254",
+    "iso8859-9"=>"windows-1254",
+    "iso88599"=>"windows-1254",
+    "iso_8859-9"=>"windows-1254",
+    "iso_8859-9:1989"=>"windows-1254",
+    "l5"=>"windows-1254",
+    "latin5"=>"windows-1254",
+    "windows-1254"=>"windows-1254",
+    "x-cp1254"=>"windows-1254",
+    "cp1255"=>"windows-1255",
+    "windows-1255"=>"windows-1255",
+    "x-cp1255"=>"windows-1255",
+    "cp1256"=>"windows-1256",
+    "windows-1256"=>"windows-1256",
+    "x-cp1256"=>"windows-1256",
+    "cp1257"=>"windows-1257",
+    "windows-1257"=>"windows-1257",
+    "x-cp1257"=>"windows-1257",
+    "cp1258"=>"windows-1258",
+    "windows-1258"=>"windows-1258",
+    "x-cp1258"=>"windows-1258",
+    "x-mac-cyrillic"=>"macCyrillic",
+    "x-mac-ukrainian"=>"macCyrillic",
+    "chinese"=>"gbk",
+    "csgb2312"=>"gbk",
+    "csiso58gb231280"=>"gbk",
+    "gb2312"=>"gbk",
+    "gb_2312"=>"gbk",
+    "gb_2312-80"=>"gbk",
+    "gbk"=>"gbk",
+    "iso-ir-58"=>"gbk",
+    "x-gbk"=>"gbk",
+    "gb18030"=>"gb18030",
+    "big5"=>"big5",
+    "big5-hkscs"=>"big5",
+    "cn-big5"=>"big5",
+    "csbig5"=>"big5",
+    "x-x-big5"=>"big5",
+    "cseucpkdfmtjapanese"=>"cp51932",
+    "euc-jp"=>"cp51932",
+    "x-euc-jp"=>"cp51932",
+    "csiso2022jp"=>"cp50221",
+    "iso-2022-jp"=>"cp50221",
+    "csshiftjis"=>"Windows-31J",
+    "ms932"=>"Windows-31J",
+    "ms_kanji"=>"Windows-31J",
+    "shift-jis"=>"Windows-31J",
+    "shift_jis"=>"Windows-31J",
+    "sjis"=>"Windows-31J",
+    "windows-31j"=>"Windows-31J",
+    "x-sjis"=>"Windows-31J",
+    "cseuckr"=>"euc-kr",
+    "csksc56011987"=>"euc-kr",
+    "euc-kr"=>"euc-kr",
+    "iso-ir-149"=>"euc-kr",
+    "korean"=>"euc-kr",
+    "ks_c_5601-1987"=>"euc-kr",
+    "ks_c_5601-1989"=>"euc-kr",
+    "ksc5601"=>"euc-kr",
+    "ksc_5601"=>"euc-kr",
+    "windows-949"=>"euc-kr",
+    "utf-16be"=>"utf-16be",
+    "utf-16"=>"utf-16le",
+    "utf-16le"=>"utf-16le",
+  } # :nodoc:
+
+  # :nodoc:
+  # return encoding or nil
+  # http://encoding.spec.whatwg.org/#concept-encoding-get
+  def self.get_encoding(label)
+    Encoding.find(WEB_ENCODINGS_[label.to_str.strip.downcase]) rescue nil
+  end
+end # module URI
+
+module Kernel
+
+  #
+  # Returns +uri+ converted to an URI object.
+  #
+  def URI(uri)
+    if uri.is_a?(URI::Generic)
+      uri
+    elsif uri = String.try_convert(uri)
+      URI.parse(uri)
+    else
+      raise ArgumentError,
+        "bad argument (expected URI object or URI string)"
+    end
+  end
+  module_function :URI
+end

--- a/mruby/src/extn/stdlib/uri/file.rb
+++ b/mruby/src/extn/stdlib/uri/file.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require_relative 'generic'
+
+module URI
+
+  #
+  # The "file" URI is defined by RFC8089.
+  #
+  class File < Generic
+    # A Default port of nil for URI::File.
+    DEFAULT_PORT = nil
+
+    #
+    # An Array of the available components for URI::File.
+    #
+    COMPONENT = [
+      :scheme,
+      :host,
+      :path
+    ].freeze
+
+    #
+    # == Description
+    #
+    # Creates a new URI::File object from components, with syntax checking.
+    #
+    # The components accepted are +host+ and +path+.
+    #
+    # The components should be provided either as an Array, or as a Hash
+    # with keys formed by preceding the component names with a colon.
+    #
+    # If an Array is used, the components must be passed in the
+    # order <code>[host, path]</code>.
+    #
+    # Examples:
+    #
+    #     require 'uri'
+    #
+    #     uri1 = URI::File.build(['host.example.com', '/path/file.zip'])
+    #     uri1.to_s  # => "file://host.example.com/path/file.zip"
+    #
+    #     uri2 = URI::File.build({:host => 'host.example.com',
+    #       :path => '/ruby/src'})
+    #     uri2.to_s  # => "file://host.example.com/ruby/src"
+    #
+    def self.build(args)
+      tmp = Util::make_components_hash(self, args)
+      super(tmp)
+    end
+
+    # Protected setter for the host component +v+.
+    #
+    # See also URI::Generic.host=.
+    #
+    def set_host(v)
+      v = "" if v.nil? || v == "localhost"
+      @host = v
+    end
+
+    # do nothing
+    def set_port(v)
+    end
+
+    # raise InvalidURIError
+    def check_userinfo(user)
+      raise URI::InvalidURIError, "can not set userinfo for file URI"
+    end
+
+    # raise InvalidURIError
+    def check_user(user)
+      raise URI::InvalidURIError, "can not set user for file URI"
+    end
+
+    # raise InvalidURIError
+    def check_password(user)
+      raise URI::InvalidURIError, "can not set password for file URI"
+    end
+
+    # do nothing
+    def set_userinfo(v)
+    end
+
+    # do nothing
+    def set_user(v)
+    end
+
+    # do nothing
+    def set_password(v)
+    end
+  end
+
+  @@schemes['FILE'] = File
+end

--- a/mruby/src/extn/stdlib/uri/ftp.rb
+++ b/mruby/src/extn/stdlib/uri/ftp.rb
@@ -1,0 +1,267 @@
+# frozen_string_literal: false
+# = uri/ftp.rb
+#
+# Author:: Akira Yamada <akira@ruby-lang.org>
+# License:: You can redistribute it and/or modify it under the same term as Ruby.
+# Revision:: $Id$
+#
+# See URI for general documentation
+#
+
+require_relative 'generic'
+
+module URI
+
+  #
+  # FTP URI syntax is defined by RFC1738 section 3.2.
+  #
+  # This class will be redesigned because of difference of implementations;
+  # the structure of its path. draft-hoffman-ftp-uri-04 is a draft but it
+  # is a good summary about the de facto spec.
+  # http://tools.ietf.org/html/draft-hoffman-ftp-uri-04
+  #
+  class FTP < Generic
+    # A Default port of 21 for URI::FTP.
+    DEFAULT_PORT = 21
+
+    #
+    # An Array of the available components for URI::FTP.
+    #
+    COMPONENT = [
+      :scheme,
+      :userinfo, :host, :port,
+      :path, :typecode
+    ].freeze
+
+    #
+    # Typecode is "a", "i", or "d".
+    #
+    # * "a" indicates a text file (the FTP command was ASCII)
+    # * "i" indicates a binary file (FTP command IMAGE)
+    # * "d" indicates the contents of a directory should be displayed
+    #
+    TYPECODE = ['a', 'i', 'd'].freeze
+
+    # Typecode prefix ";type=".
+    TYPECODE_PREFIX = ';type='.freeze
+
+    def self.new2(user, password, host, port, path,
+                  typecode = nil, arg_check = true) # :nodoc:
+      # Do not use this method!  Not tested.  [Bug #7301]
+      # This methods remains just for compatibility,
+      # Keep it undocumented until the active maintainer is assigned.
+      typecode = nil if typecode.size == 0
+      if typecode && !TYPECODE.include?(typecode)
+        raise ArgumentError,
+          "bad typecode is specified: #{typecode}"
+      end
+
+      # do escape
+
+      self.new('ftp',
+               [user, password],
+               host, port, nil,
+               typecode ? path + TYPECODE_PREFIX + typecode : path,
+               nil, nil, nil, arg_check)
+    end
+
+    #
+    # == Description
+    #
+    # Creates a new URI::FTP object from components, with syntax checking.
+    #
+    # The components accepted are +userinfo+, +host+, +port+, +path+, and
+    # +typecode+.
+    #
+    # The components should be provided either as an Array, or as a Hash
+    # with keys formed by preceding the component names with a colon.
+    #
+    # If an Array is used, the components must be passed in the
+    # order <code>[userinfo, host, port, path, typecode]</code>.
+    #
+    # If the path supplied is absolute, it will be escaped in order to
+    # make it absolute in the URI.
+    #
+    # Examples:
+    #
+    #     require 'uri'
+    #
+    #     uri1 = URI::FTP.build(['user:password', 'ftp.example.com', nil,
+    #       '/path/file.zip', 'i'])
+    #     uri1.to_s  # => "ftp://user:password@ftp.example.com/%2Fpath/file.zip;type=i"
+    #
+    #     uri2 = URI::FTP.build({:host => 'ftp.example.com',
+    #       :path => 'ruby/src'})
+    #     uri2.to_s  # => "ftp://ftp.example.com/ruby/src"
+    #
+    def self.build(args)
+
+      # Fix the incoming path to be generic URL syntax
+      # FTP path  ->  URL path
+      # foo/bar       /foo/bar
+      # /foo/bar      /%2Ffoo/bar
+      #
+      if args.kind_of?(Array)
+        args[3] = '/' + args[3].sub(/^\//, '%2F')
+      else
+        args[:path] = '/' + args[:path].sub(/^\//, '%2F')
+      end
+
+      tmp = Util::make_components_hash(self, args)
+
+      if tmp[:typecode]
+        if tmp[:typecode].size == 1
+          tmp[:typecode] = TYPECODE_PREFIX + tmp[:typecode]
+        end
+        tmp[:path] << tmp[:typecode]
+      end
+
+      return super(tmp)
+    end
+
+    #
+    # == Description
+    #
+    # Creates a new URI::FTP object from generic URL components with no
+    # syntax checking.
+    #
+    # Unlike build(), this method does not escape the path component as
+    # required by RFC1738; instead it is treated as per RFC2396.
+    #
+    # Arguments are +scheme+, +userinfo+, +host+, +port+, +registry+, +path+,
+    # +opaque+, +query+, and +fragment+, in that order.
+    #
+    def initialize(scheme,
+                   userinfo, host, port, registry,
+                   path, opaque,
+                   query,
+                   fragment,
+                   parser = nil,
+                   arg_check = false)
+      raise InvalidURIError unless path
+      path = path.sub(/^\//,'')
+      path.sub!(/^%2F/,'/')
+      super(scheme, userinfo, host, port, registry, path, opaque,
+            query, fragment, parser, arg_check)
+      @typecode = nil
+      if tmp = @path.index(TYPECODE_PREFIX)
+        typecode = @path[tmp + TYPECODE_PREFIX.size..-1]
+        @path = @path[0..tmp - 1]
+
+        if arg_check
+          self.typecode = typecode
+        else
+          self.set_typecode(typecode)
+        end
+      end
+    end
+
+    # typecode accessor.
+    #
+    # See URI::FTP::COMPONENT.
+    attr_reader :typecode
+
+    # Validates typecode +v+,
+    # returns +true+ or +false+.
+    #
+    def check_typecode(v)
+      if TYPECODE.include?(v)
+        return true
+      else
+        raise InvalidComponentError,
+          "bad typecode(expected #{TYPECODE.join(', ')}): #{v}"
+      end
+    end
+    private :check_typecode
+
+    # Private setter for the typecode +v+.
+    #
+    # See also URI::FTP.typecode=.
+    #
+    def set_typecode(v)
+      @typecode = v
+    end
+    protected :set_typecode
+
+    #
+    # == Args
+    #
+    # +v+::
+    #    String
+    #
+    # == Description
+    #
+    # Public setter for the typecode +v+
+    # (with validation).
+    #
+    # See also URI::FTP.check_typecode.
+    #
+    # == Usage
+    #
+    #   require 'uri'
+    #
+    #   uri = URI.parse("ftp://john@ftp.example.com/my_file.img")
+    #   #=> #<URI::FTP ftp://john@ftp.example.com/my_file.img>
+    #   uri.typecode = "i"
+    #   uri
+    #   #=> #<URI::FTP ftp://john@ftp.example.com/my_file.img;type=i>
+    #
+    def typecode=(typecode)
+      check_typecode(typecode)
+      set_typecode(typecode)
+      typecode
+    end
+
+    def merge(oth) # :nodoc:
+      tmp = super(oth)
+      if self != tmp
+        tmp.set_typecode(oth.typecode)
+      end
+
+      return tmp
+    end
+
+    # Returns the path from an FTP URI.
+    #
+    # RFC 1738 specifically states that the path for an FTP URI does not
+    # include the / which separates the URI path from the URI host. Example:
+    #
+    # <code>ftp://ftp.example.com/pub/ruby</code>
+    #
+    # The above URI indicates that the client should connect to
+    # ftp.example.com then cd to pub/ruby from the initial login directory.
+    #
+    # If you want to cd to an absolute directory, you must include an
+    # escaped / (%2F) in the path. Example:
+    #
+    # <code>ftp://ftp.example.com/%2Fpub/ruby</code>
+    #
+    # This method will then return "/pub/ruby".
+    #
+    def path
+      return @path.sub(/^\//,'').sub(/^%2F/,'/')
+    end
+
+    # Private setter for the path of the URI::FTP.
+    def set_path(v)
+      super("/" + v.sub(/^\//, "%2F"))
+    end
+    protected :set_path
+
+    # Returns a String representation of the URI::FTP.
+    def to_s
+      save_path = nil
+      if @typecode
+        save_path = @path
+        @path = @path + TYPECODE_PREFIX + @typecode
+      end
+      str = super
+      if @typecode
+        @path = save_path
+      end
+
+      return str
+    end
+  end
+  @@schemes['FTP'] = FTP
+end

--- a/mruby/src/extn/stdlib/uri/generic.rb
+++ b/mruby/src/extn/stdlib/uri/generic.rb
@@ -1,0 +1,1567 @@
+# frozen_string_literal: true
+
+# = uri/generic.rb
+#
+# Author:: Akira Yamada <akira@ruby-lang.org>
+# License:: You can redistribute it and/or modify it under the same term as Ruby.
+# Revision:: $Id$
+#
+# See URI for general documentation
+#
+
+require_relative 'common'
+autoload :IPSocket, 'socket'
+autoload :IPAddr, 'ipaddr'
+
+module URI
+
+  #
+  # Base class for all URI classes.
+  # Implements generic URI syntax as per RFC 2396.
+  #
+  class Generic
+    include URI
+
+    #
+    # A Default port of nil for URI::Generic.
+    #
+    DEFAULT_PORT = nil
+
+    #
+    # Returns default port.
+    #
+    def self.default_port
+      self::DEFAULT_PORT
+    end
+
+    #
+    # Returns default port.
+    #
+    def default_port
+      self.class.default_port
+    end
+
+    #
+    # An Array of the available components for URI::Generic.
+    #
+    COMPONENT = [
+      :scheme,
+      :userinfo, :host, :port, :registry,
+      :path, :opaque,
+      :query,
+      :fragment
+    ].freeze
+
+    #
+    # Components of the URI in the order.
+    #
+    def self.component
+      self::COMPONENT
+    end
+
+    USE_REGISTRY = false # :nodoc:
+
+    def self.use_registry # :nodoc:
+      self::USE_REGISTRY
+    end
+
+    #
+    # == Synopsis
+    #
+    # See ::new.
+    #
+    # == Description
+    #
+    # At first, tries to create a new URI::Generic instance using
+    # URI::Generic::build. But, if exception URI::InvalidComponentError is raised,
+    # then it does URI::Escape.escape all URI components and tries again.
+    #
+    def self.build2(args)
+      begin
+        return self.build(args)
+      rescue InvalidComponentError
+        if args.kind_of?(Array)
+          return self.build(args.collect{|x|
+            if x.is_a?(String)
+              DEFAULT_PARSER.escape(x)
+            else
+              x
+            end
+          })
+        elsif args.kind_of?(Hash)
+          tmp = {}
+          args.each do |key, value|
+            tmp[key] = if value
+                DEFAULT_PARSER.escape(value)
+              else
+                value
+              end
+          end
+          return self.build(tmp)
+        end
+      end
+    end
+
+    #
+    # == Synopsis
+    #
+    # See ::new.
+    #
+    # == Description
+    #
+    # Creates a new URI::Generic instance from components of URI::Generic
+    # with check.  Components are: scheme, userinfo, host, port, registry, path,
+    # opaque, query, and fragment. You can provide arguments either by an Array or a Hash.
+    # See ::new for hash keys to use or for order of array items.
+    #
+    def self.build(args)
+      if args.kind_of?(Array) &&
+          args.size == ::URI::Generic::COMPONENT.size
+        tmp = args.dup
+      elsif args.kind_of?(Hash)
+        tmp = ::URI::Generic::COMPONENT.collect do |c|
+          if args.include?(c)
+            args[c]
+          else
+            nil
+          end
+        end
+      else
+        component = self.class.component rescue ::URI::Generic::COMPONENT
+        raise ArgumentError,
+        "expected Array of or Hash of components of #{self.class} (#{component.join(', ')})"
+      end
+
+      tmp << nil
+      tmp << true
+      return self.new(*tmp)
+    end
+
+    #
+    # == Args
+    #
+    # +scheme+::
+    #   Protocol scheme, i.e. 'http','ftp','mailto' and so on.
+    # +userinfo+::
+    #   User name and password, i.e. 'sdmitry:bla'.
+    # +host+::
+    #   Server host name.
+    # +port+::
+    #   Server port.
+    # +registry+::
+    #   Registry of naming authorities.
+    # +path+::
+    #   Path on server.
+    # +opaque+::
+    #   Opaque part.
+    # +query+::
+    #   Query data.
+    # +fragment+::
+    #   Part of the URI after '#' character.
+    # +parser+::
+    #   Parser for internal use [URI::DEFAULT_PARSER by default].
+    # +arg_check+::
+    #   Check arguments [false by default].
+    #
+    # == Description
+    #
+    # Creates a new URI::Generic instance from ``generic'' components without check.
+    #
+    def initialize(scheme,
+                   userinfo, host, port, registry,
+                   path, opaque,
+                   query,
+                   fragment,
+                   parser = DEFAULT_PARSER,
+                   arg_check = false)
+      @scheme = nil
+      @user = nil
+      @password = nil
+      @host = nil
+      @port = nil
+      @path = nil
+      @query = nil
+      @opaque = nil
+      @fragment = nil
+      @parser = parser == DEFAULT_PARSER ? nil : parser
+
+      if arg_check
+        self.scheme = scheme
+        self.userinfo = userinfo
+        self.hostname = host
+        self.port = port
+        self.path = path
+        self.query = query
+        self.opaque = opaque
+        self.fragment = fragment
+      else
+        self.set_scheme(scheme)
+        self.set_userinfo(userinfo)
+        self.set_host(host)
+        self.set_port(port)
+        self.set_path(path)
+        self.query = query
+        self.set_opaque(opaque)
+        self.fragment=(fragment)
+      end
+      if registry
+        raise InvalidURIError,
+          "the scheme #{@scheme} does not accept registry part: #{registry} (or bad hostname?)"
+      end
+
+      @scheme&.freeze
+      self.set_path('') if !@path && !@opaque # (see RFC2396 Section 5.2)
+      self.set_port(self.default_port) if self.default_port && !@port
+    end
+
+    #
+    # Returns the scheme component of the URI.
+    #
+    #   URI("http://foo/bar/baz").scheme #=> "http"
+    #
+    attr_reader :scheme
+
+    # Returns the host component of the URI.
+    #
+    #   URI("http://foo/bar/baz").host #=> "foo"
+    #
+    # It returns nil if no host component exists.
+    #
+    #   URI("mailto:foo@example.org").host #=> nil
+    #
+    # The component does not contain the port number.
+    #
+    #   URI("http://foo:8080/bar/baz").host #=> "foo"
+    #
+    # Since IPv6 addresses are wrapped with brackets in URIs,
+    # this method returns IPv6 addresses wrapped with brackets.
+    # This form is not appropriate to pass to socket methods such as TCPSocket.open.
+    # If unwrapped host names are required, use the #hostname method.
+    #
+    #   URI("http://[::1]/bar/baz").host     #=> "[::1]"
+    #   URI("http://[::1]/bar/baz").hostname #=> "::1"
+    #
+    attr_reader :host
+
+    # Returns the port component of the URI.
+    #
+    #   URI("http://foo/bar/baz").port      #=> 80
+    #   URI("http://foo:8080/bar/baz").port #=> 8080
+    #
+    attr_reader :port
+
+    def registry # :nodoc:
+      nil
+    end
+
+    # Returns the path component of the URI.
+    #
+    #   URI("http://foo/bar/baz").path #=> "/bar/baz"
+    #
+    attr_reader :path
+
+    # Returns the query component of the URI.
+    #
+    #   URI("http://foo/bar/baz?search=FooBar").query #=> "search=FooBar"
+    #
+    attr_reader :query
+
+    # Returns the opaque part of the URI.
+    #
+    #   URI("mailto:foo@example.org").opaque #=> "foo@example.org"
+    #   URI("http://foo/bar/baz").opaque     #=> nil
+    #
+    # The portion of the path that does not make use of the slash '/'.
+    # The path typically refers to an absolute path or an opaque part.
+    # (See RFC2396 Section 3 and 5.2.)
+    #
+    attr_reader :opaque
+
+    # Returns the fragment component of the URI.
+    #
+    #   URI("http://foo/bar/baz?search=FooBar#ponies").fragment #=> "ponies"
+    #
+    attr_reader :fragment
+
+    # Returns the parser to be used.
+    #
+    # Unless a URI::Parser is defined, DEFAULT_PARSER is used.
+    #
+    def parser
+      if !defined?(@parser) || !@parser
+        DEFAULT_PARSER
+      else
+        @parser || DEFAULT_PARSER
+      end
+    end
+
+    # Replaces self by other URI object.
+    #
+    def replace!(oth)
+      if self.class != oth.class
+        raise ArgumentError, "expected #{self.class} object"
+      end
+
+      component.each do |c|
+        self.__send__("#{c}=", oth.__send__(c))
+      end
+    end
+    private :replace!
+
+    #
+    # Components of the URI in the order.
+    #
+    def component
+      self.class.component
+    end
+
+    #
+    # Checks the scheme +v+ component against the URI::Parser Regexp for :SCHEME.
+    #
+    def check_scheme(v)
+      if v && parser.regexp[:SCHEME] !~ v
+        raise InvalidComponentError,
+          "bad component(expected scheme component): #{v}"
+      end
+
+      return true
+    end
+    private :check_scheme
+
+    # Protected setter for the scheme component +v+.
+    #
+    # See also URI::Generic.scheme=.
+    #
+    def set_scheme(v)
+      @scheme = v&.downcase
+    end
+    protected :set_scheme
+
+    #
+    # == Args
+    #
+    # +v+::
+    #    String
+    #
+    # == Description
+    #
+    # Public setter for the scheme component +v+
+    # (with validation).
+    #
+    # See also URI::Generic.check_scheme.
+    #
+    # == Usage
+    #
+    #   require 'uri'
+    #
+    #   uri = URI.parse("http://my.example.com")
+    #   uri.scheme = "https"
+    #   uri.to_s  #=> "https://my.example.com"
+    #
+    def scheme=(v)
+      check_scheme(v)
+      set_scheme(v)
+      v
+    end
+
+    #
+    # Checks the +user+ and +password+.
+    #
+    # If +password+ is not provided, then +user+ is
+    # split, using URI::Generic.split_userinfo, to
+    # pull +user+ and +password.
+    #
+    # See also URI::Generic.check_user, URI::Generic.check_password.
+    #
+    def check_userinfo(user, password = nil)
+      if !password
+        user, password = split_userinfo(user)
+      end
+      check_user(user)
+      check_password(password, user)
+
+      return true
+    end
+    private :check_userinfo
+
+    #
+    # Checks the user +v+ component for RFC2396 compliance
+    # and against the URI::Parser Regexp for :USERINFO.
+    #
+    # Can not have a registry or opaque component defined,
+    # with a user component defined.
+    #
+    def check_user(v)
+      if @opaque
+        raise InvalidURIError,
+          "can not set user with opaque"
+      end
+
+      return v unless v
+
+      if parser.regexp[:USERINFO] !~ v
+        raise InvalidComponentError,
+          "bad component(expected userinfo component or user component): #{v}"
+      end
+
+      return true
+    end
+    private :check_user
+
+    #
+    # Checks the password +v+ component for RFC2396 compliance
+    # and against the URI::Parser Regexp for :USERINFO.
+    #
+    # Can not have a registry or opaque component defined,
+    # with a user component defined.
+    #
+    def check_password(v, user = @user)
+      if @opaque
+        raise InvalidURIError,
+          "can not set password with opaque"
+      end
+      return v unless v
+
+      if !user
+        raise InvalidURIError,
+          "password component depends user component"
+      end
+
+      if parser.regexp[:USERINFO] !~ v
+        raise InvalidComponentError,
+          "bad password component"
+      end
+
+      return true
+    end
+    private :check_password
+
+    #
+    # Sets userinfo, argument is string like 'name:pass'.
+    #
+    def userinfo=(userinfo)
+      if userinfo.nil?
+        return nil
+      end
+      check_userinfo(*userinfo)
+      set_userinfo(*userinfo)
+      # returns userinfo
+    end
+
+    #
+    # == Args
+    #
+    # +v+::
+    #    String
+    #
+    # == Description
+    #
+    # Public setter for the +user+ component
+    # (with validation).
+    #
+    # See also URI::Generic.check_user.
+    #
+    # == Usage
+    #
+    #   require 'uri'
+    #
+    #   uri = URI.parse("http://john:S3nsit1ve@my.example.com")
+    #   uri.user = "sam"
+    #   uri.to_s  #=> "http://sam:V3ry_S3nsit1ve@my.example.com"
+    #
+    def user=(user)
+      check_user(user)
+      set_user(user)
+      # returns user
+    end
+
+    #
+    # == Args
+    #
+    # +v+::
+    #    String
+    #
+    # == Description
+    #
+    # Public setter for the +password+ component
+    # (with validation).
+    #
+    # See also URI::Generic.check_password.
+    #
+    # == Usage
+    #
+    #   require 'uri'
+    #
+    #   uri = URI.parse("http://john:S3nsit1ve@my.example.com")
+    #   uri.password = "V3ry_S3nsit1ve"
+    #   uri.to_s  #=> "http://john:V3ry_S3nsit1ve@my.example.com"
+    #
+    def password=(password)
+      check_password(password)
+      set_password(password)
+      # returns password
+    end
+
+    # Protected setter for the +user+ component, and +password+ if available
+    # (with validation).
+    #
+    # See also URI::Generic.userinfo=.
+    #
+    def set_userinfo(user, password = nil)
+      unless password
+        user, password = split_userinfo(user)
+      end
+      @user     = user
+      @password = password if password
+
+      [@user, @password]
+    end
+    protected :set_userinfo
+
+    # Protected setter for the user component +v+.
+    #
+    # See also URI::Generic.user=.
+    #
+    def set_user(v)
+      set_userinfo(v, @password)
+      v
+    end
+    protected :set_user
+
+    # Protected setter for the password component +v+.
+    #
+    # See also URI::Generic.password=.
+    #
+    def set_password(v)
+      @password = v
+      # returns v
+    end
+    protected :set_password
+
+    # Returns the userinfo +ui+ as <code>[user, password]</code>
+    # if properly formatted as 'user:password'.
+    def split_userinfo(ui)
+      return nil, nil unless ui
+      user, password = ui.split(':', 2)
+
+      return user, password
+    end
+    private :split_userinfo
+
+    # Escapes 'user:password' +v+ based on RFC 1738 section 3.1.
+    def escape_userpass(v)
+      parser.escape(v, /[@:\/]/o) # RFC 1738 section 3.1 #/
+    end
+    private :escape_userpass
+
+    # Returns the userinfo, either as 'user' or 'user:password'.
+    def userinfo
+      if @user.nil?
+        nil
+      elsif @password.nil?
+        @user
+      else
+        @user + ':' + @password
+      end
+    end
+
+    # Returns the user component.
+    def user
+      @user
+    end
+
+    # Returns the password component.
+    def password
+      @password
+    end
+
+    #
+    # Checks the host +v+ component for RFC2396 compliance
+    # and against the URI::Parser Regexp for :HOST.
+    #
+    # Can not have a registry or opaque component defined,
+    # with a host component defined.
+    #
+    def check_host(v)
+      return v unless v
+
+      if @opaque
+        raise InvalidURIError,
+          "can not set host with registry or opaque"
+      elsif parser.regexp[:HOST] !~ v
+        raise InvalidComponentError,
+          "bad component(expected host component): #{v}"
+      end
+
+      return true
+    end
+    private :check_host
+
+    # Protected setter for the host component +v+.
+    #
+    # See also URI::Generic.host=.
+    #
+    def set_host(v)
+      @host = v
+    end
+    protected :set_host
+
+    #
+    # == Args
+    #
+    # +v+::
+    #    String
+    #
+    # == Description
+    #
+    # Public setter for the host component +v+
+    # (with validation).
+    #
+    # See also URI::Generic.check_host.
+    #
+    # == Usage
+    #
+    #   require 'uri'
+    #
+    #   uri = URI.parse("http://my.example.com")
+    #   uri.host = "foo.com"
+    #   uri.to_s  #=> "http://foo.com"
+    #
+    def host=(v)
+      check_host(v)
+      set_host(v)
+      v
+    end
+
+    # Extract the host part of the URI and unwrap brackets for IPv6 addresses.
+    #
+    # This method is the same as URI::Generic#host except
+    # brackets for IPv6 (and future IP) addresses are removed.
+    #
+    #   uri = URI("http://[::1]/bar")
+    #   uri.hostname      #=> "::1"
+    #   uri.host          #=> "[::1]"
+    #
+    def hostname
+      v = self.host
+      /\A\[(.*)\]\z/ =~ v ? $1 : v
+    end
+
+    # Sets the host part of the URI as the argument with brackets for IPv6 addresses.
+    #
+    # This method is the same as URI::Generic#host= except
+    # the argument can be a bare IPv6 address.
+    #
+    #   uri = URI("http://foo/bar")
+    #   uri.hostname = "::1"
+    #   uri.to_s  #=> "http://[::1]/bar"
+    #
+    # If the argument seems to be an IPv6 address,
+    # it is wrapped with brackets.
+    #
+    def hostname=(v)
+      v = "[#{v}]" if /\A\[.*\]\z/ !~ v && /:/ =~ v
+      self.host = v
+    end
+
+    #
+    # Checks the port +v+ component for RFC2396 compliance
+    # and against the URI::Parser Regexp for :PORT.
+    #
+    # Can not have a registry or opaque component defined,
+    # with a port component defined.
+    #
+    def check_port(v)
+      return v unless v
+
+      if @opaque
+        raise InvalidURIError,
+          "can not set port with registry or opaque"
+      elsif !v.kind_of?(Integer) && parser.regexp[:PORT] !~ v
+        raise InvalidComponentError,
+          "bad component(expected port component): #{v.inspect}"
+      end
+
+      return true
+    end
+    private :check_port
+
+    # Protected setter for the port component +v+.
+    #
+    # See also URI::Generic.port=.
+    #
+    def set_port(v)
+      v = v.empty? ? nil : v.to_i unless !v || v.kind_of?(Integer)
+      @port = v
+    end
+    protected :set_port
+
+    #
+    # == Args
+    #
+    # +v+::
+    #    String
+    #
+    # == Description
+    #
+    # Public setter for the port component +v+
+    # (with validation).
+    #
+    # See also URI::Generic.check_port.
+    #
+    # == Usage
+    #
+    #   require 'uri'
+    #
+    #   uri = URI.parse("http://my.example.com")
+    #   uri.port = 8080
+    #   uri.to_s  #=> "http://my.example.com:8080"
+    #
+    def port=(v)
+      check_port(v)
+      set_port(v)
+      port
+    end
+
+    def check_registry(v) # :nodoc:
+      raise InvalidURIError, "can not set registry"
+    end
+    private :check_registry
+
+    def set_registry(v) #:nodoc:
+      raise InvalidURIError, "can not set registry"
+    end
+    protected :set_registry
+
+    def registry=(v)
+      raise InvalidURIError, "can not set registry"
+    end
+
+    #
+    # Checks the path +v+ component for RFC2396 compliance
+    # and against the URI::Parser Regexp
+    # for :ABS_PATH and :REL_PATH.
+    #
+    # Can not have a opaque component defined,
+    # with a path component defined.
+    #
+    def check_path(v)
+      # raise if both hier and opaque are not nil, because:
+      # absoluteURI   = scheme ":" ( hier_part | opaque_part )
+      # hier_part     = ( net_path | abs_path ) [ "?" query ]
+      if v && @opaque
+        raise InvalidURIError,
+          "path conflicts with opaque"
+      end
+
+      # If scheme is ftp, path may be relative.
+      # See RFC 1738 section 3.2.2, and RFC 2396.
+      if @scheme && @scheme != "ftp"
+        if v && v != '' && parser.regexp[:ABS_PATH] !~ v
+          raise InvalidComponentError,
+            "bad component(expected absolute path component): #{v}"
+        end
+      else
+        if v && v != '' && parser.regexp[:ABS_PATH] !~ v &&
+           parser.regexp[:REL_PATH] !~ v
+          raise InvalidComponentError,
+            "bad component(expected relative path component): #{v}"
+        end
+      end
+
+      return true
+    end
+    private :check_path
+
+    # Protected setter for the path component +v+.
+    #
+    # See also URI::Generic.path=.
+    #
+    def set_path(v)
+      @path = v
+    end
+    protected :set_path
+
+    #
+    # == Args
+    #
+    # +v+::
+    #    String
+    #
+    # == Description
+    #
+    # Public setter for the path component +v+
+    # (with validation).
+    #
+    # See also URI::Generic.check_path.
+    #
+    # == Usage
+    #
+    #   require 'uri'
+    #
+    #   uri = URI.parse("http://my.example.com/pub/files")
+    #   uri.path = "/faq/"
+    #   uri.to_s  #=> "http://my.example.com/faq/"
+    #
+    def path=(v)
+      check_path(v)
+      set_path(v)
+      v
+    end
+
+    #
+    # == Args
+    #
+    # +v+::
+    #    String
+    #
+    # == Description
+    #
+    # Public setter for the query component +v+.
+    #
+    # == Usage
+    #
+    #   require 'uri'
+    #
+    #   uri = URI.parse("http://my.example.com/?id=25")
+    #   uri.query = "id=1"
+    #   uri.to_s  #=> "http://my.example.com/?id=1"
+    #
+    def query=(v)
+      return @query = nil unless v
+      raise InvalidURIError, "query conflicts with opaque" if @opaque
+
+      x = v.to_str
+      v = x.dup if x.equal? v
+      v.encode!(Encoding::UTF_8) rescue nil
+      v.delete!("\t\r\n")
+      v.force_encoding(Encoding::ASCII_8BIT)
+      v.gsub!(/(?!%\h\h|[!$-&(-;=?-_a-~])./n.freeze){'%%%02X' % $&.ord}
+      v.force_encoding(Encoding::US_ASCII)
+      @query = v
+    end
+
+    #
+    # Checks the opaque +v+ component for RFC2396 compliance and
+    # against the URI::Parser Regexp for :OPAQUE.
+    #
+    # Can not have a host, port, user, or path component defined,
+    # with an opaque component defined.
+    #
+    def check_opaque(v)
+      return v unless v
+
+      # raise if both hier and opaque are not nil, because:
+      # absoluteURI   = scheme ":" ( hier_part | opaque_part )
+      # hier_part     = ( net_path | abs_path ) [ "?" query ]
+      if @host || @port || @user || @path  # userinfo = @user + ':' + @password
+        raise InvalidURIError,
+          "can not set opaque with host, port, userinfo or path"
+      elsif v && parser.regexp[:OPAQUE] !~ v
+        raise InvalidComponentError,
+          "bad component(expected opaque component): #{v}"
+      end
+
+      return true
+    end
+    private :check_opaque
+
+    # Protected setter for the opaque component +v+.
+    #
+    # See also URI::Generic.opaque=.
+    #
+    def set_opaque(v)
+      @opaque = v
+    end
+    protected :set_opaque
+
+    #
+    # == Args
+    #
+    # +v+::
+    #    String
+    #
+    # == Description
+    #
+    # Public setter for the opaque component +v+
+    # (with validation).
+    #
+    # See also URI::Generic.check_opaque.
+    #
+    def opaque=(v)
+      check_opaque(v)
+      set_opaque(v)
+      v
+    end
+
+    #
+    # Checks the fragment +v+ component against the URI::Parser Regexp for :FRAGMENT.
+    #
+    #
+    # == Args
+    #
+    # +v+::
+    #    String
+    #
+    # == Description
+    #
+    # Public setter for the fragment component +v+
+    # (with validation).
+    #
+    # == Usage
+    #
+    #   require 'uri'
+    #
+    #   uri = URI.parse("http://my.example.com/?id=25#time=1305212049")
+    #   uri.fragment = "time=1305212086"
+    #   uri.to_s  #=> "http://my.example.com/?id=25#time=1305212086"
+    #
+    def fragment=(v)
+      return @fragment = nil unless v
+
+      x = v.to_str
+      v = x.dup if x.equal? v
+      v.encode!(Encoding::UTF_8) rescue nil
+      v.delete!("\t\r\n")
+      v.force_encoding(Encoding::ASCII_8BIT)
+      v.gsub!(/(?!%\h\h|[!-~])./n){'%%%02X' % $&.ord}
+      v.force_encoding(Encoding::US_ASCII)
+      @fragment = v
+    end
+
+    #
+    # Returns true if URI is hierarchical.
+    #
+    # == Description
+    #
+    # URI has components listed in order of decreasing significance from left to right,
+    # see RFC3986 https://tools.ietf.org/html/rfc3986 1.2.3.
+    #
+    # == Usage
+    #
+    #   require 'uri'
+    #
+    #   uri = URI.parse("http://my.example.com/")
+    #   uri.hierarchical?
+    #   #=> true
+    #   uri = URI.parse("mailto:joe@example.com")
+    #   uri.hierarchical?
+    #   #=> false
+    #
+    def hierarchical?
+      if @path
+        true
+      else
+        false
+      end
+    end
+
+    #
+    # Returns true if URI has a scheme (e.g. http:// or https://) specified.
+    #
+    def absolute?
+      if @scheme
+        true
+      else
+        false
+      end
+    end
+    alias absolute absolute?
+
+    #
+    # Returns true if URI does not have a scheme (e.g. http:// or https://) specified.
+    #
+    def relative?
+      !absolute?
+    end
+
+    #
+    # Returns an Array of the path split on '/'.
+    #
+    def split_path(path)
+      path.split("/", -1)
+    end
+    private :split_path
+
+    #
+    # Merges a base path +base+, with relative path +rel+,
+    # returns a modified base path.
+    #
+    def merge_path(base, rel)
+
+      # RFC2396, Section 5.2, 5)
+      # RFC2396, Section 5.2, 6)
+      base_path = split_path(base)
+      rel_path  = split_path(rel)
+
+      # RFC2396, Section 5.2, 6), a)
+      base_path << '' if base_path.last == '..'
+      while i = base_path.index('..')
+        base_path.slice!(i - 1, 2)
+      end
+
+      if (first = rel_path.first) and first.empty?
+        base_path.clear
+        rel_path.shift
+      end
+
+      # RFC2396, Section 5.2, 6), c)
+      # RFC2396, Section 5.2, 6), d)
+      rel_path.push('') if rel_path.last == '.' || rel_path.last == '..'
+      rel_path.delete('.')
+
+      # RFC2396, Section 5.2, 6), e)
+      tmp = []
+      rel_path.each do |x|
+        if x == '..' &&
+            !(tmp.empty? || tmp.last == '..')
+          tmp.pop
+        else
+          tmp << x
+        end
+      end
+
+      add_trailer_slash = !tmp.empty?
+      if base_path.empty?
+        base_path = [''] # keep '/' for root directory
+      elsif add_trailer_slash
+        base_path.pop
+      end
+      while x = tmp.shift
+        if x == '..'
+          # RFC2396, Section 4
+          # a .. or . in an absolute path has no special meaning
+          base_path.pop if base_path.size > 1
+        else
+          # if x == '..'
+          #   valid absolute (but abnormal) path "/../..."
+          # else
+          #   valid absolute path
+          # end
+          base_path << x
+          tmp.each {|t| base_path << t}
+          add_trailer_slash = false
+          break
+        end
+      end
+      base_path.push('') if add_trailer_slash
+
+      return base_path.join('/')
+    end
+    private :merge_path
+
+    #
+    # == Args
+    #
+    # +oth+::
+    #    URI or String
+    #
+    # == Description
+    #
+    # Destructive form of #merge.
+    #
+    # == Usage
+    #
+    #   require 'uri'
+    #
+    #   uri = URI.parse("http://my.example.com")
+    #   uri.merge!("/main.rbx?page=1")
+    #   uri.to_s  # => "http://my.example.com/main.rbx?page=1"
+    #
+    def merge!(oth)
+      t = merge(oth)
+      if self == t
+        nil
+      else
+        replace!(t)
+        self
+      end
+    end
+
+    #
+    # == Args
+    #
+    # +oth+::
+    #    URI or String
+    #
+    # == Description
+    #
+    # Merges two URIs.
+    #
+    # == Usage
+    #
+    #   require 'uri'
+    #
+    #   uri = URI.parse("http://my.example.com")
+    #   uri.merge("/main.rbx?page=1")
+    #   # => "http://my.example.com/main.rbx?page=1"
+    #
+    def merge(oth)
+      rel = parser.send(:convert_to_uri, oth)
+
+      if rel.absolute?
+        #raise BadURIError, "both URI are absolute" if absolute?
+        # hmm... should return oth for usability?
+        return rel
+      end
+
+      unless self.absolute?
+        raise BadURIError, "both URI are relative"
+      end
+
+      base = self.dup
+
+      authority = rel.userinfo || rel.host || rel.port
+
+      # RFC2396, Section 5.2, 2)
+      if (rel.path.nil? || rel.path.empty?) && !authority && !rel.query
+        base.fragment=(rel.fragment) if rel.fragment
+        return base
+      end
+
+      base.query = nil
+      base.fragment=(nil)
+
+      # RFC2396, Section 5.2, 4)
+      if !authority
+        base.set_path(merge_path(base.path, rel.path)) if base.path && rel.path
+      else
+        # RFC2396, Section 5.2, 4)
+        base.set_path(rel.path) if rel.path
+      end
+
+      # RFC2396, Section 5.2, 7)
+      base.set_userinfo(rel.userinfo) if rel.userinfo
+      base.set_host(rel.host)         if rel.host
+      base.set_port(rel.port)         if rel.port
+      base.query = rel.query       if rel.query
+      base.fragment=(rel.fragment) if rel.fragment
+
+      return base
+    end # merge
+    alias + merge
+
+    # :stopdoc:
+    def route_from_path(src, dst)
+      case dst
+      when src
+        # RFC2396, Section 4.2
+        return ''
+      when %r{(?:\A|/)\.\.?(?:/|\z)}
+        # dst has abnormal absolute path,
+        # like "/./", "/../", "/x/../", ...
+        return dst.dup
+      end
+
+      src_path = src.scan(%r{[^/]*/})
+      dst_path = dst.scan(%r{[^/]*/?})
+
+      # discard same parts
+      while !dst_path.empty? && dst_path.first == src_path.first
+        src_path.shift
+        dst_path.shift
+      end
+
+      tmp = dst_path.join
+
+      # calculate
+      if src_path.empty?
+        if tmp.empty?
+          return './'
+        elsif dst_path.first.include?(':') # (see RFC2396 Section 5)
+          return './' + tmp
+        else
+          return tmp
+        end
+      end
+
+      return '../' * src_path.size + tmp
+    end
+    private :route_from_path
+    # :startdoc:
+
+    # :stopdoc:
+    def route_from0(oth)
+      oth = parser.send(:convert_to_uri, oth)
+      if self.relative?
+        raise BadURIError,
+          "relative URI: #{self}"
+      end
+      if oth.relative?
+        raise BadURIError,
+          "relative URI: #{oth}"
+      end
+
+      if self.scheme != oth.scheme
+        return self, self.dup
+      end
+      rel = URI::Generic.new(nil, # it is relative URI
+                             self.userinfo, self.host, self.port,
+                             nil, self.path, self.opaque,
+                             self.query, self.fragment, parser)
+
+      if rel.userinfo != oth.userinfo ||
+          rel.host.to_s.downcase != oth.host.to_s.downcase ||
+          rel.port != oth.port
+
+        if self.userinfo.nil? && self.host.nil?
+          return self, self.dup
+        end
+
+        rel.set_port(nil) if rel.port == oth.default_port
+        return rel, rel
+      end
+      rel.set_userinfo(nil)
+      rel.set_host(nil)
+      rel.set_port(nil)
+
+      if rel.path && rel.path == oth.path
+        rel.set_path('')
+        rel.query = nil if rel.query == oth.query
+        return rel, rel
+      elsif rel.opaque && rel.opaque == oth.opaque
+        rel.set_opaque('')
+        rel.query = nil if rel.query == oth.query
+        return rel, rel
+      end
+
+      # you can modify `rel', but can not `oth'.
+      return oth, rel
+    end
+    private :route_from0
+    # :startdoc:
+
+    #
+    # == Args
+    #
+    # +oth+::
+    #    URI or String
+    #
+    # == Description
+    #
+    # Calculates relative path from oth to self.
+    #
+    # == Usage
+    #
+    #   require 'uri'
+    #
+    #   uri = URI.parse('http://my.example.com/main.rbx?page=1')
+    #   uri.route_from('http://my.example.com')
+    #   #=> #<URI::Generic /main.rbx?page=1>
+    #
+    def route_from(oth)
+      # you can modify `rel', but can not `oth'.
+      begin
+        oth, rel = route_from0(oth)
+      rescue
+        raise $!.class, $!.message
+      end
+      if oth == rel
+        return rel
+      end
+
+      rel.set_path(route_from_path(oth.path, self.path))
+      if rel.path == './' && self.query
+        # "./?foo" -> "?foo"
+        rel.set_path('')
+      end
+
+      return rel
+    end
+
+    alias - route_from
+
+    #
+    # == Args
+    #
+    # +oth+::
+    #    URI or String
+    #
+    # == Description
+    #
+    # Calculates relative path to oth from self.
+    #
+    # == Usage
+    #
+    #   require 'uri'
+    #
+    #   uri = URI.parse('http://my.example.com')
+    #   uri.route_to('http://my.example.com/main.rbx?page=1')
+    #   #=> #<URI::Generic /main.rbx?page=1>
+    #
+    def route_to(oth)
+      parser.send(:convert_to_uri, oth).route_from(self)
+    end
+
+    #
+    # Returns normalized URI.
+    #
+    #   require 'uri'
+    #
+    #   URI("HTTP://my.EXAMPLE.com").normalize
+    #   #=> #<URI::HTTP http://my.example.com/>
+    #
+    # Normalization here means:
+    #
+    # * scheme and host are converted to lowercase,
+    # * an empty path component is set to "/".
+    #
+    def normalize
+      uri = dup
+      uri.normalize!
+      uri
+    end
+
+    #
+    # Destructive version of #normalize.
+    #
+    def normalize!
+      if path&.empty?
+        set_path('/')
+      end
+      if scheme && scheme != scheme.downcase
+        set_scheme(self.scheme.downcase)
+      end
+      if host && host != host.downcase
+        set_host(self.host.downcase)
+      end
+    end
+
+    #
+    # Constructs String from URI.
+    #
+    def to_s
+      str = ''.dup
+      if @scheme
+        str << @scheme
+        str << ':'
+      end
+
+      if @opaque
+        str << @opaque
+      else
+        if @host || %w[file postgres].include?(@scheme)
+          str << '//'
+        end
+        if self.userinfo
+          str << self.userinfo
+          str << '@'
+        end
+        if @host
+          str << @host
+        end
+        if @port && @port != self.default_port
+          str << ':'
+          str << @port.to_s
+        end
+        str << @path
+        if @query
+          str << '?'
+          str << @query
+        end
+      end
+      if @fragment
+        str << '#'
+        str << @fragment
+      end
+      str
+    end
+
+    #
+    # Compares two URIs.
+    #
+    def ==(oth)
+      if self.class == oth.class
+        self.normalize.component_ary == oth.normalize.component_ary
+      else
+        false
+      end
+    end
+
+    def hash
+      self.component_ary.hash
+    end
+
+    def eql?(oth)
+      self.class == oth.class &&
+      parser == oth.parser &&
+      self.component_ary.eql?(oth.component_ary)
+    end
+
+=begin
+
+--- URI::Generic#===(oth)
+
+=end
+#    def ===(oth)
+#      raise NotImplementedError
+#    end
+
+=begin
+=end
+
+
+    # Returns an Array of the components defined from the COMPONENT Array.
+    def component_ary
+      component.collect do |x|
+        self.send(x)
+      end
+    end
+    protected :component_ary
+
+    # == Args
+    #
+    # +components+::
+    #    Multiple Symbol arguments defined in URI::HTTP.
+    #
+    # == Description
+    #
+    # Selects specified components from URI.
+    #
+    # == Usage
+    #
+    #   require 'uri'
+    #
+    #   uri = URI.parse('http://myuser:mypass@my.example.com/test.rbx')
+    #   uri.select(:userinfo, :host, :path)
+    #   # => ["myuser:mypass", "my.example.com", "/test.rbx"]
+    #
+    def select(*components)
+      components.collect do |c|
+        if component.include?(c)
+          self.send(c)
+        else
+          raise ArgumentError,
+            "expected of components of #{self.class} (#{self.class.component.join(', ')})"
+        end
+      end
+    end
+
+    def inspect
+      "#<#{self.class} #{self}>"
+    end
+
+    #
+    # == Args
+    #
+    # +v+::
+    #    URI or String
+    #
+    # == Description
+    #
+    # Attempts to parse other URI +oth+,
+    # returns [parsed_oth, self].
+    #
+    # == Usage
+    #
+    #   require 'uri'
+    #
+    #   uri = URI.parse("http://my.example.com")
+    #   uri.coerce("http://foo.com")
+    #   #=> [#<URI::HTTP http://foo.com>, #<URI::HTTP http://my.example.com>]
+    #
+    def coerce(oth)
+      case oth
+      when String
+        oth = parser.parse(oth)
+      else
+        super
+      end
+
+      return oth, self
+    end
+
+    # Returns a proxy URI.
+    # The proxy URI is obtained from environment variables such as http_proxy,
+    # ftp_proxy, no_proxy, etc.
+    # If there is no proper proxy, nil is returned.
+    #
+    # If the optional parameter +env+ is specified, it is used instead of ENV.
+    #
+    # Note that capitalized variables (HTTP_PROXY, FTP_PROXY, NO_PROXY, etc.)
+    # are examined, too.
+    #
+    # But http_proxy and HTTP_PROXY is treated specially under CGI environment.
+    # It's because HTTP_PROXY may be set by Proxy: header.
+    # So HTTP_PROXY is not used.
+    # http_proxy is not used too if the variable is case insensitive.
+    # CGI_HTTP_PROXY can be used instead.
+    def find_proxy(env=ENV)
+      raise BadURIError, "relative URI: #{self}" if self.relative?
+      name = self.scheme.downcase + '_proxy'
+      proxy_uri = nil
+      if name == 'http_proxy' && env.include?('REQUEST_METHOD') # CGI?
+        # HTTP_PROXY conflicts with *_proxy for proxy settings and
+        # HTTP_* for header information in CGI.
+        # So it should be careful to use it.
+        pairs = env.reject {|k, v| /\Ahttp_proxy\z/i !~ k }
+        case pairs.length
+        when 0 # no proxy setting anyway.
+          proxy_uri = nil
+        when 1
+          k, _ = pairs.shift
+          if k == 'http_proxy' && env[k.upcase] == nil
+            # http_proxy is safe to use because ENV is case sensitive.
+            proxy_uri = env[name]
+          else
+            proxy_uri = nil
+          end
+        else # http_proxy is safe to use because ENV is case sensitive.
+          proxy_uri = env.to_hash[name]
+        end
+        if !proxy_uri
+          # Use CGI_HTTP_PROXY.  cf. libwww-perl.
+          proxy_uri = env["CGI_#{name.upcase}"]
+        end
+      elsif name == 'http_proxy'
+        unless proxy_uri = env[name]
+          if proxy_uri = env[name.upcase]
+            warn 'The environment variable HTTP_PROXY is discouraged.  Use http_proxy.', uplevel: 1
+          end
+        end
+      else
+        proxy_uri = env[name] || env[name.upcase]
+      end
+
+      if proxy_uri.nil? || proxy_uri.empty?
+        return nil
+      end
+
+      if self.hostname
+        begin
+          addr = IPSocket.getaddress(self.hostname)
+          return nil if /\A127\.|\A::1\z/ =~ addr
+        rescue SocketError
+        end
+      end
+
+      name = 'no_proxy'
+      if no_proxy = env[name] || env[name.upcase]
+        return nil unless URI::Generic.use_proxy?(self.hostname, addr, self.port, no_proxy)
+      end
+      URI.parse(proxy_uri)
+    end
+
+    def self.use_proxy?(hostname, addr, port, no_proxy) # :nodoc:
+      hostname = hostname.downcase
+      dothostname = ".#{hostname}"
+      no_proxy.scan(/([^:,\s]+)(?::(\d+))?/) {|p_host, p_port|
+        if !p_port || port == p_port.to_i
+          if p_host.start_with?('.')
+            return false if hostname.end_with?(p_host.downcase)
+          else
+            return false if dothostname.end_with?(".#{p_host.downcase}")
+          end
+          if addr
+            begin
+              return false if IPAddr.new(p_host).include?(addr)
+            rescue IPAddr::InvalidAddressError
+              next
+            end
+          end
+        end
+      }
+      true
+    end
+  end
+end

--- a/mruby/src/extn/stdlib/uri/generic.rb
+++ b/mruby/src/extn/stdlib/uri/generic.rb
@@ -288,11 +288,7 @@ module URI
     # Unless a URI::Parser is defined, DEFAULT_PARSER is used.
     #
     def parser
-      if !defined?(@parser) || !@parser
-        DEFAULT_PARSER
-      else
-        @parser || DEFAULT_PARSER
-      end
+      @parser || DEFAULT_PARSER
     end
 
     # Replaces self by other URI object.
@@ -550,7 +546,7 @@ module URI
 
     # Escapes 'user:password' +v+ based on RFC 1738 section 3.1.
     def escape_userpass(v)
-      parser.escape(v, /[@:\/]/o) # RFC 1738 section 3.1 #/
+      parser.escape(v, /[@:\/]/) # RFC 1738 section 3.1 #/
     end
     private :escape_userpass
 

--- a/mruby/src/extn/stdlib/uri/http.rb
+++ b/mruby/src/extn/stdlib/uri/http.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: false
+# = uri/http.rb
+#
+# Author:: Akira Yamada <akira@ruby-lang.org>
+# License:: You can redistribute it and/or modify it under the same term as Ruby.
+# Revision:: $Id$
+#
+# See URI for general documentation
+#
+
+require_relative 'generic'
+
+module URI
+
+  #
+  # The syntax of HTTP URIs is defined in RFC1738 section 3.3.
+  #
+  # Note that the Ruby URI library allows HTTP URLs containing usernames and
+  # passwords. This is not legal as per the RFC, but used to be
+  # supported in Internet Explorer 5 and 6, before the MS04-004 security
+  # update. See <URL:http://support.microsoft.com/kb/834489>.
+  #
+  class HTTP < Generic
+    # A Default port of 80 for URI::HTTP.
+    DEFAULT_PORT = 80
+
+    # An Array of the available components for URI::HTTP.
+    COMPONENT = %i[
+      scheme
+      userinfo host port
+      path
+      query
+      fragment
+    ].freeze
+
+    #
+    # == Description
+    #
+    # Creates a new URI::HTTP object from components, with syntax checking.
+    #
+    # The components accepted are userinfo, host, port, path, query, and
+    # fragment.
+    #
+    # The components should be provided either as an Array, or as a Hash
+    # with keys formed by preceding the component names with a colon.
+    #
+    # If an Array is used, the components must be passed in the
+    # order <code>[userinfo, host, port, path, query, fragment]</code>.
+    #
+    # Example:
+    #
+    #     uri = URI::HTTP.build(host: 'www.example.com', path: '/foo/bar')
+    #
+    #     uri = URI::HTTP.build([nil, "www.example.com", nil, "/path",
+    #       "query", 'fragment'])
+    #
+    # Currently, if passed userinfo components this method generates
+    # invalid HTTP URIs as per RFC 1738.
+    #
+    def self.build(args)
+      tmp = Util.make_components_hash(self, args)
+      super(tmp)
+    end
+
+    #
+    # == Description
+    #
+    # Returns the full path for an HTTP request, as required by Net::HTTP::Get.
+    #
+    # If the URI contains a query, the full path is URI#path + '?' + URI#query.
+    # Otherwise, the path is simply URI#path.
+    #
+    # Example:
+    #
+    #     uri = URI::HTTP.build(path: '/foo/bar', query: 'test=true')
+    #     uri.request_uri #  => "/foo/bar?test=true"
+    #
+    def request_uri
+      return unless @path
+
+      url = @query ? "#@path?#@query" : @path.dup
+      url.start_with?(?/.freeze) ? url : ?/ + url
+    end
+  end
+
+  @@schemes['HTTP'] = HTTP
+
+end

--- a/mruby/src/extn/stdlib/uri/http.rb
+++ b/mruby/src/extn/stdlib/uri/http.rb
@@ -78,7 +78,7 @@ module URI
     def request_uri
       return unless @path
 
-      url = @query ? "#@path?#@query" : @path.dup
+      url = @query ? "#{@path}?#{@query}" : @path.dup
       url.start_with?(?/.freeze) ? url : ?/ + url
     end
   end

--- a/mruby/src/extn/stdlib/uri/https.rb
+++ b/mruby/src/extn/stdlib/uri/https.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: false
+# = uri/https.rb
+#
+# Author:: Akira Yamada <akira@ruby-lang.org>
+# License:: You can redistribute it and/or modify it under the same term as Ruby.
+# Revision:: $Id$
+#
+# See URI for general documentation
+#
+
+require_relative 'http'
+
+module URI
+
+  # The default port for HTTPS URIs is 443, and the scheme is 'https:' rather
+  # than 'http:'. Other than that, HTTPS URIs are identical to HTTP URIs;
+  # see URI::HTTP.
+  class HTTPS < HTTP
+    # A Default port of 443 for URI::HTTPS
+    DEFAULT_PORT = 443
+  end
+  @@schemes['HTTPS'] = HTTPS
+end

--- a/mruby/src/extn/stdlib/uri/ldap.rb
+++ b/mruby/src/extn/stdlib/uri/ldap.rb
@@ -1,0 +1,261 @@
+# frozen_string_literal: false
+# = uri/ldap.rb
+#
+# Author::
+#  Takaaki Tateishi <ttate@jaist.ac.jp>
+#  Akira Yamada <akira@ruby-lang.org>
+# License::
+#   URI::LDAP is copyrighted free software by Takaaki Tateishi and Akira Yamada.
+#   You can redistribute it and/or modify it under the same term as Ruby.
+# Revision:: $Id$
+#
+# See URI for general documentation
+#
+
+require_relative 'generic'
+
+module URI
+
+  #
+  # LDAP URI SCHEMA (described in RFC2255).
+  #--
+  # ldap://<host>/<dn>[?<attrs>[?<scope>[?<filter>[?<extensions>]]]]
+  #++
+  class LDAP < Generic
+
+    # A Default port of 389 for URI::LDAP.
+    DEFAULT_PORT = 389
+
+    # An Array of the available components for URI::LDAP.
+    COMPONENT = [
+      :scheme,
+      :host, :port,
+      :dn,
+      :attributes,
+      :scope,
+      :filter,
+      :extensions,
+    ].freeze
+
+    # Scopes available for the starting point.
+    #
+    # * SCOPE_BASE - the Base DN
+    # * SCOPE_ONE  - one level under the Base DN, not including the base DN and
+    #   not including any entries under this
+    # * SCOPE_SUB  - subtrees, all entries at all levels
+    #
+    SCOPE = [
+      SCOPE_ONE = 'one',
+      SCOPE_SUB = 'sub',
+      SCOPE_BASE = 'base',
+    ].freeze
+
+    #
+    # == Description
+    #
+    # Creates a new URI::LDAP object from components, with syntax checking.
+    #
+    # The components accepted are host, port, dn, attributes,
+    # scope, filter, and extensions.
+    #
+    # The components should be provided either as an Array, or as a Hash
+    # with keys formed by preceding the component names with a colon.
+    #
+    # If an Array is used, the components must be passed in the
+    # order <code>[host, port, dn, attributes, scope, filter, extensions]</code>.
+    #
+    # Example:
+    #
+    #     uri = URI::LDAP.build({:host => 'ldap.example.com',
+    #       :dn => '/dc=example'})
+    #
+    #     uri = URI::LDAP.build(["ldap.example.com", nil,
+    #       "/dc=example;dc=com", "query", nil, nil, nil])
+    #
+    def self.build(args)
+      tmp = Util::make_components_hash(self, args)
+
+      if tmp[:dn]
+        tmp[:path] = tmp[:dn]
+      end
+
+      query = []
+      [:extensions, :filter, :scope, :attributes].collect do |x|
+        next if !tmp[x] && query.size == 0
+        query.unshift(tmp[x])
+      end
+
+      tmp[:query] = query.join('?')
+
+      return super(tmp)
+    end
+
+    #
+    # == Description
+    #
+    # Creates a new URI::LDAP object from generic URI components as per
+    # RFC 2396. No LDAP-specific syntax checking is performed.
+    #
+    # Arguments are +scheme+, +userinfo+, +host+, +port+, +registry+, +path+,
+    # +opaque+, +query+, and +fragment+, in that order.
+    #
+    # Example:
+    #
+    #     uri = URI::LDAP.new("ldap", nil, "ldap.example.com", nil, nil,
+    #       "/dc=example;dc=com", nil, "query", nil)
+    #
+    # See also URI::Generic.new.
+    #
+    def initialize(*arg)
+      super(*arg)
+
+      if @fragment
+        raise InvalidURIError, 'bad LDAP URL'
+      end
+
+      parse_dn
+      parse_query
+    end
+
+    # Private method to cleanup +dn+ from using the +path+ component attribute.
+    def parse_dn
+      @dn = @path[1..-1]
+    end
+    private :parse_dn
+
+    # Private method to cleanup +attributes+, +scope+, +filter+, and +extensions+
+    # from using the +query+ component attribute.
+    def parse_query
+      @attributes = nil
+      @scope      = nil
+      @filter     = nil
+      @extensions = nil
+
+      if @query
+        attrs, scope, filter, extensions = @query.split('?')
+
+        @attributes = attrs if attrs && attrs.size > 0
+        @scope      = scope if scope && scope.size > 0
+        @filter     = filter if filter && filter.size > 0
+        @extensions = extensions if extensions && extensions.size > 0
+      end
+    end
+    private :parse_query
+
+    # Private method to assemble +query+ from +attributes+, +scope+, +filter+, and +extensions+.
+    def build_path_query
+      @path = '/' + @dn
+
+      query = []
+      [@extensions, @filter, @scope, @attributes].each do |x|
+        next if !x && query.size == 0
+        query.unshift(x)
+      end
+      @query = query.join('?')
+    end
+    private :build_path_query
+
+    # Returns dn.
+    def dn
+      @dn
+    end
+
+    # Private setter for dn +val+.
+    def set_dn(val)
+      @dn = val
+      build_path_query
+      @dn
+    end
+    protected :set_dn
+
+    # Setter for dn +val+.
+    def dn=(val)
+      set_dn(val)
+      val
+    end
+
+    # Returns attributes.
+    def attributes
+      @attributes
+    end
+
+    # Private setter for attributes +val+.
+    def set_attributes(val)
+      @attributes = val
+      build_path_query
+      @attributes
+    end
+    protected :set_attributes
+
+    # Setter for attributes +val+.
+    def attributes=(val)
+      set_attributes(val)
+      val
+    end
+
+    # Returns scope.
+    def scope
+      @scope
+    end
+
+    # Private setter for scope +val+.
+    def set_scope(val)
+      @scope = val
+      build_path_query
+      @scope
+    end
+    protected :set_scope
+
+    # Setter for scope +val+.
+    def scope=(val)
+      set_scope(val)
+      val
+    end
+
+    # Returns filter.
+    def filter
+      @filter
+    end
+
+    # Private setter for filter +val+.
+    def set_filter(val)
+      @filter = val
+      build_path_query
+      @filter
+    end
+    protected :set_filter
+
+    # Setter for filter +val+.
+    def filter=(val)
+      set_filter(val)
+      val
+    end
+
+    # Returns extensions.
+    def extensions
+      @extensions
+    end
+
+    # Private setter for extensions +val+.
+    def set_extensions(val)
+      @extensions = val
+      build_path_query
+      @extensions
+    end
+    protected :set_extensions
+
+    # Setter for extensions +val+.
+    def extensions=(val)
+      set_extensions(val)
+      val
+    end
+
+    # Checks if URI has a path.
+    # For URI::LDAP this will return +false+.
+    def hierarchical?
+      false
+    end
+  end
+
+  @@schemes['LDAP'] = LDAP
+end

--- a/mruby/src/extn/stdlib/uri/ldaps.rb
+++ b/mruby/src/extn/stdlib/uri/ldaps.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: false
+# = uri/ldap.rb
+#
+# License:: You can redistribute it and/or modify it under the same term as Ruby.
+#
+# See URI for general documentation
+#
+
+require_relative 'ldap'
+
+module URI
+
+  # The default port for LDAPS URIs is 636, and the scheme is 'ldaps:' rather
+  # than 'ldap:'. Other than that, LDAPS URIs are identical to LDAP URIs;
+  # see URI::LDAP.
+  class LDAPS < LDAP
+    # A Default port of 636 for URI::LDAPS
+    DEFAULT_PORT = 636
+  end
+  @@schemes['LDAPS'] = LDAPS
+end

--- a/mruby/src/extn/stdlib/uri/mailto.rb
+++ b/mruby/src/extn/stdlib/uri/mailto.rb
@@ -1,0 +1,294 @@
+# frozen_string_literal: false
+# = uri/mailto.rb
+#
+# Author:: Akira Yamada <akira@ruby-lang.org>
+# License:: You can redistribute it and/or modify it under the same term as Ruby.
+# Revision:: $Id$
+#
+# See URI for general documentation
+#
+
+require_relative 'generic'
+
+module URI
+
+  #
+  # RFC6068, the mailto URL scheme.
+  #
+  class MailTo < Generic
+    include REGEXP
+
+    # A Default port of nil for URI::MailTo.
+    DEFAULT_PORT = nil
+
+    # An Array of the available components for URI::MailTo.
+    COMPONENT = [ :scheme, :to, :headers ].freeze
+
+    # :stopdoc:
+    #  "hname" and "hvalue" are encodings of an RFC 822 header name and
+    #  value, respectively. As with "to", all URL reserved characters must
+    #  be encoded.
+    #
+    #  "#mailbox" is as specified in RFC 822 [RFC822]. This means that it
+    #  consists of zero or more comma-separated mail addresses, possibly
+    #  including "phrase" and "comment" components. Note that all URL
+    #  reserved characters in "to" must be encoded: in particular,
+    #  parentheses, commas, and the percent sign ("%"), which commonly occur
+    #  in the "mailbox" syntax.
+    #
+    #  Within mailto URLs, the characters "?", "=", "&" are reserved.
+
+    # ; RFC 6068
+    # hfields      = "?" hfield *( "&" hfield )
+    # hfield       = hfname "=" hfvalue
+    # hfname       = *qchar
+    # hfvalue      = *qchar
+    # qchar        = unreserved / pct-encoded / some-delims
+    # some-delims  = "!" / "$" / "'" / "(" / ")" / "*"
+    #              / "+" / "," / ";" / ":" / "@"
+    #
+    # ; RFC3986
+    # unreserved   = ALPHA / DIGIT / "-" / "." / "_" / "~"
+    # pct-encoded  = "%" HEXDIG HEXDIG
+    HEADER_REGEXP  = /\A(?<hfield>(?:%\h\h|[!$'-.0-;@-Z_a-z~])*=(?:%\h\h|[!$'-.0-;@-Z_a-z~])*)(?:&\g<hfield>)*\z/
+    # practical regexp for email address
+    # https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
+    EMAIL_REGEXP = /\A[a-zA-Z0-9.!\#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\z/
+    # :startdoc:
+
+    #
+    # == Description
+    #
+    # Creates a new URI::MailTo object from components, with syntax checking.
+    #
+    # Components can be provided as an Array or Hash. If an Array is used,
+    # the components must be supplied as <code>[to, headers]</code>.
+    #
+    # If a Hash is used, the keys are the component names preceded by colons.
+    #
+    # The headers can be supplied as a pre-encoded string, such as
+    # <code>"subject=subscribe&cc=address"</code>, or as an Array of Arrays
+    # like <code>[['subject', 'subscribe'], ['cc', 'address']]</code>.
+    #
+    # Examples:
+    #
+    #    require 'uri'
+    #
+    #    m1 = URI::MailTo.build(['joe@example.com', 'subject=Ruby'])
+    #    m1.to_s  # => "mailto:joe@example.com?subject=Ruby"
+    #
+    #    m2 = URI::MailTo.build(['john@example.com', [['Subject', 'Ruby'], ['Cc', 'jack@example.com']]])
+    #    m2.to_s  # => "mailto:john@example.com?Subject=Ruby&Cc=jack@example.com"
+    #
+    #    m3 = URI::MailTo.build({:to => 'listman@example.com', :headers => [['subject', 'subscribe']]})
+    #    m3.to_s  # => "mailto:listman@example.com?subject=subscribe"
+    #
+    def self.build(args)
+      tmp = Util.make_components_hash(self, args)
+
+      case tmp[:to]
+      when Array
+        tmp[:opaque] = tmp[:to].join(',')
+      when String
+        tmp[:opaque] = tmp[:to].dup
+      else
+        tmp[:opaque] = ''
+      end
+
+      if tmp[:headers]
+        query =
+          case tmp[:headers]
+          when Array
+            tmp[:headers].collect { |x|
+              if x.kind_of?(Array)
+                x[0] + '=' + x[1..-1].join
+              else
+                x.to_s
+              end
+            }.join('&')
+          when Hash
+            tmp[:headers].collect { |h,v|
+              h + '=' + v
+            }.join('&')
+          else
+            tmp[:headers].to_s
+          end
+        unless query.empty?
+          tmp[:opaque] << '?' << query
+        end
+      end
+
+      super(tmp)
+    end
+
+    #
+    # == Description
+    #
+    # Creates a new URI::MailTo object from generic URL components with
+    # no syntax checking.
+    #
+    # This method is usually called from URI::parse, which checks
+    # the validity of each component.
+    #
+    def initialize(*arg)
+      super(*arg)
+
+      @to = nil
+      @headers = []
+
+      # The RFC3986 parser does not normally populate opaque
+      @opaque = "?#{@query}" if @query && !@opaque
+
+      unless @opaque
+        raise InvalidComponentError,
+          "missing opaque part for mailto URL"
+      end
+      to, header = @opaque.split('?', 2)
+      # allow semicolon as a addr-spec separator
+      # http://support.microsoft.com/kb/820868
+      unless /\A(?:[^@,;]+@[^@,;]+(?:\z|[,;]))*\z/ =~ to
+        raise InvalidComponentError,
+          "unrecognised opaque part for mailtoURL: #{@opaque}"
+      end
+
+      if arg[10] # arg_check
+        self.to = to
+        self.headers = header
+      else
+        set_to(to)
+        set_headers(header)
+      end
+    end
+
+    # The primary e-mail address of the URL, as a String.
+    attr_reader :to
+
+    # E-mail headers set by the URL, as an Array of Arrays.
+    attr_reader :headers
+
+    # Checks the to +v+ component.
+    def check_to(v)
+      return true unless v
+      return true if v.size == 0
+
+      v.split(/[,;]/).each do |addr|
+        # check url safety as path-rootless
+        if /\A(?:%\h\h|[!$&-.0-;=@-Z_a-z~])*\z/ !~ addr
+          raise InvalidComponentError,
+            "an address in 'to' is invalid as URI #{addr.dump}"
+        end
+
+        # check addr-spec
+        # don't s/\+/ /g
+        addr.gsub!(/%\h\h/, URI::TBLDECWWWCOMP_)
+        if EMAIL_REGEXP !~ addr
+          raise InvalidComponentError,
+            "an address in 'to' is invalid as uri-escaped addr-spec #{addr.dump}"
+        end
+      end
+
+      true
+    end
+    private :check_to
+
+    # Private setter for to +v+.
+    def set_to(v)
+      @to = v
+    end
+    protected :set_to
+
+    # Setter for to +v+.
+    def to=(v)
+      check_to(v)
+      set_to(v)
+      v
+    end
+
+    # Checks the headers +v+ component against either
+    # * HEADER_REGEXP
+    def check_headers(v)
+      return true unless v
+      return true if v.size == 0
+      if HEADER_REGEXP !~ v
+        raise InvalidComponentError,
+          "bad component(expected opaque component): #{v}"
+      end
+
+      true
+    end
+    private :check_headers
+
+    # Private setter for headers +v+.
+    def set_headers(v)
+      @headers = []
+      if v
+        v.split('&').each do |x|
+          @headers << x.split(/=/, 2)
+        end
+      end
+    end
+    protected :set_headers
+
+    # Setter for headers +v+.
+    def headers=(v)
+      check_headers(v)
+      set_headers(v)
+      v
+    end
+
+    # Constructs String from URI.
+    def to_s
+      @scheme + ':' +
+        if @to
+          @to
+        else
+          ''
+        end +
+        if @headers.size > 0
+          '?' + @headers.collect{|x| x.join('=')}.join('&')
+        else
+          ''
+        end +
+        if @fragment
+          '#' + @fragment
+        else
+          ''
+        end
+    end
+
+    # Returns the RFC822 e-mail text equivalent of the URL, as a String.
+    #
+    # Example:
+    #
+    #   require 'uri'
+    #
+    #   uri = URI.parse("mailto:ruby-list@ruby-lang.org?Subject=subscribe&cc=myaddr")
+    #   uri.to_mailtext
+    #   # => "To: ruby-list@ruby-lang.org\nSubject: subscribe\nCc: myaddr\n\n\n"
+    #
+    def to_mailtext
+      to = URI.decode_www_form_component(@to)
+      head = ''
+      body = ''
+      @headers.each do |x|
+        case x[0]
+        when 'body'
+          body = URI.decode_www_form_component(x[1])
+        when 'to'
+          to << ', ' + URI.decode_www_form_component(x[1])
+        else
+          head << URI.decode_www_form_component(x[0]).capitalize + ': ' +
+            URI.decode_www_form_component(x[1])  + "\n"
+        end
+      end
+
+      "To: #{to}
+#{head}
+#{body}
+"
+    end
+    alias to_rfc822text to_mailtext
+  end
+
+  @@schemes['MAILTO'] = MailTo
+end

--- a/mruby/src/extn/stdlib/uri/rfc2396_parser.rb
+++ b/mruby/src/extn/stdlib/uri/rfc2396_parser.rb
@@ -1,0 +1,546 @@
+# frozen_string_literal: false
+#--
+# = uri/common.rb
+#
+# Author:: Akira Yamada <akira@ruby-lang.org>
+# Revision:: $Id$
+# License::
+#   You can redistribute it and/or modify it under the same term as Ruby.
+#
+# See URI for general documentation
+#
+
+module URI
+  #
+  # Includes URI::REGEXP::PATTERN
+  #
+  module RFC2396_REGEXP
+    #
+    # Patterns used to parse URI's
+    #
+    module PATTERN
+      # :stopdoc:
+
+      # RFC 2396 (URI Generic Syntax)
+      # RFC 2732 (IPv6 Literal Addresses in URL's)
+      # RFC 2373 (IPv6 Addressing Architecture)
+
+      # alpha         = lowalpha | upalpha
+      ALPHA = "a-zA-Z"
+      # alphanum      = alpha | digit
+      ALNUM = "#{ALPHA}\\d"
+
+      # hex           = digit | "A" | "B" | "C" | "D" | "E" | "F" |
+      #                         "a" | "b" | "c" | "d" | "e" | "f"
+      HEX     = "a-fA-F\\d"
+      # escaped       = "%" hex hex
+      ESCAPED = "%[#{HEX}]{2}"
+      # mark          = "-" | "_" | "." | "!" | "~" | "*" | "'" |
+      #                 "(" | ")"
+      # unreserved    = alphanum | mark
+      UNRESERVED = "\\-_.!~*'()#{ALNUM}"
+      # reserved      = ";" | "/" | "?" | ":" | "@" | "&" | "=" | "+" |
+      #                 "$" | ","
+      # reserved      = ";" | "/" | "?" | ":" | "@" | "&" | "=" | "+" |
+      #                 "$" | "," | "[" | "]" (RFC 2732)
+      RESERVED = ";/?:@&=+$,\\[\\]"
+
+      # domainlabel   = alphanum | alphanum *( alphanum | "-" ) alphanum
+      DOMLABEL = "(?:[#{ALNUM}](?:[-#{ALNUM}]*[#{ALNUM}])?)"
+      # toplabel      = alpha | alpha *( alphanum | "-" ) alphanum
+      TOPLABEL = "(?:[#{ALPHA}](?:[-#{ALNUM}]*[#{ALNUM}])?)"
+      # hostname      = *( domainlabel "." ) toplabel [ "." ]
+      HOSTNAME = "(?:#{DOMLABEL}\\.)*#{TOPLABEL}\\.?"
+
+      # :startdoc:
+    end # PATTERN
+
+    # :startdoc:
+  end # REGEXP
+
+  # Class that parses String's into URI's.
+  #
+  # It contains a Hash set of patterns and Regexp's that match and validate.
+  #
+  class RFC2396_Parser
+    include RFC2396_REGEXP
+
+    #
+    # == Synopsis
+    #
+    #   URI::Parser.new([opts])
+    #
+    # == Args
+    #
+    # The constructor accepts a hash as options for parser.
+    # Keys of options are pattern names of URI components
+    # and values of options are pattern strings.
+    # The constructor generates set of regexps for parsing URIs.
+    #
+    # You can use the following keys:
+    #
+    #   * :ESCAPED (URI::PATTERN::ESCAPED in default)
+    #   * :UNRESERVED (URI::PATTERN::UNRESERVED in default)
+    #   * :DOMLABEL (URI::PATTERN::DOMLABEL in default)
+    #   * :TOPLABEL (URI::PATTERN::TOPLABEL in default)
+    #   * :HOSTNAME (URI::PATTERN::HOSTNAME in default)
+    #
+    # == Examples
+    #
+    #   p = URI::Parser.new(:ESCAPED => "(?:%[a-fA-F0-9]{2}|%u[a-fA-F0-9]{4})")
+    #   u = p.parse("http://example.jp/%uABCD") #=> #<URI::HTTP http://example.jp/%uABCD>
+    #   URI.parse(u.to_s) #=> raises URI::InvalidURIError
+    #
+    #   s = "http://example.com/ABCD"
+    #   u1 = p.parse(s) #=> #<URI::HTTP http://example.com/ABCD>
+    #   u2 = URI.parse(s) #=> #<URI::HTTP http://example.com/ABCD>
+    #   u1 == u2 #=> true
+    #   u1.eql?(u2) #=> false
+    #
+    def initialize(opts = {})
+      @pattern = initialize_pattern(opts)
+      @pattern.each_value(&:freeze)
+      @pattern.freeze
+
+      @regexp = initialize_regexp(@pattern)
+      @regexp.each_value(&:freeze)
+      @regexp.freeze
+    end
+
+    # The Hash of patterns.
+    #
+    # See also URI::Parser.initialize_pattern.
+    attr_reader :pattern
+
+    # The Hash of Regexp.
+    #
+    # See also URI::Parser.initialize_regexp.
+    attr_reader :regexp
+
+    # Returns a split URI against regexp[:ABS_URI].
+    def split(uri)
+      case uri
+      when ''
+        # null uri
+
+      when @regexp[:ABS_URI]
+        scheme, opaque, userinfo, host, port,
+          registry, path, query, fragment = $~[1..-1]
+
+        # URI-reference = [ absoluteURI | relativeURI ] [ "#" fragment ]
+
+        # absoluteURI   = scheme ":" ( hier_part | opaque_part )
+        # hier_part     = ( net_path | abs_path ) [ "?" query ]
+        # opaque_part   = uric_no_slash *uric
+
+        # abs_path      = "/"  path_segments
+        # net_path      = "//" authority [ abs_path ]
+
+        # authority     = server | reg_name
+        # server        = [ [ userinfo "@" ] hostport ]
+
+        if !scheme
+          raise InvalidURIError,
+            "bad URI(absolute but no scheme): #{uri}"
+        end
+        if !opaque && (!path && (!host && !registry))
+          raise InvalidURIError,
+            "bad URI(absolute but no path): #{uri}"
+        end
+
+      when @regexp[:REL_URI]
+        scheme = nil
+        opaque = nil
+
+        userinfo, host, port, registry,
+          rel_segment, abs_path, query, fragment = $~[1..-1]
+        if rel_segment && abs_path
+          path = rel_segment + abs_path
+        elsif rel_segment
+          path = rel_segment
+        elsif abs_path
+          path = abs_path
+        end
+
+        # URI-reference = [ absoluteURI | relativeURI ] [ "#" fragment ]
+
+        # relativeURI   = ( net_path | abs_path | rel_path ) [ "?" query ]
+
+        # net_path      = "//" authority [ abs_path ]
+        # abs_path      = "/"  path_segments
+        # rel_path      = rel_segment [ abs_path ]
+
+        # authority     = server | reg_name
+        # server        = [ [ userinfo "@" ] hostport ]
+
+      else
+        raise InvalidURIError, "bad URI(is not URI?): #{uri}"
+      end
+
+      path = '' if !path && !opaque # (see RFC2396 Section 5.2)
+      ret = [
+        scheme,
+        userinfo, host, port,         # X
+        registry,                     # X
+        path,                         # Y
+        opaque,                       # Y
+        query,
+        fragment
+      ]
+      return ret
+    end
+
+    #
+    # == Args
+    #
+    # +uri+::
+    #    String
+    #
+    # == Description
+    #
+    # Parses +uri+ and constructs either matching URI scheme object
+    # (File, FTP, HTTP, HTTPS, LDAP, LDAPS, or MailTo) or URI::Generic.
+    #
+    # == Usage
+    #
+    #   p = URI::Parser.new
+    #   p.parse("ldap://ldap.example.com/dc=example?user=john")
+    #   #=> #<URI::LDAP ldap://ldap.example.com/dc=example?user=john>
+    #
+    def parse(uri)
+      scheme, userinfo, host, port,
+        registry, path, opaque, query, fragment = self.split(uri)
+
+      if scheme && URI.scheme_list.include?(scheme.upcase)
+        URI.scheme_list[scheme.upcase].new(scheme, userinfo, host, port,
+                                           registry, path, opaque, query,
+                                           fragment, self)
+      else
+        Generic.new(scheme, userinfo, host, port,
+                    registry, path, opaque, query,
+                    fragment, self)
+      end
+    end
+
+
+    #
+    # == Args
+    #
+    # +uris+::
+    #    an Array of Strings
+    #
+    # == Description
+    #
+    # Attempts to parse and merge a set of URIs.
+    #
+    def join(*uris)
+      uris[0] = convert_to_uri(uris[0])
+      uris.inject :merge
+    end
+
+    #
+    # :call-seq:
+    #   extract( str )
+    #   extract( str, schemes )
+    #   extract( str, schemes ) {|item| block }
+    #
+    # == Args
+    #
+    # +str+::
+    #    String to search
+    # +schemes+::
+    #    Patterns to apply to +str+
+    #
+    # == Description
+    #
+    # Attempts to parse and merge a set of URIs.
+    # If no +block+ given, then returns the result,
+    # else it calls +block+ for each element in result.
+    #
+    # See also URI::Parser.make_regexp.
+    #
+    def extract(str, schemes = nil)
+      if block_given?
+        str.scan(make_regexp(schemes)) { yield $& }
+        nil
+      else
+        result = []
+        str.scan(make_regexp(schemes)) { result.push $& }
+        result
+      end
+    end
+
+    # Returns Regexp that is default self.regexp[:ABS_URI_REF],
+    # unless +schemes+ is provided. Then it is a Regexp.union with self.pattern[:X_ABS_URI].
+    def make_regexp(schemes = nil)
+      unless schemes
+        @regexp[:ABS_URI_REF]
+      else
+        /(?=#{Regexp.union(*schemes)}:)#{@pattern[:X_ABS_URI]}/x
+      end
+    end
+
+    #
+    # :call-seq:
+    #   escape( str )
+    #   escape( str, unsafe )
+    #
+    # == Args
+    #
+    # +str+::
+    #    String to make safe
+    # +unsafe+::
+    #    Regexp to apply. Defaults to self.regexp[:UNSAFE]
+    #
+    # == Description
+    #
+    # Constructs a safe String from +str+, removing unsafe characters,
+    # replacing them with codes.
+    #
+    def escape(str, unsafe = @regexp[:UNSAFE])
+      unless unsafe.kind_of?(Regexp)
+        # perhaps unsafe is String object
+        unsafe = Regexp.new("[#{Regexp.quote(unsafe)}]", false)
+      end
+      str.gsub(unsafe) do
+        us = $&
+        tmp = ''
+        us.each_byte do |uc|
+          tmp << sprintf('%%%02X', uc)
+        end
+        tmp
+      end.force_encoding(Encoding::US_ASCII)
+    end
+
+    #
+    # :call-seq:
+    #   unescape( str )
+    #   unescape( str, escaped )
+    #
+    # == Args
+    #
+    # +str+::
+    #    String to remove escapes from
+    # +escaped+::
+    #    Regexp to apply. Defaults to self.regexp[:ESCAPED]
+    #
+    # == Description
+    #
+    # Removes escapes from +str+.
+    #
+    def unescape(str, escaped = @regexp[:ESCAPED])
+      enc = str.encoding
+      enc = Encoding::UTF_8 if enc == Encoding::US_ASCII
+      str.gsub(escaped) { [$&[1, 2]].pack('H2').force_encoding(enc) }
+    end
+
+    @@to_s = Kernel.instance_method(:to_s)
+    def inspect
+      @@to_s.bind(self).call
+    end
+
+    private
+
+    # Constructs the default Hash of patterns.
+    def initialize_pattern(opts = {})
+      ret = {}
+      ret[:ESCAPED] = escaped = (opts.delete(:ESCAPED) || PATTERN::ESCAPED)
+      ret[:UNRESERVED] = unreserved = opts.delete(:UNRESERVED) || PATTERN::UNRESERVED
+      ret[:RESERVED] = reserved = opts.delete(:RESERVED) || PATTERN::RESERVED
+      ret[:DOMLABEL] = opts.delete(:DOMLABEL) || PATTERN::DOMLABEL
+      ret[:TOPLABEL] = opts.delete(:TOPLABEL) || PATTERN::TOPLABEL
+      ret[:HOSTNAME] = hostname = opts.delete(:HOSTNAME)
+
+      # RFC 2396 (URI Generic Syntax)
+      # RFC 2732 (IPv6 Literal Addresses in URL's)
+      # RFC 2373 (IPv6 Addressing Architecture)
+
+      # uric          = reserved | unreserved | escaped
+      ret[:URIC] = uric = "(?:[#{unreserved}#{reserved}]|#{escaped})"
+      # uric_no_slash = unreserved | escaped | ";" | "?" | ":" | "@" |
+      #                 "&" | "=" | "+" | "$" | ","
+      ret[:URIC_NO_SLASH] = uric_no_slash = "(?:[#{unreserved};?:@&=+$,]|#{escaped})"
+      # query         = *uric
+      ret[:QUERY] = query = "#{uric}*"
+      # fragment      = *uric
+      ret[:FRAGMENT] = fragment = "#{uric}*"
+
+      # hostname      = *( domainlabel "." ) toplabel [ "." ]
+      # reg-name      = *( unreserved / pct-encoded / sub-delims ) # RFC3986
+      unless hostname
+        ret[:HOSTNAME] = hostname = "(?:[a-zA-Z0-9\\-.]|%\\h\\h)+"
+      end
+
+      # RFC 2373, APPENDIX B:
+      # IPv6address = hexpart [ ":" IPv4address ]
+      # IPv4address   = 1*3DIGIT "." 1*3DIGIT "." 1*3DIGIT "." 1*3DIGIT
+      # hexpart = hexseq | hexseq "::" [ hexseq ] | "::" [ hexseq ]
+      # hexseq  = hex4 *( ":" hex4)
+      # hex4    = 1*4HEXDIG
+      #
+      # XXX: This definition has a flaw. "::" + IPv4address must be
+      # allowed too.  Here is a replacement.
+      #
+      # IPv4address = 1*3DIGIT "." 1*3DIGIT "." 1*3DIGIT "." 1*3DIGIT
+      ret[:IPV4ADDR] = ipv4addr = "\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
+      # hex4     = 1*4HEXDIG
+      hex4 = "[#{PATTERN::HEX}]{1,4}"
+      # lastpart = hex4 | IPv4address
+      lastpart = "(?:#{hex4}|#{ipv4addr})"
+      # hexseq1  = *( hex4 ":" ) hex4
+      hexseq1 = "(?:#{hex4}:)*#{hex4}"
+      # hexseq2  = *( hex4 ":" ) lastpart
+      hexseq2 = "(?:#{hex4}:)*#{lastpart}"
+      # IPv6address = hexseq2 | [ hexseq1 ] "::" [ hexseq2 ]
+      ret[:IPV6ADDR] = ipv6addr = "(?:#{hexseq2}|(?:#{hexseq1})?::(?:#{hexseq2})?)"
+
+      # IPv6prefix  = ( hexseq1 | [ hexseq1 ] "::" [ hexseq1 ] ) "/" 1*2DIGIT
+      # unused
+
+      # ipv6reference = "[" IPv6address "]" (RFC 2732)
+      ret[:IPV6REF] = ipv6ref = "\\[#{ipv6addr}\\]"
+
+      # host          = hostname | IPv4address
+      # host          = hostname | IPv4address | IPv6reference (RFC 2732)
+      ret[:HOST] = host = "(?:#{hostname}|#{ipv4addr}|#{ipv6ref})"
+      # port          = *digit
+      ret[:PORT] = port = '\d*'
+      # hostport      = host [ ":" port ]
+      ret[:HOSTPORT] = hostport = "#{host}(?::#{port})?"
+
+      # userinfo      = *( unreserved | escaped |
+      #                    ";" | ":" | "&" | "=" | "+" | "$" | "," )
+      ret[:USERINFO] = userinfo = "(?:[#{unreserved};:&=+$,]|#{escaped})*"
+
+      # pchar         = unreserved | escaped |
+      #                 ":" | "@" | "&" | "=" | "+" | "$" | ","
+      pchar = "(?:[#{unreserved}:@&=+$,]|#{escaped})"
+      # param         = *pchar
+      param = "#{pchar}*"
+      # segment       = *pchar *( ";" param )
+      segment = "#{pchar}*(?:;#{param})*"
+      # path_segments = segment *( "/" segment )
+      ret[:PATH_SEGMENTS] = path_segments = "#{segment}(?:/#{segment})*"
+
+      # server        = [ [ userinfo "@" ] hostport ]
+      server = "(?:#{userinfo}@)?#{hostport}"
+      # reg_name      = 1*( unreserved | escaped | "$" | "," |
+      #                     ";" | ":" | "@" | "&" | "=" | "+" )
+      ret[:REG_NAME] = reg_name = "(?:[#{unreserved}$,;:@&=+]|#{escaped})+"
+      # authority     = server | reg_name
+      authority = "(?:#{server}|#{reg_name})"
+
+      # rel_segment   = 1*( unreserved | escaped |
+      #                     ";" | "@" | "&" | "=" | "+" | "$" | "," )
+      ret[:REL_SEGMENT] = rel_segment = "(?:[#{unreserved};@&=+$,]|#{escaped})+"
+
+      # scheme        = alpha *( alpha | digit | "+" | "-" | "." )
+      ret[:SCHEME] = scheme = "[#{PATTERN::ALPHA}][\\-+.#{PATTERN::ALPHA}\\d]*"
+
+      # abs_path      = "/"  path_segments
+      ret[:ABS_PATH] = abs_path = "/#{path_segments}"
+      # rel_path      = rel_segment [ abs_path ]
+      ret[:REL_PATH] = rel_path = "#{rel_segment}(?:#{abs_path})?"
+      # net_path      = "//" authority [ abs_path ]
+      ret[:NET_PATH] = net_path = "//#{authority}(?:#{abs_path})?"
+
+      # hier_part     = ( net_path | abs_path ) [ "?" query ]
+      ret[:HIER_PART] = hier_part = "(?:#{net_path}|#{abs_path})(?:\\?(?:#{query}))?"
+      # opaque_part   = uric_no_slash *uric
+      ret[:OPAQUE_PART] = opaque_part = "#{uric_no_slash}#{uric}*"
+
+      # absoluteURI   = scheme ":" ( hier_part | opaque_part )
+      ret[:ABS_URI] = abs_uri = "#{scheme}:(?:#{hier_part}|#{opaque_part})"
+      # relativeURI   = ( net_path | abs_path | rel_path ) [ "?" query ]
+      ret[:REL_URI] = rel_uri = "(?:#{net_path}|#{abs_path}|#{rel_path})(?:\\?#{query})?"
+
+      # URI-reference = [ absoluteURI | relativeURI ] [ "#" fragment ]
+      ret[:URI_REF] = "(?:#{abs_uri}|#{rel_uri})?(?:##{fragment})?"
+
+      ret[:X_ABS_URI] = "
+        (#{scheme}):                           (?# 1: scheme)
+        (?:
+           (#{opaque_part})                    (?# 2: opaque)
+        |
+           (?:(?:
+             //(?:
+                 (?:(?:(#{userinfo})@)?        (?# 3: userinfo)
+                   (?:(#{host})(?::(\\d*))?))? (?# 4: host, 5: port)
+               |
+                 (#{reg_name})                 (?# 6: registry)
+               )
+             |
+             (?!//))                           (?# XXX: '//' is the mark for hostport)
+             (#{abs_path})?                    (?# 7: path)
+           )(?:\\?(#{query}))?                 (?# 8: query)
+        )
+        (?:\\#(#{fragment}))?                  (?# 9: fragment)
+      "
+
+      ret[:X_REL_URI] = "
+        (?:
+          (?:
+            //
+            (?:
+              (?:(#{userinfo})@)?       (?# 1: userinfo)
+                (#{host})?(?::(\\d*))?  (?# 2: host, 3: port)
+            |
+              (#{reg_name})             (?# 4: registry)
+            )
+          )
+        |
+          (#{rel_segment})              (?# 5: rel_segment)
+        )?
+        (#{abs_path})?                  (?# 6: abs_path)
+        (?:\\?(#{query}))?              (?# 7: query)
+        (?:\\#(#{fragment}))?           (?# 8: fragment)
+      "
+
+      ret
+    end
+
+    # Constructs the default Hash of Regexp's.
+    def initialize_regexp(pattern)
+      ret = {}
+
+      # for URI::split
+      ret[:ABS_URI] = Regexp.new('\A\s*' + pattern[:X_ABS_URI] + '\s*\z', Regexp::EXTENDED)
+      ret[:REL_URI] = Regexp.new('\A\s*' + pattern[:X_REL_URI] + '\s*\z', Regexp::EXTENDED)
+
+      # for URI::extract
+      ret[:URI_REF]     = Regexp.new(pattern[:URI_REF])
+      ret[:ABS_URI_REF] = Regexp.new(pattern[:X_ABS_URI], Regexp::EXTENDED)
+      ret[:REL_URI_REF] = Regexp.new(pattern[:X_REL_URI], Regexp::EXTENDED)
+
+      # for URI::escape/unescape
+      ret[:ESCAPED] = Regexp.new(pattern[:ESCAPED])
+      ret[:UNSAFE]  = Regexp.new("[^#{pattern[:UNRESERVED]}#{pattern[:RESERVED]}]")
+
+      # for Generic#initialize
+      ret[:SCHEME]   = Regexp.new("\\A#{pattern[:SCHEME]}\\z")
+      ret[:USERINFO] = Regexp.new("\\A#{pattern[:USERINFO]}\\z")
+      ret[:HOST]     = Regexp.new("\\A#{pattern[:HOST]}\\z")
+      ret[:PORT]     = Regexp.new("\\A#{pattern[:PORT]}\\z")
+      ret[:OPAQUE]   = Regexp.new("\\A#{pattern[:OPAQUE_PART]}\\z")
+      ret[:REGISTRY] = Regexp.new("\\A#{pattern[:REG_NAME]}\\z")
+      ret[:ABS_PATH] = Regexp.new("\\A#{pattern[:ABS_PATH]}\\z")
+      ret[:REL_PATH] = Regexp.new("\\A#{pattern[:REL_PATH]}\\z")
+      ret[:QUERY]    = Regexp.new("\\A#{pattern[:QUERY]}\\z")
+      ret[:FRAGMENT] = Regexp.new("\\A#{pattern[:FRAGMENT]}\\z")
+
+      ret
+    end
+
+    def convert_to_uri(uri)
+      if uri.is_a?(URI::Generic)
+        uri
+      elsif uri = String.try_convert(uri)
+        parse(uri)
+      else
+        raise ArgumentError,
+          "bad argument (expected URI object or URI string)"
+      end
+    end
+
+  end # class Parser
+end # module URI

--- a/mruby/src/extn/stdlib/uri/rfc3986_parser.rb
+++ b/mruby/src/extn/stdlib/uri/rfc3986_parser.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: false
+module URI
+  class RFC3986_Parser # :nodoc:
+    # URI defined in RFC3986
+    # this regexp is modified not to host is not empty string
+    RFC3986_URI = /\A(?<URI>(?<scheme>[A-Za-z][+\-.0-9A-Za-z]*):(?<hier-part>\/\/(?<authority>(?:(?<userinfo>(?:%\h\h|[!$&-.0-;=A-Z_a-z~])*)@)?(?<host>(?<IP-literal>\[(?:(?<IPv6address>(?:\h{1,4}:){6}(?<ls32>\h{1,4}:\h{1,4}|(?<IPv4address>(?<dec-octet>[1-9]\d|1\d{2}|2[0-4]\d|25[0-5]|\d)\.\g<dec-octet>\.\g<dec-octet>\.\g<dec-octet>))|::(?:\h{1,4}:){5}\g<ls32>|\h{1,4}?::(?:\h{1,4}:){4}\g<ls32>|(?:(?:\h{1,4}:)?\h{1,4})?::(?:\h{1,4}:){3}\g<ls32>|(?:(?:\h{1,4}:){,2}\h{1,4})?::(?:\h{1,4}:){2}\g<ls32>|(?:(?:\h{1,4}:){,3}\h{1,4})?::\h{1,4}:\g<ls32>|(?:(?:\h{1,4}:){,4}\h{1,4})?::\g<ls32>|(?:(?:\h{1,4}:){,5}\h{1,4})?::\h{1,4}|(?:(?:\h{1,4}:){,6}\h{1,4})?::)|(?<IPvFuture>v\h+\.[!$&-.0-;=A-Z_a-z~]+))\])|\g<IPv4address>|(?<reg-name>(?:%\h\h|[!$&-.0-9;=A-Z_a-z~])+))?(?::(?<port>\d*))?)(?<path-abempty>(?:\/(?<segment>(?:%\h\h|[!$&-.0-;=@-Z_a-z~])*))*)|(?<path-absolute>\/(?:(?<segment-nz>(?:%\h\h|[!$&-.0-;=@-Z_a-z~])+)(?:\/\g<segment>)*)?)|(?<path-rootless>\g<segment-nz>(?:\/\g<segment>)*)|(?<path-empty>))(?:\?(?<query>[^#]*))?(?:\#(?<fragment>(?:%\h\h|[!$&-.0-;=@-Z_a-z~\/?])*))?)\z/
+    RFC3986_relative_ref = /\A(?<relative-ref>(?<relative-part>\/\/(?<authority>(?:(?<userinfo>(?:%\h\h|[!$&-.0-;=A-Z_a-z~])*)@)?(?<host>(?<IP-literal>\[(?<IPv6address>(?:\h{1,4}:){6}(?<ls32>\h{1,4}:\h{1,4}|(?<IPv4address>(?<dec-octet>[1-9]\d|1\d{2}|2[0-4]\d|25[0-5]|\d)\.\g<dec-octet>\.\g<dec-octet>\.\g<dec-octet>))|::(?:\h{1,4}:){5}\g<ls32>|\h{1,4}?::(?:\h{1,4}:){4}\g<ls32>|(?:(?:\h{1,4}:){,1}\h{1,4})?::(?:\h{1,4}:){3}\g<ls32>|(?:(?:\h{1,4}:){,2}\h{1,4})?::(?:\h{1,4}:){2}\g<ls32>|(?:(?:\h{1,4}:){,3}\h{1,4})?::\h{1,4}:\g<ls32>|(?:(?:\h{1,4}:){,4}\h{1,4})?::\g<ls32>|(?:(?:\h{1,4}:){,5}\h{1,4})?::\h{1,4}|(?:(?:\h{1,4}:){,6}\h{1,4})?::)|(?<IPvFuture>v\h+\.[!$&-.0-;=A-Z_a-z~]+)\])|\g<IPv4address>|(?<reg-name>(?:%\h\h|[!$&-.0-9;=A-Z_a-z~])+))?(?::(?<port>\d*))?)(?<path-abempty>(?:\/(?<segment>(?:%\h\h|[!$&-.0-;=@-Z_a-z~])*))*)|(?<path-absolute>\/(?:(?<segment-nz>(?:%\h\h|[!$&-.0-;=@-Z_a-z~])+)(?:\/\g<segment>)*)?)|(?<path-noscheme>(?<segment-nz-nc>(?:%\h\h|[!$&-.0-9;=@-Z_a-z~])+)(?:\/\g<segment>)*)|(?<path-empty>))(?:\?(?<query>[^#]*))?(?:\#(?<fragment>(?:%\h\h|[!$&-.0-;=@-Z_a-z~\/?])*))?)\z/
+    attr_reader :regexp
+
+    def initialize
+      @regexp = default_regexp.each_value(&:freeze).freeze
+    end
+
+    def split(uri) #:nodoc:
+      begin
+        uri = uri.to_str
+      rescue NoMethodError
+        raise InvalidURIError, "bad URI(is not URI?): #{uri.inspect}"
+      end
+      uri.ascii_only? or
+        raise InvalidURIError, "URI must be ascii only #{uri.dump}"
+      if m = RFC3986_URI.match(uri)
+        query = m["query".freeze]
+        scheme = m["scheme".freeze]
+        opaque = m["path-rootless".freeze]
+        if opaque
+          opaque << "?#{query}" if query
+          [ scheme,
+            nil, # userinfo
+            nil, # host
+            nil, # port
+            nil, # registry
+            nil, # path
+            opaque,
+            nil, # query
+            m["fragment".freeze]
+          ]
+        else # normal
+          [ scheme,
+            m["userinfo".freeze],
+            m["host".freeze],
+            m["port".freeze],
+            nil, # registry
+            (m["path-abempty".freeze] ||
+             m["path-absolute".freeze] ||
+             m["path-empty".freeze]),
+            nil, # opaque
+            query,
+            m["fragment".freeze]
+          ]
+        end
+      elsif m = RFC3986_relative_ref.match(uri)
+        [ nil, # scheme
+          m["userinfo".freeze],
+          m["host".freeze],
+          m["port".freeze],
+          nil, # registry,
+          (m["path-abempty".freeze] ||
+           m["path-absolute".freeze] ||
+           m["path-noscheme".freeze] ||
+           m["path-empty".freeze]),
+          nil, # opaque
+          m["query".freeze],
+          m["fragment".freeze]
+        ]
+      else
+        raise InvalidURIError, "bad URI(is not URI?): #{uri.inspect}"
+      end
+    end
+
+    def parse(uri) # :nodoc:
+      scheme, userinfo, host, port,
+        registry, path, opaque, query, fragment = self.split(uri)
+      scheme_list = URI.scheme_list
+      if scheme && scheme_list.include?(uc = scheme.upcase)
+        scheme_list[uc].new(scheme, userinfo, host, port,
+                            registry, path, opaque, query,
+                            fragment, self)
+      else
+        Generic.new(scheme, userinfo, host, port,
+                    registry, path, opaque, query,
+                    fragment, self)
+      end
+    end
+
+
+    def join(*uris) # :nodoc:
+      uris[0] = convert_to_uri(uris[0])
+      uris.inject :merge
+    end
+
+    @@to_s = Kernel.instance_method(:to_s)
+    def inspect
+      @@to_s.bind(self).call
+    end
+
+    private
+
+    def default_regexp # :nodoc:
+      {
+        SCHEME: /\A[A-Za-z][A-Za-z0-9+\-.]*\z/,
+        USERINFO: /\A(?:%\h\h|[!$&-.0-;=A-Z_a-z~])*\z/,
+        HOST: /\A(?:(?<IP-literal>\[(?:(?<IPv6address>(?:\h{1,4}:){6}(?<ls32>\h{1,4}:\h{1,4}|(?<IPv4address>(?<dec-octet>[1-9]\d|1\d{2}|2[0-4]\d|25[0-5]|\d)\.\g<dec-octet>\.\g<dec-octet>\.\g<dec-octet>))|::(?:\h{1,4}:){5}\g<ls32>|\h{,4}::(?:\h{1,4}:){4}\g<ls32>|(?:(?:\h{1,4}:)?\h{1,4})?::(?:\h{1,4}:){3}\g<ls32>|(?:(?:\h{1,4}:){,2}\h{1,4})?::(?:\h{1,4}:){2}\g<ls32>|(?:(?:\h{1,4}:){,3}\h{1,4})?::\h{1,4}:\g<ls32>|(?:(?:\h{1,4}:){,4}\h{1,4})?::\g<ls32>|(?:(?:\h{1,4}:){,5}\h{1,4})?::\h{1,4}|(?:(?:\h{1,4}:){,6}\h{1,4})?::)|(?<IPvFuture>v\h+\.[!$&-.0-;=A-Z_a-z~]+))\])|\g<IPv4address>|(?<reg-name>(?:%\h\h|[!$&-.0-9;=A-Z_a-z~])*))\z/,
+        ABS_PATH: /\A\/(?:%\h\h|[!$&-.0-;=@-Z_a-z~])*(?:\/(?:%\h\h|[!$&-.0-;=@-Z_a-z~])*)*\z/,
+        REL_PATH: /\A(?:%\h\h|[!$&-.0-;=@-Z_a-z~])+(?:\/(?:%\h\h|[!$&-.0-;=@-Z_a-z~])*)*\z/,
+        QUERY: /\A(?:%\h\h|[!$&-.0-;=@-Z_a-z~\/?])*\z/,
+        FRAGMENT: /\A(?:%\h\h|[!$&-.0-;=@-Z_a-z~\/?])*\z/,
+        OPAQUE: /\A(?:[^\/].*)?\z/,
+        PORT: /\A[\x09\x0a\x0c\x0d ]*\d*[\x09\x0a\x0c\x0d ]*\z/,
+      }
+    end
+
+    def convert_to_uri(uri)
+      if uri.is_a?(URI::Generic)
+        uri
+      elsif uri = String.try_convert(uri)
+        parse(uri)
+      else
+        raise ArgumentError,
+          "bad argument (expected URI object or URI string)"
+      end
+    end
+
+  end # class Parser
+end # module URI


### PR DESCRIPTION
Imported from Ruby 2.6.3, rubocoped (although ignored), and modified to work with mruby.

URI required implementing other parts of core:

- `Array#to_ary`
- `Encoding` (added as a stub)
- `MatchData#pre_match`
- `MatchData#post_match`
- `String#slice` with `Regexp` arguments

This is the first stdlib package that has Ruby specs! This PR uses the mspec machinery introduced in GH-122 and GH-123 to embed the [uri specs](https://github.com/ruby/spec/tree/master/library/uri) and validate the package works correctly.

Using mspec turns out to be a lovely integration test for the bits of core exercised by `uri`. This PR fixes some of those bugs:

- Missing `Object#method` and friends (solved by adding `mruby-method` gem)
- Implement previously unimplemented `String#delete` (done using `String#tr`)
- `String#gsub!` should always return `self`
- `Regexp` should escape `/` in patterns

Only one spec had to be skipped: one spec asserts that `URI` method is not public, but mruby has no private visibility so this spec is invalid. The test is skipped using an implementation guard.