### PR TITLE
Prevent Nemesis segfault during Rack response processing

### DIFF
--- a/mruby/src/value/mod.rs
+++ b/mruby/src/value/mod.rs
@@ -285,6 +285,17 @@ impl Value {
         self.ruby_type() == types::Ruby::Unreachable
     }
 
+    /// Prevent this value from being garbage collected.
+    ///
+    /// Calls [`sys::mrb_gc_protect`] on this value which adds it to the GC
+    /// arena. This object will remain in the arena until
+    /// [`ArenaIndex::restore`](crate::gc::ArenaIndex::restore) restores the
+    /// arena to an index before this call to protect.
+    pub fn protect(&self) {
+        unsafe { sys::mrb_gc_protect(self.interp.borrow().mrb, self.value) }
+    }
+
+    /// Return whether this object is unreachable by any GC roots.
     pub fn is_dead(&self) -> bool {
         unsafe { sys::mrb_sys_value_is_dead(self.interp.borrow().mrb, self.value) }
     }

--- a/mruby/src/value/mod.rs
+++ b/mruby/src/value/mod.rs
@@ -244,10 +244,9 @@ where
         }
     }
 
-    fn respond_to<T: AsRef<str>>(&self, method: T) -> Result<bool, MrbError> {
-        let sym = Value::from_mrb(self.interp(), method.as_ref())
-            .funcall::<Value, _, _>("to_sym", &[])?;
-        self.funcall::<bool, _, _>("respond_to?", &[sym])
+    fn respond_to(&self, method: &str) -> Result<bool, MrbError> {
+        let method = Value::from_mrb(self.interp(), method);
+        self.funcall::<bool, _, _>("respond_to?", &[method])
     }
 }
 

--- a/mruby/src/value/mod.rs
+++ b/mruby/src/value/mod.rs
@@ -251,12 +251,14 @@ where
     }
 }
 
+/// Wrapper around a [`sys::mrb_value`].
 pub struct Value {
     interp: Mrb,
     value: sys::mrb_value,
 }
 
 impl Value {
+    /// Construct a new [`Value`] from an interpreter and [`sys::mrb_value`].
     pub fn new(interp: &Mrb, value: sys::mrb_value) -> Self {
         Self {
             interp: Rc::clone(interp),
@@ -264,10 +266,12 @@ impl Value {
         }
     }
 
+    /// The [`sys::mrb_value`] that this [`Value`] wraps.
     pub fn inner(&self) -> sys::mrb_value {
         self.value
     }
 
+    /// Return this values [Rust-mapped type tag](types::Ruby).
     pub fn ruby_type(&self) -> types::Ruby {
         types::Ruby::from(self.value)
     }
@@ -300,15 +304,30 @@ impl Value {
         unsafe { sys::mrb_sys_value_is_dead(self.interp.borrow().mrb, self.value) }
     }
 
+    /// Call `#to_s` on this [`Value`].
+    ///
+    /// This function can never fail.
     pub fn to_s(&self) -> String {
         self.funcall::<String, _, _>("to_s", &[])
             .unwrap_or_else(|_| "<unknown>".to_owned())
     }
 
+    /// Generate a debug representation of self.
+    ///
+    /// Format:
+    ///
+    /// ```ruby
+    /// "#{self.class.name}<#{self.inspect}>"
+    /// ```
+    ///
+    /// This function can never fail.
     pub fn to_s_debug(&self) -> String {
         format!("{}<{}>", self.ruby_type().class_name(), self.inspect())
     }
 
+    /// Call `#inspect` on this [`Value`].
+    ///
+    /// This function can never fail.
     pub fn inspect(&self) -> String {
         self.funcall::<String, _, _>("inspect", &[])
             .unwrap_or_else(|_| "<unknown>".to_owned())

--- a/nemesis/src/adapter.rs
+++ b/nemesis/src/adapter.rs
@@ -45,6 +45,9 @@ impl RackApp {
     pub fn call<T: Request>(&self, req: &T) -> Result<Response, Error> {
         let env = req.to_env(&self.interp)?;
         let response = self.funcall::<Vec<Value>, _, _>("call", &[env])?;
+        for value in &response {
+            value.protect();
+        }
         let response = Response::from_rack_tuple(&self.interp, response.as_slice())?;
         Ok(response)
     }


### PR DESCRIPTION
Nemesis converts a Rack response tuple into a `Vec<Value>`. The `Value`s in the `Vec` are not created by the interpreter so they do not reach a GC root. Under high load, mruby was collecting these values as they were being processed by Nemesis, which resulted in unpredictable segfaults.

Implement `Value::protect` which forces a `Value`'s inner `mrb_value` to be stored in the GC arena and be uncollectable until `mrb_sys_gc_arena_restore` is called.