### PR TITLE
Add a Symbol cache for interned symbols generated in Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,7 @@ members = [
   "nemesis",
   "spec-runner",
 ]
+
+[profile.release]
+debug = true
+lto = true

--- a/guide/development-setup.md
+++ b/guide/development-setup.md
@@ -212,3 +212,14 @@ running:
 ```shell
 cargo install loc
 ```
+
+## Flamegraphs
+
+To generate flamegraphs with
+[`scripts/hubris-flamegraph.sh`](/scripts/hubris-flamegraph.sh), you need the
+[inferno flamegraph implementation](https://github.com/jonhoo/inferno). You can
+install inferno by running:
+
+```shell
+cargo install inferno
+```

--- a/mruby/src/extn/core/kernel.rs
+++ b/mruby/src/extn/core/kernel.rs
@@ -55,8 +55,7 @@ pub struct Warning;
 impl Warning {
     unsafe extern "C" fn warn(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value {
         let interp = interpreter_or_raise!(mrb);
-        let stderr = sys::mrb_intern(mrb, b"$stderr\0".as_ptr() as *const i8, 7);
-        let stderr = sys::mrb_gv_get(mrb, stderr);
+        let stderr = sys::mrb_gv_get(mrb, interp.borrow_mut().sym_intern("$stderr"));
         if !sys::mrb_sys_value_is_nil(stderr) {
             let args = unwrap_or_raise!(interp, args::Rest::extract(&interp), interp.nil().inner());
             let stderr = Value::new(&interp, stderr);

--- a/mruby/src/extn/core/regexp/mod.rs
+++ b/mruby/src/extn/core/regexp/mod.rs
@@ -1,4 +1,5 @@
 use onig::{Regex, RegexOptions, Region, SearchOptions, Syntax};
+use std::cmp;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::mem;
@@ -663,11 +664,11 @@ impl Regexp {
         );
         let data = if is_match.is_some() {
             if let Some(captures) = regexp.borrow().regex.captures(&string[pos..]) {
-                let regexp_global_set_count = {
-                    let previously_set_globals = interp.borrow().num_set_regexp_capture_globals;
-                    std::cmp::max(previously_set_globals, captures.len())
+                let num_regexp_globals_to_set = {
+                    let num_previously_set_globals = interp.borrow().num_set_regexp_capture_globals;
+                    cmp::max(num_previously_set_globals, captures.len())
                 };
-                for group in 1..=regexp_global_set_count {
+                for group in 1..=num_regexp_globals_to_set {
                     let value = Value::from_mrb(&interp, captures.at(group));
                     sys::mrb_gv_set(
                         mrb,

--- a/mruby/src/extn/core/regexp/mod.rs
+++ b/mruby/src/extn/core/regexp/mod.rs
@@ -688,11 +688,7 @@ impl Regexp {
         } else {
             interp.nil().inner()
         };
-        sys::mrb_gv_set(
-            mrb,
-            interp.borrow_mut().sym_intern("$~"),
-            data,
-        );
+        sys::mrb_gv_set(mrb, interp.borrow_mut().sym_intern("$~"), data);
         if let Some(block) = args.block {
             if sys::mrb_sys_value_is_nil(data) {
                 interp.nil().inner()
@@ -868,11 +864,7 @@ impl Regexp {
         } else {
             interp.nil().inner()
         };
-        sys::mrb_gv_set(
-            mrb,
-            interp.borrow_mut().sym_intern("$~"),
-            data,
-        );
+        sys::mrb_gv_set(mrb, interp.borrow_mut().sym_intern("$~"), data);
         interp.bool(!sys::mrb_sys_value_is_nil(data)).inner()
     }
 

--- a/mruby/src/extn/core/regexp/mod.rs
+++ b/mruby/src/extn/core/regexp/mod.rs
@@ -619,15 +619,9 @@ impl Regexp {
             Ok(Some(ref string)) => string.to_owned(),
             Err(_) => return TypeError::raise(&interp, "No implicit conversion into String"),
             _ => {
-                let global_last_match_captures = "$~";
-                let global_match_captures_name = sys::mrb_intern(
-                    interp.borrow().mrb,
-                    global_last_match_captures.as_ptr() as *const i8,
-                    global_last_match_captures.len(),
-                );
                 sys::mrb_gv_set(
-                    interp.borrow().mrb,
-                    global_match_captures_name,
+                    mrb,
+                    interp.borrow_mut().sym_intern("$~"),
                     interp.nil().inner(),
                 );
                 return interp.nil().inner();
@@ -662,33 +656,22 @@ impl Regexp {
         } else {
             interp.nil().inner()
         };
-        let global_last_match_string = "$&";
-        let global_match_string_name = sys::mrb_intern(
-            interp.borrow().mrb,
-            global_last_match_string.as_ptr() as *const i8,
-            global_last_match_string.len(),
-        );
         sys::mrb_gv_set(
-            interp.borrow().mrb,
-            global_match_string_name,
+            mrb,
+            interp.borrow_mut().sym_intern("$&"),
             last_matched_string,
         );
         let data = if is_match.is_some() {
             if let Some(captures) = regexp.borrow().regex.captures(&string[pos..]) {
-                for group in 1..=std::cmp::max(
-                    interp.borrow().num_set_regexp_capture_globals,
-                    captures.len(),
-                ) {
+                let regexp_global_set_count = {
+                    let previously_set_globals = interp.borrow().num_set_regexp_capture_globals;
+                    std::cmp::max(previously_set_globals, captures.len())
+                };
+                for group in 1..=regexp_global_set_count {
                     let value = Value::from_mrb(&interp, captures.at(group));
-                    let global_capture_group = format!("${}", group);
-                    let global_capture_group_name = sys::mrb_intern(
-                        interp.borrow().mrb,
-                        global_capture_group.as_ptr() as *const i8,
-                        global_capture_group.len(),
-                    );
                     sys::mrb_gv_set(
-                        interp.borrow().mrb,
-                        global_capture_group_name,
+                        mrb,
+                        interp.borrow_mut().sym_intern(&format!("${}", group)),
                         value.inner(),
                     );
                 }
@@ -704,18 +687,16 @@ impl Regexp {
         } else {
             interp.nil().inner()
         };
-        let global_last_match_captures = "$~";
-        let global_match_captures_name = sys::mrb_intern(
-            interp.borrow().mrb,
-            global_last_match_captures.as_ptr() as *const i8,
-            global_last_match_captures.len(),
+        sys::mrb_gv_set(
+            mrb,
+            interp.borrow_mut().sym_intern("$~"),
+            data,
         );
-        sys::mrb_gv_set(interp.borrow().mrb, global_match_captures_name, data);
         if let Some(block) = args.block {
             if sys::mrb_sys_value_is_nil(data) {
                 interp.nil().inner()
             } else {
-                sys::mrb_yield(interp.borrow().mrb, block.inner(), data)
+                sys::mrb_yield(mrb, block.inner(), data)
             }
         } else {
             data
@@ -818,15 +799,9 @@ impl Regexp {
             Ok(Some(ref string)) => string.to_owned(),
             Err(_) => return interp.bool(false).inner(),
             _ => {
-                let global_last_match_captures = "$~";
-                let global_match_captures_name = sys::mrb_intern(
-                    interp.borrow().mrb,
-                    global_last_match_captures.as_ptr() as *const i8,
-                    global_last_match_captures.len(),
-                );
                 sys::mrb_gv_set(
-                    interp.borrow().mrb,
-                    global_match_captures_name,
+                    mrb,
+                    interp.borrow_mut().sym_intern("$~"),
                     interp.nil().inner(),
                 );
                 return interp.bool(false).inner();
@@ -861,30 +836,18 @@ impl Regexp {
         } else {
             interp.nil().inner()
         };
-        let global_last_match_string = "$&";
-        let global_match_string_name = sys::mrb_intern(
-            interp.borrow().mrb,
-            global_last_match_string.as_ptr() as *const i8,
-            global_last_match_string.len(),
-        );
         sys::mrb_gv_set(
-            interp.borrow().mrb,
-            global_match_string_name,
+            mrb,
+            interp.borrow_mut().sym_intern("$&"),
             last_matched_string,
         );
         let data = if is_match.is_some() {
             if let Some(captures) = regexp.borrow().regex.captures(&string[pos..]) {
                 for group in 1..=99 {
                     let value = Value::from_mrb(&interp, captures.at(group));
-                    let global_capture_group = format!("${}", group);
-                    let global_capture_group_name = sys::mrb_intern(
-                        interp.borrow().mrb,
-                        global_capture_group.as_ptr() as *const i8,
-                        global_capture_group.len(),
-                    );
                     sys::mrb_gv_set(
-                        interp.borrow().mrb,
-                        global_capture_group_name,
+                        mrb,
+                        interp.borrow_mut().sym_intern(&format!("${}", group)),
                         value.inner(),
                     );
                 }
@@ -904,13 +867,11 @@ impl Regexp {
         } else {
             interp.nil().inner()
         };
-        let global_last_match_captures = "$~";
-        let global_match_captures_name = sys::mrb_intern(
-            interp.borrow().mrb,
-            global_last_match_captures.as_ptr() as *const i8,
-            global_last_match_captures.len(),
+        sys::mrb_gv_set(
+            mrb,
+            interp.borrow_mut().sym_intern("$~"),
+            data,
         );
-        sys::mrb_gv_set(interp.borrow().mrb, global_match_captures_name, data);
         interp.bool(!sys::mrb_sys_value_is_nil(data)).inner()
     }
 

--- a/mruby/src/extn/mod.rs
+++ b/mruby/src/extn/mod.rs
@@ -9,29 +9,25 @@ pub const RUBY_PLATFORM: &str = "x86_64-unknown-mruby";
 pub const INPUT_RECORD_SEPARATOR: &str = "\n";
 
 pub fn patch(interp: &Mrb) -> Result<(), MrbError> {
+    let mrb = interp.borrow().mrb;
     unsafe {
         let ruby_platform = interp.string(RUBY_PLATFORM);
         sys::mrb_define_global_const(
-            interp.borrow().mrb,
+            mrb,
             b"RUBY_PLATFORM\0".as_ptr() as *const i8,
             ruby_platform.inner(),
         );
         let ruby_description = interp.string(sys::mruby_sys_version(true));
         sys::mrb_define_global_const(
-            interp.borrow().mrb,
+            mrb,
             b"RUBY_DESCRIPTION\0".as_ptr() as *const i8,
             ruby_description.inner(),
         );
-        let global_input_record_separator = "$/";
-        let global_input_record_separator_name = sys::mrb_intern(
-            interp.borrow().mrb,
-            global_input_record_separator.as_ptr() as *const i8,
-            global_input_record_separator.len(),
-        );
+        let input_record_separator = interp.string(INPUT_RECORD_SEPARATOR);
         sys::mrb_gv_set(
-            interp.borrow().mrb,
-            global_input_record_separator_name,
-            interp.string(INPUT_RECORD_SEPARATOR).inner(),
+            mrb,
+            interp.borrow_mut().sym_intern("$/"),
+            input_record_separator.inner(),
         );
     }
     core::patch(interp)?;

--- a/mruby/src/module.rs
+++ b/mruby/src/module.rs
@@ -70,7 +70,7 @@ impl ClassLike for Spec {
                     sys::mrb_const_defined_at(
                         mrb,
                         sys::mrb_sys_obj_value(scope as *mut c_void),
-                        sys::mrb_intern_cstr(mrb, self.cstring.as_ptr()),
+                        interp.borrow_mut().sym_intern(self.name.as_str()),
                     )
                 };
                 if defined == 0 {
@@ -91,7 +91,7 @@ impl ClassLike for Spec {
                 sys::mrb_const_defined_at(
                     mrb,
                     sys::mrb_sys_obj_value((*mrb).object_class as *mut c_void),
-                    sys::mrb_intern_cstr(mrb, self.cstring.as_ptr()),
+                    interp.borrow_mut().sym_intern(self.name.as_str()),
                 )
             };
             if defined == 0 {

--- a/mruby/src/state.rs
+++ b/mruby/src/state.rs
@@ -221,13 +221,12 @@ impl State {
 
     pub fn sym_intern(&mut self, sym: &str) -> sys::mrb_sym {
         let mrb = self.mrb;
-        let interned = self.symbol_cache.entry(sym.to_owned()).or_insert_with(|| unsafe {
-            sys::mrb_intern(
-                mrb,
-                sym.as_ptr() as *const i8,
-                sym.len(),
-            )
-        });
+        let interned = self
+            .symbol_cache
+            .entry(sym.to_owned())
+            .or_insert_with(|| unsafe {
+                sys::mrb_intern(mrb, sym.as_ptr() as *const i8, sym.len())
+            });
         *interned
     }
 }

--- a/mruby/src/state.rs
+++ b/mruby/src/state.rs
@@ -61,7 +61,7 @@ pub struct State {
     // TODO: make this private
     pub(crate) context_stack: Vec<EvalContext>,
     pub num_set_regexp_capture_globals: usize,
-    symbol_cache: HashMap<String, u32>,
+    symbol_cache: HashMap<String, sys::mrb_sym>,
 }
 
 impl State {
@@ -219,7 +219,7 @@ impl State {
         self.modules.get(&TypeId::of::<T>()).map(Rc::clone)
     }
 
-    pub fn sym_intern(&mut self, sym: &str) -> u32 {
+    pub fn sym_intern(&mut self, sym: &str) -> sys::mrb_sym {
         let mrb = self.mrb;
         let interned = self.symbol_cache.entry(sym.to_owned()).or_insert_with(|| unsafe {
             sys::mrb_intern(

--- a/mruby/src/state.rs
+++ b/mruby/src/state.rs
@@ -61,6 +61,7 @@ pub struct State {
     // TODO: make this private
     pub(crate) context_stack: Vec<EvalContext>,
     pub num_set_regexp_capture_globals: usize,
+    symbol_cache: HashMap<String, u32>,
 }
 
 impl State {
@@ -77,11 +78,12 @@ impl State {
         Self {
             mrb,
             ctx,
-            classes: HashMap::new(),
-            modules: HashMap::new(),
+            classes: HashMap::default(),
+            modules: HashMap::default(),
             vfs,
             context_stack: vec![],
             num_set_regexp_capture_globals: 0,
+            symbol_cache: HashMap::default(),
         }
     }
 
@@ -215,6 +217,18 @@ impl State {
     /// reference to the module spec.
     pub fn module_spec<T: Any>(&self) -> Option<Rc<RefCell<module::Spec>>> {
         self.modules.get(&TypeId::of::<T>()).map(Rc::clone)
+    }
+
+    pub fn sym_intern(&mut self, sym: &str) -> u32 {
+        let mrb = self.mrb;
+        let interned = self.symbol_cache.entry(sym.to_owned()).or_insert_with(|| unsafe {
+            sys::mrb_intern(
+                mrb,
+                sym.as_ptr() as *const i8,
+                sym.len(),
+            )
+        });
+        *interned
     }
 }
 

--- a/mruby/src/warn.rs
+++ b/mruby/src/warn.rs
@@ -27,8 +27,7 @@ impl MrbWarn for Mrb {
         warn!("rb warning: {}", message);
         let mrb = self.borrow().mrb;
         let kernel = unsafe {
-            let stderr = sys::mrb_intern_cstr(mrb, b"$stderr\0".as_ptr() as *const i8);
-            let stderr = sys::mrb_gv_get(mrb, stderr);
+            let stderr = sys::mrb_gv_get(mrb, self.borrow_mut().sym_intern("$stderr"));
             if sys::mrb_sys_value_is_nil(stderr) {
                 return Ok(());
             }

--- a/nemesis/src/response.rs
+++ b/nemesis/src/response.rs
@@ -54,7 +54,6 @@ impl Response {
         let headers = response
             .funcall::<Value, _, _>("header", &[])?
             .funcall::<Value, _, _>("each", &[])?
-            .funcall::<Value, _, _>("to_a", &[])?
             .funcall::<HashMap<String, String>, _, _>("to_h", &[])?;
 
         let headers = headers

--- a/nemesis/src/response.rs
+++ b/nemesis/src/response.rs
@@ -33,9 +33,8 @@ impl Response {
             warn!("malformed rack response: {:?}", response);
             return Err(Error::RackResponse);
         }
-        let response = interp
-            .borrow()
-            .class_spec::<nemesis::Response>()
+        let spec = interp.borrow().class_spec::<nemesis::Response>();
+        let response = spec
             .and_then(|spec| spec.borrow().new_instance(interp, response))
             .ok_or_else(|| Error::Mrb(MrbError::NotDefined("Nemesis::Response".to_owned())))?;
         Ok(Self {

--- a/scripts/hubris-flamegraph.sh
+++ b/scripts/hubris-flamegraph.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+set -x
+
+scratch="$(mktemp -d)"
+pushd "$scratch"
+pid="$(pgrep "[h]ubris")"
+
+sudo dtrace -x ustackframes=100 -n "profile-99 /pid == $pid/ { @[ustack()] = count(); } tick-10s { exit(0); }" -o out.stacks
+
+inferno-collapse-dtrace <out.stacks >stacks.folded
+inferno-flamegraph <stacks.folded >flamegraph.svg
+
+open -a "Google Chrome.app" flamegraph.svg
+echo "$(pwd)/flamegraph.svg"


### PR DESCRIPTION
On master, running a flamegraph on hubris shows that in `Regexp::match_` alone, mruby spends 1.2% of total hubris execution time retrieving interned `Symbol` `u32`s from a lookup table.

<img width="1194" alt="Screen Shot 2019-06-27 at 3 19 22 PM" src="https://user-images.githubusercontent.com/860434/60270244-4f35a700-98f0-11e9-8ffd-712efe0b1864.png">

The Rust `HashMap` implementation is likely better than the C implementation mruby uses _and_ the number of interned `Symbol`s in Rust is smaller. Take advantage of these two properties to speed up `Symbol` `u32` lookup times for `Regexp` (mostly `Regexp` globals like `$&` and `$1`) and `Warning` (`$stderr`). Caching `Symbol`s in a Rust `HashMap` cuts time spent resolving `Symbol` `u32`s in Regexp::match_` in half to 0.69% of hubris execution time

<img width="1191" alt="Screen Shot 2019-06-27 at 3 19 38 PM" src="https://user-images.githubusercontent.com/860434/60269953-b737bd80-98ef-11e9-8d1d-9b2cde033d61.png">

This optimization speeds up the short circuiting of `MrbWarn::warn` when `$stderr` is unset by limiting interaction to the mruby VM to one global lookup.

Latest bench results:

```console
$ ab -c 8 -n 10000 -l "http://127.0.0.1:8000/ferrocarril?boom"

Concurrency Level:      8
Time taken for tests:   7.262 seconds
Complete requests:      10000
Failed requests:        0
Total transferred:      3270000 bytes
HTML transferred:       1500000 bytes
Requests per second:    1377.07 [#/sec] (mean)
Time per request:       5.809 [ms] (mean)
Time per request:       0.726 [ms] (mean, across all concurrent requests)
Transfer rate:          439.75 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.1      0       9
Processing:     3    6  15.2      4     296
Waiting:        3    6  15.2      4     296
Total:          3    6  15.2      4     296

Percentage of the requests served within a certain time (ms)
  50%      4
  66%      5
  75%      6
  80%      6
  90%      7
  95%      7
  98%     10
  99%     11
 100%    296 (longest request)
```