### PR TITLE
Optimize String#scan and make MatchData ruby/spec compliant

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,18 +129,35 @@ jobs:
             bundle exec rubocop
       - restore_cache:
           keys:
-            - ruby-bundler-v1-foolsgold-{{ checksum "./mruby/src/extn/Gemfile.lock" }}
+            - ruby-bundler-v1-spec-runner-{{ checksum "./spec-runner/src/Gemfile.lock" }}
       - run:
-          name: FoolsGold Bundle Install
-          working_directory: ./foolsgold/ruby
-          command: bundle install --path ~/vendor/foolsgold-bundle
+          name: spec-runner Bundle Install
+          working_directory: ./spec-runner/src
+          command: bundle install --path ~/vendor/mruby-spec-runner-bundle
       - save_cache:
-          key: ruby-bundler-v1-foolsgold-{{ checksum "./foolsgold/ruby/Gemfile.lock" }}
+          key: ruby-bundler-v1-spec-runner-{{ checksum "./spec-runner/src/Gemfile.lock" }}
           paths:
-            - ~/vendor/foolsgold-bundle
+            - ~/vendor/mruby-spec-runner-bundle
       - run:
-          name: FoolsGold Lint Ruby With RuboCop
-          working_directory: ./foolsgold/ruby
+          name: spec-runner Lint Ruby With RuboCop
+          working_directory: ./spec-runner/src
+          command: |
+            bundle exec rubocop --version
+            bundle exec rubocop
+      - restore_cache:
+          keys:
+            - ruby-bundler-v1-mruby-bin-{{ checksum "./mruby-bin/ruby/Gemfile.lock" }}
+      - run:
+          name: mruby-bin Bundle Install
+          working_directory: ./mruby-bin/ruby
+          command: bundle install --path ~/vendor/mruby-bin-bundle
+      - save_cache:
+          key: ruby-bundler-v1-mruby-bin-{{ checksum "./mruby-bin/ruby/Gemfile.lock" }}
+          paths:
+            - ~/vendor/mruby-bin-bundle
+      - run:
+          name: mruby-bin Lint Ruby With RuboCop
+          working_directory: ./mruby-bin/ruby
           command: |
             bundle exec rubocop --version
             bundle exec rubocop
@@ -158,6 +175,40 @@ jobs:
       - run:
           name: Nemesis Lint Ruby With RuboCop
           working_directory: ./nemesis/ruby
+          command: |
+            bundle exec rubocop --version
+            bundle exec rubocop
+      - restore_cache:
+          keys:
+            - ruby-bundler-v1-foolsgold-{{ checksum "./foolsgold/Gemfile.lock" }}
+      - run:
+          name: FoolsGold Bundle Install
+          working_directory: ./foolsgold/ruby
+          command: bundle install --path ~/vendor/foolsgold-bundle
+      - save_cache:
+          key: ruby-bundler-v1-foolsgold-{{ checksum "./foolsgold/ruby/Gemfile.lock" }}
+          paths:
+            - ~/vendor/foolsgold-bundle
+      - run:
+          name: FoolsGold Lint Ruby With RuboCop
+          working_directory: ./foolsgold/ruby
+          command: |
+            bundle exec rubocop --version
+            bundle exec rubocop
+      - restore_cache:
+          keys:
+            - ruby-bundler-v1-hubris-{{ checksum "./hubris/src/Gemfile.lock" }}
+      - run:
+          name: Hubris Bundle Install
+          working_directory: ./hubris/src
+          command: bundle install --path ~/vendor/hubris-bundle
+      - save_cache:
+          key: ruby-bundler-v1-hubris-{{ checksum "./hubris/src/Gemfile.lock" }}
+          paths:
+            - ~/vendor/hubris-bundle
+      - run:
+          name: Hubris Lint Ruby With RuboCop
+          working_directory: ./hubris/src
           command: |
             bundle exec rubocop --version
             bundle exec rubocop

--- a/mruby-bin/ruby/.rubocop.yml
+++ b/mruby-bin/ruby/.rubocop.yml
@@ -1,0 +1,7 @@
+AllCops:
+  TargetRubyVersion: 2.5
+  DisplayCopNames: true
+Metrics:
+  Enabled: false
+Style/Documentation:
+  Enabled: false

--- a/mruby-bin/ruby/Gemfile
+++ b/mruby-bin/ruby/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'rubocop'

--- a/mruby-bin/ruby/Gemfile.lock
+++ b/mruby-bin/ruby/Gemfile.lock
@@ -1,0 +1,27 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.0)
+    jaro_winkler (1.5.2)
+    parallel (1.17.0)
+    parser (2.6.3.0)
+      ast (~> 2.4.0)
+    rainbow (3.0.0)
+    rubocop (0.70.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.6)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 1.7)
+    ruby-progressbar (1.10.0)
+    unicode-display_width (1.6.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rubocop
+
+BUNDLED WITH
+   2.0.1

--- a/mruby-bin/ruby/benches/string_scan.rb
+++ b/mruby-bin/ruby/benches/string_scan.rb
@@ -1,0 +1,68 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+begin
+  Time
+rescue NameError
+  require 'time'
+end
+
+ITERATIONS = 50
+
+def data
+  File.read(File.join(__dir__, '..', 'fixtures', 'learnxinyminutes.txt'))
+rescue StandardError
+  $data # rubocop:disable Style/GlobalVars
+end
+
+# Timer that can log multiple iterations
+class Stopwatch
+  def initialize(name)
+    @name = name
+    @elapsed = 0
+    @laps = 0
+  end
+
+  def lap
+    start = Time.now
+    yield
+  ensure
+    @elapsed += Time.now - start
+    @laps += 1
+  end
+
+  def report
+    ms = (@elapsed * 1e5).to_i / 1e2
+    avg = (@elapsed / @laps *1e5).to_i / 1e2
+    "#{@name}: #{ms}ms elapsed in #{@laps} iterations (avg. #{avg}ms / iteration)"
+  end
+end
+
+def bench(name, pattern)
+  bench = data
+  puts "\n#{name}: #{bench.scan(Regexp.compile(pattern)).size} matches"
+  compile = Stopwatch.new('compile')
+  scan = Stopwatch.new('scan')
+  scan_with_block = Stopwatch.new('scan with block')
+  ITERATIONS.times do
+    print '.'
+    regexp = compile.lap { Regexp.compile(pattern) }
+    scan_count = scan.lap { bench.scan(regexp) }.size
+    scan_with_block_count = scan_with_block.lap do
+      count = 0
+      bench.scan(regexp) { count += 1 }
+      count
+    end
+    raise 'count mismatch' unless scan_count == scan_with_block_count
+  end
+  puts '', ''
+  puts "    #{compile.report}"
+  puts "    #{scan.report}"
+  puts "    #{scan_with_block.report}"
+end
+
+puts "String#scan bench for #{RUBY_DESCRIPTION}"
+
+bench('Email', '[\w\.+-]+@[\w\.-]+\.[\w\.-]+')
+bench('URI', '[\w]+:\/\/[^\/\s?#]+[^\s?#]+(?:\?[^\s#]*)?(?:#[^\s]*)?')
+bench('IP', '(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9])')

--- a/mruby-bin/ruby/benches/string_scan.rb
+++ b/mruby-bin/ruby/benches/string_scan.rb
@@ -33,7 +33,7 @@ class Stopwatch
 
   def report
     ms = (@elapsed * 1e5).to_i / 1e2
-    avg = (@elapsed / @laps *1e5).to_i / 1e2
+    avg = (@elapsed / @laps * 1e5).to_i / 1e2
     "#{@name}: #{ms}ms elapsed in #{@laps} iterations (avg. #{avg}ms / iteration)"
   end
 end

--- a/mruby-bin/src/bin/string_scan_bench.rs
+++ b/mruby-bin/src/bin/string_scan_bench.rs
@@ -1,0 +1,51 @@
+#![deny(warnings, intra_doc_link_resolution_failure)]
+#![deny(clippy::all, clippy::pedantic)]
+
+use mruby::eval::{EvalContext, MrbEval};
+use mruby::interpreter::{Interpreter, MrbApi};
+use mruby::sys;
+use std::env;
+use std::fs::File;
+use std::io::{self, Read};
+use std::process;
+
+fn main() {
+    let interp = match Interpreter::create() {
+        Ok(interp) => interp,
+        Err(err) => {
+            eprintln!("{}", err);
+            process::exit(1);
+        }
+    };
+    let mrb = interp.borrow().mrb;
+
+    // program is either supplied as a file via command line argument or piped
+    // in via stdin.
+    let mut program = vec![];
+    if let Some(file) = env::args().nth(1) {
+        match File::open(file) {
+            Ok(mut file) => {
+                if let Err(err) = file.read_to_end(&mut program) {
+                    eprintln!("Unable to read program: {}", err);
+                    process::exit(1);
+                }
+            }
+            Err(err) => {
+                eprintln!("{}", err);
+                process::exit(1);
+            }
+        }
+    } else if let Err(err) = io::stdin().read_to_end(&mut program) {
+        eprintln!("Unable to read program: {}", err);
+        process::exit(1);
+    }
+
+    let data = interp.bytes(include_bytes!("../../ruby/fixtures/learnxinyminutes.txt").as_ref());
+    data.protect();
+    unsafe { sys::mrb_gv_set(mrb, interp.borrow_mut().sym_intern("$data"), data.inner()) }
+    let ctx = EvalContext::new("(main)");
+    if let Err(err) = interp.eval_with_context(program, ctx) {
+        eprintln!("{}", err);
+        process::exit(1);
+    }
+}

--- a/mruby/src/convert/hash.rs
+++ b/mruby/src/convert/hash.rs
@@ -255,6 +255,16 @@ impl FromMrb<Vec<(&str, Value)>> for Value {
     }
 }
 
+impl FromMrb<HashMap<&str, Value>> for Value {
+    type From = Rust;
+    type To = Ruby;
+
+    fn from_mrb(interp: &Mrb, value: HashMap<&str, Value>) -> Self {
+        let pairs = value.into_iter().collect::<Vec<(&str, Value)>>();
+        Self::from_mrb(interp, pairs)
+    }
+}
+
 #[cfg(test)]
 mod value {
     mod tests {

--- a/mruby/src/convert/hash.rs
+++ b/mruby/src/convert/hash.rs
@@ -255,12 +255,12 @@ impl FromMrb<Vec<(&str, Value)>> for Value {
     }
 }
 
-impl FromMrb<HashMap<&str, Value>> for Value {
+impl FromMrb<HashMap<&str, Self>> for Value {
     type From = Rust;
     type To = Ruby;
 
-    fn from_mrb(interp: &Mrb, value: HashMap<&str, Value>) -> Self {
-        let pairs = value.into_iter().collect::<Vec<(&str, Value)>>();
+    fn from_mrb(interp: &Mrb, value: HashMap<&str, Self>) -> Self {
+        let pairs = value.into_iter().collect::<Vec<(&str, Self)>>();
         Self::from_mrb(interp, pairs)
     }
 }

--- a/mruby/src/extn/core/error.rs
+++ b/mruby/src/extn/core/error.rs
@@ -50,6 +50,9 @@ pub fn patch(interp: &Mrb) -> Result<(), MrbError> {
         .def_class::<ArgumentError>("ArgumentError", None, None);
     interp
         .borrow_mut()
+        .def_class::<IndexError>("IndexError", None, None);
+    interp
+        .borrow_mut()
         .def_class::<RuntimeError>("RuntimeError", None, None);
     interp
         .borrow_mut()
@@ -167,6 +170,11 @@ impl RubyException for LoadError {
 pub struct ArgumentError;
 
 impl RubyException for ArgumentError {}
+
+#[allow(clippy::module_name_repetitions)]
+pub struct IndexError;
+
+impl RubyException for IndexError {}
 
 #[allow(clippy::module_name_repetitions)]
 pub struct RuntimeError;

--- a/mruby/src/extn/core/kernel.rs
+++ b/mruby/src/extn/core/kernel.rs
@@ -1,6 +1,7 @@
 use log::trace;
 use mruby_vfs::FileSystem;
 use path_abs::PathAbs;
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
@@ -194,6 +195,7 @@ impl Kernel {
         for value in args.rest {
             print!("{}", value.to_s());
         }
+        let _ = io::stdout().flush();
         interp.nil().inner()
     }
 

--- a/mruby/src/extn/core/matchdata/begin.rs
+++ b/mruby/src/extn/core/matchdata/begin.rs
@@ -73,6 +73,7 @@ pub fn method(interp: &Mrb, args: Args, value: &Value) -> Result<Value, Error> {
     };
     let begin = captures.pos(index).ok_or(Error::NoMatch)?.0;
     let begin = match_against[0..begin].chars().count();
+    let begin = begin + borrow.region.start;
     let begin = i64::try_from(begin).map_err(|_| Error::Fatal)?;
     Ok(Value::from_mrb(&interp, begin))
 }

--- a/mruby/src/extn/core/matchdata/begin.rs
+++ b/mruby/src/extn/core/matchdata/begin.rs
@@ -1,0 +1,78 @@
+use std::convert::TryFrom;
+use std::mem;
+
+use crate::convert::{FromMrb, RustBackedValue, TryFromMrb};
+use crate::extn::core::matchdata::MatchData;
+use crate::interpreter::Mrb;
+use crate::sys;
+use crate::value::Value;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Error {
+    Fatal,
+    IndexType,
+    NoGroup,
+    NoMatch,
+}
+
+#[derive(Debug, Clone)]
+pub enum Args {
+    Index(i64),
+    Name(String),
+}
+
+impl Args {
+    const ARGSPEC: &'static [u8] = b"o\0";
+
+    pub unsafe fn extract(interp: &Mrb) -> Result<Self, Error> {
+        let first = mem::uninitialized::<sys::mrb_value>();
+        sys::mrb_get_args(
+            interp.borrow().mrb,
+            Self::ARGSPEC.as_ptr() as *const i8,
+            &first,
+        );
+        if let Ok(index) = i64::try_from_mrb(interp, Value::new(interp, first)) {
+            Ok(Args::Index(index))
+        } else if let Ok(name) = String::try_from_mrb(interp, Value::new(interp, first)) {
+            Ok(Args::Name(name))
+        } else {
+            Err(Error::IndexType)
+        }
+    }
+}
+
+pub fn method(interp: &Mrb, args: Args, value: &Value) -> Result<Value, Error> {
+    let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
+    let borrow = data.borrow();
+    let match_against = &borrow.string[borrow.region.start..borrow.region.end];
+    let captures = borrow
+        .regexp
+        .regex
+        .captures(match_against)
+        .ok_or(Error::NoMatch)?;
+    let index = match args {
+        Args::Index(index) => {
+            if index < 0 {
+                // Positive i64 must be usize
+                let index = usize::try_from(-index).map_err(|_| Error::Fatal)?;
+                captures.len().checked_sub(index).ok_or(Error::Fatal)?
+            } else {
+                // Positive i64 must be usize
+                usize::try_from(index).map_err(|_| Error::Fatal)?
+            }
+        }
+        Args::Name(name) => {
+            let index = borrow
+                .regexp
+                .regex
+                .capture_names()
+                .find(|capture| capture.0 == name)
+                .ok_or(Error::NoGroup)?;
+            usize::try_from(index.1[0]).map_err(|_| Error::Fatal)?
+        }
+    };
+    let begin = captures.pos(index).ok_or(Error::NoMatch)?.0;
+    let begin = match_against[0..begin].chars().count();
+    let begin = i64::try_from(begin).map_err(|_| Error::Fatal)?;
+    Ok(Value::from_mrb(&interp, begin))
+}

--- a/mruby/src/extn/core/matchdata/captures.rs
+++ b/mruby/src/extn/core/matchdata/captures.rs
@@ -1,0 +1,26 @@
+use crate::convert::{FromMrb, RustBackedValue};
+use crate::extn::core::matchdata::MatchData;
+use crate::interpreter::Mrb;
+use crate::value::Value;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Error {
+    Fatal,
+    NoMatch,
+}
+
+pub fn method(interp: &Mrb, value: &Value) -> Result<Value, Error> {
+    let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
+    let borrow = data.borrow();
+    let match_against = &borrow.string[borrow.region.start..borrow.region.end];
+    let captures = borrow
+        .regexp
+        .regex
+        .captures(match_against)
+        .ok_or(Error::NoMatch)?;
+    let mut iter = captures.iter();
+    // skip 0 (full match) capture group
+    iter.next();
+    let vec = iter.collect::<Vec<_>>();
+    Ok(Value::from_mrb(&interp, vec))
+}

--- a/mruby/src/extn/core/matchdata/element_reference.rs
+++ b/mruby/src/extn/core/matchdata/element_reference.rs
@@ -110,11 +110,16 @@ pub fn method(interp: &Mrb, args: Args, value: &Value) -> Result<Value, Error> {
                 .regexp
                 .regex
                 .capture_names()
-                .find(|capture| capture.0 == name)
-                .map(|index| index.1)
+                .find_map(|capture| {
+                    if capture.0 == name {
+                        Some(capture.1)
+                    } else {
+                        None
+                    }
+                })
                 .ok_or_else(|| Error::NoGroup(name))?;
             let group = index
-                .into_iter()
+                .iter()
                 .filter_map(|index| {
                     usize::try_from(*index)
                         .ok()

--- a/mruby/src/extn/core/matchdata/element_reference.rs
+++ b/mruby/src/extn/core/matchdata/element_reference.rs
@@ -1,0 +1,131 @@
+use std::convert::TryFrom;
+use std::mem;
+
+use crate::convert::{FromMrb, RustBackedValue, TryFromMrb};
+use crate::extn::core::matchdata::MatchData;
+use crate::interpreter::{Mrb, MrbApi};
+use crate::sys;
+use crate::value::Value;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Error {
+    Fatal,
+    IndexType,
+    LengthType,
+    NoGroup,
+    NoMatch,
+}
+
+#[derive(Debug, Clone)]
+pub enum Args {
+    Index(i64),
+    Name(String),
+    StartLen(i64, usize),
+}
+
+impl Args {
+    const ARGSPEC: &'static [u8] = b"o|o?\0";
+
+    pub unsafe fn extract(interp: &Mrb, num_captures: usize) -> Result<Self, Error> {
+        let num_captures = i64::try_from(num_captures).map_err(|_| Error::Fatal)?;
+        let first = mem::uninitialized::<sys::mrb_value>();
+        let second = mem::uninitialized::<sys::mrb_value>();
+        let has_second = mem::uninitialized::<sys::mrb_bool>();
+        sys::mrb_get_args(
+            interp.borrow().mrb,
+            Self::ARGSPEC.as_ptr() as *const i8,
+            &first,
+            &second,
+            &has_second,
+        );
+        let has_length = has_second != 0;
+        if has_length {
+            let start = i64::try_from_mrb(&interp, Value::new(interp, first))
+                .map_err(|_| Error::IndexType)?;
+            let len = usize::try_from_mrb(&interp, Value::new(interp, second))
+                .map_err(|_| Error::LengthType)?;
+            Ok(Args::StartLen(start, len))
+        } else if let Ok(index) = i64::try_from_mrb(interp, Value::new(interp, first)) {
+            Ok(Args::Index(index))
+        } else if let Ok(name) = String::try_from_mrb(interp, Value::new(interp, first)) {
+            Ok(Args::Name(name))
+        } else if let Some(args) = Self::is_range(interp, first, num_captures)? {
+            Ok(args)
+        } else {
+            Err(Error::Fatal)
+        }
+    }
+
+    unsafe fn is_range(
+        interp: &Mrb,
+        first: sys::mrb_value,
+        num_captures: i64,
+    ) -> Result<Option<Self>, Error> {
+        let mut start = mem::uninitialized::<sys::mrb_int>();
+        let mut len = mem::uninitialized::<sys::mrb_int>();
+        let check_range = sys::mrb_range_beg_len(
+            interp.borrow().mrb,
+            first,
+            &mut start,
+            &mut len,
+            num_captures,
+            0_u8,
+        );
+        if check_range == sys::mrb_range_beg_len::MRB_RANGE_OK {
+            let len =
+                usize::try_from_mrb(&interp, interp.fixnum(len)).map_err(|_| Error::LengthType)?;
+            Ok(Some(Args::StartLen(start, len)))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+pub fn method(interp: &Mrb, args: Args, value: &Value) -> Result<Value, Error> {
+    let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
+    let borrow = data.borrow();
+    let match_against = &borrow.string[borrow.region.start..borrow.region.end];
+    let captures = borrow
+        .regexp
+        .regex
+        .captures(match_against)
+        .ok_or(Error::NoMatch)?;
+    match args {
+        Args::Index(index) => {
+            let index = if index < 0 {
+                // Positive i64 must be usize
+                let index = usize::try_from(-index).map_err(|_| Error::Fatal)?;
+                captures.len().checked_sub(index).ok_or(Error::Fatal)?
+            } else {
+                // Positive i64 must be usize
+                usize::try_from(index).map_err(|_| Error::Fatal)?
+            };
+            Ok(Value::from_mrb(&interp, captures.at(index)))
+        }
+        Args::Name(name) => {
+            let index = borrow
+                .regexp
+                .regex
+                .capture_names()
+                .find(|capture| capture.0 == name)
+                .ok_or(Error::NoGroup)?;
+            let index = usize::try_from(index.1[0]).map_err(|_| Error::Fatal)?;
+            Ok(Value::from_mrb(&interp, captures.at(index)))
+        }
+        Args::StartLen(start, len) => {
+            let start = if start < 0 {
+                // Positive i64 must be usize
+                let start = usize::try_from(-start).map_err(|_| Error::Fatal)?;
+                captures.len().checked_sub(start).ok_or(Error::Fatal)?
+            } else {
+                // Positive i64 must be usize
+                usize::try_from(start).map_err(|_| Error::Fatal)?
+            };
+            let mut matches = vec![];
+            for index in start..(start + len) {
+                matches.push(captures.at(index));
+            }
+            Ok(Value::from_mrb(&interp, matches))
+        }
+    }
+}

--- a/mruby/src/extn/core/matchdata/end.rs
+++ b/mruby/src/extn/core/matchdata/end.rs
@@ -72,7 +72,7 @@ pub fn method(interp: &Mrb, args: Args, value: &Value) -> Result<Value, Error> {
         }
     };
     let end = captures.pos(index).ok_or(Error::NoMatch)?.1;
-    let end = match_against[0..end].chars().count();
+    let end = match_against[0..end].chars().count() + 1;
     let end = i64::try_from(end).map_err(|_| Error::Fatal)?;
     Ok(Value::from_mrb(&interp, end))
 }

--- a/mruby/src/extn/core/matchdata/end.rs
+++ b/mruby/src/extn/core/matchdata/end.rs
@@ -1,0 +1,78 @@
+use std::convert::TryFrom;
+use std::mem;
+
+use crate::convert::{FromMrb, RustBackedValue, TryFromMrb};
+use crate::extn::core::matchdata::MatchData;
+use crate::interpreter::Mrb;
+use crate::sys;
+use crate::value::Value;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Error {
+    Fatal,
+    IndexType,
+    NoGroup,
+    NoMatch,
+}
+
+#[derive(Debug, Clone)]
+pub enum Args {
+    Index(i64),
+    Name(String),
+}
+
+impl Args {
+    const ARGSPEC: &'static [u8] = b"o\0";
+
+    pub unsafe fn extract(interp: &Mrb) -> Result<Self, Error> {
+        let first = mem::uninitialized::<sys::mrb_value>();
+        sys::mrb_get_args(
+            interp.borrow().mrb,
+            Self::ARGSPEC.as_ptr() as *const i8,
+            &first,
+        );
+        if let Ok(index) = i64::try_from_mrb(interp, Value::new(interp, first)) {
+            Ok(Args::Index(index))
+        } else if let Ok(name) = String::try_from_mrb(interp, Value::new(interp, first)) {
+            Ok(Args::Name(name))
+        } else {
+            Err(Error::IndexType)
+        }
+    }
+}
+
+pub fn method(interp: &Mrb, args: Args, value: &Value) -> Result<Value, Error> {
+    let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
+    let borrow = data.borrow();
+    let match_against = &borrow.string[borrow.region.start..borrow.region.end];
+    let captures = borrow
+        .regexp
+        .regex
+        .captures(match_against)
+        .ok_or(Error::NoMatch)?;
+    let index = match args {
+        Args::Index(index) => {
+            if index < 0 {
+                // Positive i64 must be usize
+                let index = usize::try_from(-index).map_err(|_| Error::Fatal)?;
+                captures.len().checked_sub(index).ok_or(Error::Fatal)?
+            } else {
+                // Positive i64 must be usize
+                usize::try_from(index).map_err(|_| Error::Fatal)?
+            }
+        }
+        Args::Name(name) => {
+            let index = borrow
+                .regexp
+                .regex
+                .capture_names()
+                .find(|capture| capture.0 == name)
+                .ok_or(Error::NoGroup)?;
+            usize::try_from(index.1[0]).map_err(|_| Error::Fatal)?
+        }
+    };
+    let end = captures.pos(index).ok_or(Error::NoMatch)?.1;
+    let end = match_against[0..end].chars().count();
+    let end = i64::try_from(end).map_err(|_| Error::Fatal)?;
+    Ok(Value::from_mrb(&interp, end))
+}

--- a/mruby/src/extn/core/matchdata/end.rs
+++ b/mruby/src/extn/core/matchdata/end.rs
@@ -73,6 +73,7 @@ pub fn method(interp: &Mrb, args: Args, value: &Value) -> Result<Value, Error> {
     };
     let end = captures.pos(index).ok_or(Error::NoMatch)?.1;
     let end = match_against[0..end].chars().count();
+    let end = end + borrow.region.start;
     let end = i64::try_from(end).map_err(|_| Error::Fatal)?;
     Ok(Value::from_mrb(&interp, end))
 }

--- a/mruby/src/extn/core/matchdata/end.rs
+++ b/mruby/src/extn/core/matchdata/end.rs
@@ -72,7 +72,7 @@ pub fn method(interp: &Mrb, args: Args, value: &Value) -> Result<Value, Error> {
         }
     };
     let end = captures.pos(index).ok_or(Error::NoMatch)?.1;
-    let end = match_against[0..end].chars().count() + 1;
+    let end = match_against[0..end].chars().count();
     let end = i64::try_from(end).map_err(|_| Error::Fatal)?;
     Ok(Value::from_mrb(&interp, end))
 }

--- a/mruby/src/extn/core/matchdata/length.rs
+++ b/mruby/src/extn/core/matchdata/length.rs
@@ -1,0 +1,24 @@
+use std::convert::TryFrom;
+
+use crate::convert::RustBackedValue;
+use crate::extn::core::matchdata::MatchData;
+use crate::interpreter::{Mrb, MrbApi};
+use crate::value::Value;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Error {
+    Fatal,
+}
+
+pub fn method(interp: &Mrb, value: &Value) -> Result<Value, Error> {
+    let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
+    let borrow = data.borrow();
+    let match_against = &borrow.string[borrow.region.start..borrow.region.end];
+    let captures = borrow.regexp.regex.captures(match_against);
+    if let Some(captures) = captures {
+        let len = i64::try_from(captures.len()).map_err(|_| Error::Fatal)?;
+        Ok(interp.fixnum(len))
+    } else {
+        Ok(interp.fixnum(0))
+    }
+}

--- a/mruby/src/extn/core/matchdata/matchdata.rb
+++ b/mruby/src/extn/core/matchdata/matchdata.rb
@@ -1,6 +1,33 @@
 # frozen_string_literal: true
 
 class MatchData
+  def ==(other)
+    return false unless other.is_a?(MatchData)
+    return false unless string == other.string
+    return false unless regexp == other.regexp
+    return false unless offset(0) == other.offset(0)
+
+    true
+  end
+
+  def eql?(other)
+    self == other
+  end
+
+  def inspect
+    s = %(#<MatchData "#{self[0]}")
+    if named_captures.empty?
+      captures.each_with_index do |capture, index|
+        s << %( #{index + 1}:"#{capture || nil.inspect}")
+      end
+    else
+      named_captures.each do |(group, capture)|
+        s << %( #{group}:"#{capture || nil.inspect}")
+      end
+    end
+    s << '>'
+  end
+
   def values_at(*indexes)
     indexes.map { |index| self[index] }.flatten
   end

--- a/mruby/src/extn/core/matchdata/matchdata.rb
+++ b/mruby/src/extn/core/matchdata/matchdata.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class MatchData
+  def values_at(*indexes)
+    indexes.map { |index| self[index] }.flatten
+  end
+end

--- a/mruby/src/extn/core/matchdata/mod.rs
+++ b/mruby/src/extn/core/matchdata/mod.rs
@@ -1,5 +1,6 @@
 use crate::convert::{FromMrb, RustBackedValue};
 use crate::def::{rust_data_free, ClassLike, Define};
+use crate::eval::MrbEval;
 use crate::extn::core::error::{IndexError, RubyException, RuntimeError, TypeError};
 use crate::extn::core::regexp::Regexp;
 use crate::interpreter::{Mrb, MrbApi};
@@ -29,6 +30,7 @@ pub fn init(interp: &Mrb) -> Result<(), MrbError> {
         Some(rust_data_free::<MatchData>),
     );
     match_data.borrow_mut().mrb_value_is_rust_backed(true);
+    interp.eval(include_str!("matchdata.rb"))?;
     match_data
         .borrow_mut()
         .add_method("begin", MatchData::begin, sys::mrb_args_req(1));

--- a/mruby/src/extn/core/matchdata/mod.rs
+++ b/mruby/src/extn/core/matchdata/mod.rs
@@ -97,6 +97,10 @@ impl MatchData {
         }
     }
 
+    pub fn set_region(&mut self, start: usize, end: usize) {
+        self.region = Region { start, end };
+    }
+
     unsafe extern "C" fn begin(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
         let interp = interpreter_or_raise!(mrb);
         let value = Value::new(&interp, slf);

--- a/mruby/src/extn/core/matchdata/mod.rs
+++ b/mruby/src/extn/core/matchdata/mod.rs
@@ -141,7 +141,7 @@ impl MatchData {
         slf: sys::mrb_value,
     ) -> sys::mrb_value {
         let interp = interpreter_or_raise!(mrb);
-        let num_captures = match MatchData::try_from_ruby(&interp, &Value::new(&interp, slf)) {
+        let num_captures = match Self::try_from_ruby(&interp, &Value::new(&interp, slf)) {
             Ok(data) => data.borrow().regexp.regex.captures_len(),
             Err(_) => return interp.nil().inner(),
         };
@@ -209,9 +209,7 @@ impl MatchData {
         let value = Value::new(&interp, slf);
         match names::method(&interp, &value) {
             Ok(result) => result.inner(),
-            Err(names::Error::Fatal) => {
-                RuntimeError::raise(&interp, "fatal MatchData#names error")
-            }
+            Err(names::Error::Fatal) => RuntimeError::raise(&interp, "fatal MatchData#names error"),
         }
     }
 

--- a/mruby/src/extn/core/matchdata/mod.rs
+++ b/mruby/src/extn/core/matchdata/mod.rs
@@ -1,0 +1,262 @@
+use crate::convert::RustBackedValue;
+use crate::def::{rust_data_free, ClassLike, Define};
+use crate::extn::core::error::{RubyException, RuntimeError, TypeError};
+use crate::extn::core::regexp::Regexp;
+use crate::interpreter::{Mrb, MrbApi};
+use crate::sys;
+use crate::value::Value;
+use crate::MrbError;
+
+mod begin;
+mod captures;
+mod element_reference;
+mod end;
+mod length;
+mod named_captures;
+mod post_match;
+mod pre_match;
+mod regexp;
+mod string;
+mod to_a;
+mod to_s;
+
+pub fn init(interp: &Mrb) -> Result<(), MrbError> {
+    let match_data = interp.borrow_mut().def_class::<MatchData>(
+        "MatchData",
+        None,
+        Some(rust_data_free::<MatchData>),
+    );
+    match_data.borrow_mut().mrb_value_is_rust_backed(true);
+    match_data
+        .borrow_mut()
+        .add_method("begin", MatchData::begin, sys::mrb_args_req(1));
+    match_data
+        .borrow_mut()
+        .add_method("captures", MatchData::captures, sys::mrb_args_none());
+    match_data
+        .borrow_mut()
+        .add_method("[]", MatchData::element_reference, sys::mrb_args_none());
+    match_data
+        .borrow_mut()
+        .add_method("length", MatchData::length, sys::mrb_args_none());
+    match_data.borrow_mut().add_method(
+        "named_captures",
+        MatchData::named_captures,
+        sys::mrb_args_none(),
+    );
+    match_data
+        .borrow_mut()
+        .add_method("post_match", MatchData::post_match, sys::mrb_args_none());
+    match_data
+        .borrow_mut()
+        .add_method("pre_match", MatchData::pre_match, sys::mrb_args_none());
+    match_data
+        .borrow_mut()
+        .add_method("regexp", MatchData::regexp, sys::mrb_args_none());
+    match_data
+        .borrow_mut()
+        .add_method("size", MatchData::length, sys::mrb_args_none());
+    match_data
+        .borrow_mut()
+        .add_method("string", MatchData::string, sys::mrb_args_none());
+    match_data
+        .borrow_mut()
+        .add_method("to_a", MatchData::to_a, sys::mrb_args_none());
+    match_data
+        .borrow_mut()
+        .add_method("to_s", MatchData::to_s, sys::mrb_args_none());
+    match_data
+        .borrow_mut()
+        .add_method("end", MatchData::end, sys::mrb_args_req(1));
+    match_data.borrow().define(&interp)?;
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub struct Region {
+    start: usize,
+    end: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct MatchData {
+    string: String,
+    regexp: Regexp,
+    region: Region,
+}
+
+impl RustBackedValue for MatchData {}
+
+impl MatchData {
+    pub fn new(string: &str, regexp: Regexp, start: usize, end: usize) -> Self {
+        let region = Region { start, end };
+        Self {
+            string: string.to_owned(),
+            regexp,
+            region,
+        }
+    }
+
+    unsafe extern "C" fn begin(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+        let interp = interpreter_or_raise!(mrb);
+        let value = Value::new(&interp, slf);
+        let result =
+            begin::Args::extract(&interp).and_then(|args| begin::method(&interp, args, &value));
+        match result {
+            Ok(result) => result.inner(),
+            Err(begin::Error::NoMatch) | Err(begin::Error::NoGroup) => interp.nil().inner(),
+            Err(begin::Error::IndexType) => TypeError::raise(&interp, "Unexpected capture group"),
+            Err(begin::Error::Fatal) => RuntimeError::raise(&interp, "fatal MatchData#begin error"),
+        }
+    }
+
+    unsafe extern "C" fn captures(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+        let interp = interpreter_or_raise!(mrb);
+        let value = Value::new(&interp, slf);
+        match captures::method(&interp, &value) {
+            Ok(result) => result.inner(),
+            Err(captures::Error::NoMatch) => interp.nil().inner(),
+            Err(captures::Error::Fatal) => {
+                RuntimeError::raise(&interp, "fatal MatchData#captures error")
+            }
+        }
+    }
+
+    unsafe extern "C" fn element_reference(
+        mrb: *mut sys::mrb_state,
+        slf: sys::mrb_value,
+    ) -> sys::mrb_value {
+        let interp = interpreter_or_raise!(mrb);
+        let num_captures = match MatchData::try_from_ruby(&interp, &Value::new(&interp, slf)) {
+            Ok(data) => data.borrow().regexp.regex.captures_len(),
+            Err(_) => return interp.nil().inner(),
+        };
+        let value = Value::new(&interp, slf);
+        let result = element_reference::Args::extract(&interp, num_captures)
+            .and_then(|args| element_reference::method(&interp, args, &value));
+        match result {
+            Ok(result) => result.inner(),
+            Err(element_reference::Error::NoMatch) | Err(element_reference::Error::NoGroup) => {
+                interp.nil().inner()
+            }
+            Err(element_reference::Error::IndexType)
+            | Err(element_reference::Error::LengthType) => {
+                TypeError::raise(&interp, "Unexpected element reference")
+            }
+            Err(element_reference::Error::Fatal) => {
+                RuntimeError::raise(&interp, "fatal MatchData#[] error")
+            }
+        }
+    }
+
+    unsafe extern "C" fn end(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+        let interp = interpreter_or_raise!(mrb);
+        let value = Value::new(&interp, slf);
+        let result =
+            end::Args::extract(&interp).and_then(|args| end::method(&interp, args, &value));
+        match result {
+            Ok(result) => result.inner(),
+            Err(end::Error::NoMatch) | Err(end::Error::NoGroup) => interp.nil().inner(),
+            Err(end::Error::IndexType) => TypeError::raise(&interp, "Unexpected capture group"),
+            Err(end::Error::Fatal) => RuntimeError::raise(&interp, "fatal MatchData#begin error"),
+        }
+    }
+
+    unsafe extern "C" fn length(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+        let interp = interpreter_or_raise!(mrb);
+        let value = Value::new(&interp, slf);
+        match length::method(&interp, &value) {
+            Ok(result) => result.inner(),
+            Err(length::Error::Fatal) => {
+                RuntimeError::raise(&interp, "fatal MatchData#length error")
+            }
+        }
+    }
+
+    unsafe extern "C" fn named_captures(
+        mrb: *mut sys::mrb_state,
+        slf: sys::mrb_value,
+    ) -> sys::mrb_value {
+        let interp = interpreter_or_raise!(mrb);
+        let value = Value::new(&interp, slf);
+        match named_captures::method(&interp, &value) {
+            Ok(result) => result.inner(),
+            Err(named_captures::Error::NoMatch) => interp.nil().inner(),
+            Err(named_captures::Error::Fatal) => {
+                RuntimeError::raise(&interp, "fatal MatchData#named_captures error")
+            }
+        }
+    }
+
+    unsafe extern "C" fn post_match(
+        mrb: *mut sys::mrb_state,
+        slf: sys::mrb_value,
+    ) -> sys::mrb_value {
+        let interp = interpreter_or_raise!(mrb);
+        let value = Value::new(&interp, slf);
+        match post_match::method(&interp, &value) {
+            Ok(result) => result.inner(),
+            Err(post_match::Error::Fatal) => {
+                RuntimeError::raise(&interp, "fatal MatchData#post_match error")
+            }
+        }
+    }
+
+    unsafe extern "C" fn pre_match(
+        mrb: *mut sys::mrb_state,
+        slf: sys::mrb_value,
+    ) -> sys::mrb_value {
+        let interp = interpreter_or_raise!(mrb);
+        let value = Value::new(&interp, slf);
+        match pre_match::method(&interp, &value) {
+            Ok(result) => result.inner(),
+            Err(pre_match::Error::Fatal) => {
+                RuntimeError::raise(&interp, "fatal MatchData#pre_match error")
+            }
+        }
+    }
+
+    unsafe extern "C" fn regexp(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+        let interp = interpreter_or_raise!(mrb);
+        let value = Value::new(&interp, slf);
+        match regexp::method(&interp, &value) {
+            Ok(result) => result.inner(),
+            Err(regexp::Error::Fatal) => {
+                RuntimeError::raise(&interp, "fatal MatchData#regexp error")
+            }
+        }
+    }
+
+    unsafe extern "C" fn string(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+        let interp = interpreter_or_raise!(mrb);
+        let value = Value::new(&interp, slf);
+        match string::method(&interp, &value) {
+            Ok(result) => result.inner(),
+            Err(string::Error::Fatal) => {
+                RuntimeError::raise(&interp, "fatal MatchData#string error")
+            }
+        }
+    }
+
+    #[allow(clippy::wrong_self_convention)]
+    unsafe extern "C" fn to_a(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+        let interp = interpreter_or_raise!(mrb);
+        let value = Value::new(&interp, slf);
+        match to_a::method(&interp, &value) {
+            Ok(result) => result.inner(),
+            Err(to_a::Error::NoMatch) => interp.nil().inner(),
+            Err(to_a::Error::Fatal) => RuntimeError::raise(&interp, "fatal MatchData#to_a error"),
+        }
+    }
+
+    #[allow(clippy::wrong_self_convention)]
+    unsafe extern "C" fn to_s(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+        let interp = interpreter_or_raise!(mrb);
+        let value = Value::new(&interp, slf);
+        match to_s::method(&interp, &value) {
+            Ok(result) => result.inner(),
+            Err(to_s::Error::NoMatch) => interp.string("").inner(),
+            Err(to_s::Error::Fatal) => RuntimeError::raise(&interp, "fatal MatchData#to_s error"),
+        }
+    }
+}

--- a/mruby/src/extn/core/matchdata/mod.rs
+++ b/mruby/src/extn/core/matchdata/mod.rs
@@ -13,6 +13,7 @@ mod element_reference;
 mod end;
 mod length;
 mod named_captures;
+mod names;
 mod offset;
 mod post_match;
 mod pre_match;
@@ -45,6 +46,9 @@ pub fn init(interp: &Mrb) -> Result<(), MrbError> {
         MatchData::named_captures,
         sys::mrb_args_none(),
     );
+    match_data
+        .borrow_mut()
+        .add_method("names", MatchData::names, sys::mrb_args_none());
     match_data
         .borrow_mut()
         .add_method("offset", MatchData::offset, sys::mrb_args_req(1));
@@ -194,6 +198,17 @@ impl MatchData {
             Err(named_captures::Error::NoMatch) => interp.nil().inner(),
             Err(named_captures::Error::Fatal) => {
                 RuntimeError::raise(&interp, "fatal MatchData#named_captures error")
+            }
+        }
+    }
+
+    unsafe extern "C" fn names(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+        let interp = interpreter_or_raise!(mrb);
+        let value = Value::new(&interp, slf);
+        match names::method(&interp, &value) {
+            Ok(result) => result.inner(),
+            Err(names::Error::Fatal) => {
+                RuntimeError::raise(&interp, "fatal MatchData#names error")
             }
         }
     }

--- a/mruby/src/extn/core/matchdata/named_captures.rs
+++ b/mruby/src/extn/core/matchdata/named_captures.rs
@@ -1,0 +1,30 @@
+use std::collections::HashMap;
+use std::convert::TryFrom;
+
+use crate::convert::{FromMrb, RustBackedValue};
+use crate::extn::core::matchdata::MatchData;
+use crate::interpreter::Mrb;
+use crate::value::Value;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Error {
+    Fatal,
+    NoMatch,
+}
+
+pub fn method(interp: &Mrb, value: &Value) -> Result<Value, Error> {
+    let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
+    let borrow = data.borrow();
+    let match_against = &borrow.string[borrow.region.start..borrow.region.end];
+    let captures = borrow
+        .regexp
+        .regex
+        .captures(match_against)
+        .ok_or(Error::NoMatch)?;
+    let mut map = HashMap::default();
+    for (name, index) in borrow.regexp.regex.capture_names() {
+        let index = usize::try_from(index[0]).map_err(|_| Error::Fatal)?;
+        map.insert(name, Value::from_mrb(interp, captures.at(index)));
+    }
+    Ok(Value::from_mrb(&interp, map))
+}

--- a/mruby/src/extn/core/matchdata/names.rs
+++ b/mruby/src/extn/core/matchdata/names.rs
@@ -1,0 +1,30 @@
+use std::cmp::Ordering;
+
+use crate::convert::{FromMrb, RustBackedValue};
+use crate::extn::core::matchdata::MatchData;
+use crate::interpreter::Mrb;
+use crate::value::Value;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Error {
+    Fatal,
+}
+
+pub fn method(interp: &Mrb, value: &Value) -> Result<Value, Error> {
+    let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
+    let borrow = data.borrow();
+    let mut names = vec![];
+    let mut capture_names = borrow.regexp.regex.capture_names().collect::<Vec<_>>();
+    capture_names.sort_by(|a, b| {
+        a.1.iter()
+            .fold(u32::max_value(), |a, &b| a.min(b))
+            .partial_cmp(b.1.iter().fold(&u32::max_value(), |a, b| a.min(b)))
+            .unwrap_or(Ordering::Equal)
+    });
+    for (name, _) in capture_names {
+        if !names.contains(&name) {
+            names.push(name);
+        }
+    }
+    Ok(Value::from_mrb(&interp, names))
+}

--- a/mruby/src/extn/core/matchdata/offset.rs
+++ b/mruby/src/extn/core/matchdata/offset.rs
@@ -1,0 +1,82 @@
+use std::convert::TryFrom;
+use std::mem;
+
+use crate::convert::{FromMrb, RustBackedValue, TryFromMrb};
+use crate::extn::core::matchdata::MatchData;
+use crate::interpreter::Mrb;
+use crate::sys;
+use crate::value::Value;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Error {
+    Fatal,
+    IndexType,
+    NoGroup,
+    NoMatch,
+}
+
+#[derive(Debug, Clone)]
+pub enum Args {
+    Index(i64),
+    Name(String),
+}
+
+impl Args {
+    const ARGSPEC: &'static [u8] = b"o\0";
+
+    pub unsafe fn extract(interp: &Mrb) -> Result<Self, Error> {
+        let first = mem::uninitialized::<sys::mrb_value>();
+        sys::mrb_get_args(
+            interp.borrow().mrb,
+            Self::ARGSPEC.as_ptr() as *const i8,
+            &first,
+        );
+        if let Ok(index) = i64::try_from_mrb(interp, Value::new(interp, first)) {
+            Ok(Args::Index(index))
+        } else if let Ok(name) = String::try_from_mrb(interp, Value::new(interp, first)) {
+            Ok(Args::Name(name))
+        } else {
+            Err(Error::IndexType)
+        }
+    }
+}
+
+pub fn method(interp: &Mrb, args: Args, value: &Value) -> Result<Value, Error> {
+    let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
+    let borrow = data.borrow();
+    let match_against = &borrow.string[borrow.region.start..borrow.region.end];
+    let captures = borrow
+        .regexp
+        .regex
+        .captures(match_against)
+        .ok_or(Error::NoMatch)?;
+    let index = match args {
+        Args::Index(index) => {
+            if index < 0 {
+                // Positive i64 must be usize
+                let index = usize::try_from(-index).map_err(|_| Error::Fatal)?;
+                captures.len().checked_sub(index).ok_or(Error::Fatal)?
+            } else {
+                // Positive i64 must be usize
+                usize::try_from(index).map_err(|_| Error::Fatal)?
+            }
+        }
+        Args::Name(name) => {
+            let index = borrow
+                .regexp
+                .regex
+                .capture_names()
+                .find(|capture| capture.0 == name)
+                .ok_or(Error::NoGroup)?;
+            usize::try_from(index.1[0]).map_err(|_| Error::Fatal)?
+        }
+    };
+    let (begin, end) = captures.pos(index).ok_or(Error::NoMatch)?;
+    let begin = match_against[0..begin].chars().count();
+    let begin = begin + borrow.region.start;
+    let begin = i64::try_from(begin).map_err(|_| Error::Fatal)?;
+    let end = match_against[0..end].chars().count();
+    let end = end + borrow.region.start;
+    let end = i64::try_from(end).map_err(|_| Error::Fatal)?;
+    Ok(Value::from_mrb(&interp, vec![begin, end]))
+}

--- a/mruby/src/extn/core/matchdata/post_match.rs
+++ b/mruby/src/extn/core/matchdata/post_match.rs
@@ -1,0 +1,16 @@
+use crate::convert::{FromMrb, RustBackedValue};
+use crate::extn::core::matchdata::MatchData;
+use crate::interpreter::Mrb;
+use crate::value::Value;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Error {
+    Fatal,
+}
+
+pub fn method(interp: &Mrb, value: &Value) -> Result<Value, Error> {
+    let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
+    let borrow = data.borrow();
+    let post_match = &borrow.string[borrow.region.end..];
+    Ok(Value::from_mrb(&interp, post_match))
+}

--- a/mruby/src/extn/core/matchdata/pre_match.rs
+++ b/mruby/src/extn/core/matchdata/pre_match.rs
@@ -1,0 +1,16 @@
+use crate::convert::{FromMrb, RustBackedValue};
+use crate::extn::core::matchdata::MatchData;
+use crate::interpreter::Mrb;
+use crate::value::Value;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Error {
+    Fatal,
+}
+
+pub fn method(interp: &Mrb, value: &Value) -> Result<Value, Error> {
+    let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
+    let borrow = data.borrow();
+    let pre_match = &borrow.string[0..borrow.region.start];
+    Ok(Value::from_mrb(&interp, pre_match))
+}

--- a/mruby/src/extn/core/matchdata/regexp.rs
+++ b/mruby/src/extn/core/matchdata/regexp.rs
@@ -1,0 +1,19 @@
+use crate::convert::RustBackedValue;
+use crate::extn::core::matchdata::MatchData;
+use crate::interpreter::Mrb;
+use crate::value::Value;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Error {
+    Fatal,
+}
+
+pub fn method(interp: &Mrb, value: &Value) -> Result<Value, Error> {
+    if let Ok(data) = unsafe { MatchData::try_from_ruby(interp, value) } {
+        let borrow = data.borrow();
+        let regexp = borrow.regexp.clone();
+        unsafe { regexp.try_into_ruby(interp, None) }.map_err(|_| Error::Fatal)
+    } else {
+        Err(Error::Fatal)
+    }
+}

--- a/mruby/src/extn/core/matchdata/string.rs
+++ b/mruby/src/extn/core/matchdata/string.rs
@@ -10,7 +10,10 @@ pub enum Error {
 
 pub fn method(interp: &Mrb, value: &Value) -> Result<Value, Error> {
     if let Ok(data) = unsafe { MatchData::try_from_ruby(interp, value) } {
-        Ok(interp.string(data.borrow().string.as_str()))
+        interp
+            .string(data.borrow().string.as_str())
+            .freeze()
+            .map_err(|_| Error::Fatal)
     } else {
         Err(Error::Fatal)
     }

--- a/mruby/src/extn/core/matchdata/string.rs
+++ b/mruby/src/extn/core/matchdata/string.rs
@@ -1,0 +1,17 @@
+use crate::convert::RustBackedValue;
+use crate::extn::core::matchdata::MatchData;
+use crate::interpreter::{Mrb, MrbApi};
+use crate::value::Value;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Error {
+    Fatal,
+}
+
+pub fn method(interp: &Mrb, value: &Value) -> Result<Value, Error> {
+    if let Ok(data) = unsafe { MatchData::try_from_ruby(interp, value) } {
+        Ok(interp.string(data.borrow().string.as_str()))
+    } else {
+        Err(Error::Fatal)
+    }
+}

--- a/mruby/src/extn/core/matchdata/to_a.rs
+++ b/mruby/src/extn/core/matchdata/to_a.rs
@@ -1,0 +1,23 @@
+use crate::convert::{FromMrb, RustBackedValue};
+use crate::extn::core::matchdata::MatchData;
+use crate::interpreter::Mrb;
+use crate::value::Value;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Error {
+    Fatal,
+    NoMatch,
+}
+
+pub fn method(interp: &Mrb, value: &Value) -> Result<Value, Error> {
+    let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
+    let borrow = data.borrow();
+    let match_against = &borrow.string[borrow.region.start..borrow.region.end];
+    let captures = borrow
+        .regexp
+        .regex
+        .captures(match_against)
+        .ok_or(Error::NoMatch)?;
+    let vec = captures.iter().collect::<Vec<_>>();
+    Ok(Value::from_mrb(&interp, vec))
+}

--- a/mruby/src/extn/core/matchdata/to_s.rs
+++ b/mruby/src/extn/core/matchdata/to_s.rs
@@ -1,0 +1,22 @@
+use crate::convert::{FromMrb, RustBackedValue};
+use crate::extn::core::matchdata::MatchData;
+use crate::interpreter::Mrb;
+use crate::value::Value;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Error {
+    Fatal,
+    NoMatch,
+}
+
+pub fn method(interp: &Mrb, value: &Value) -> Result<Value, Error> {
+    let data = unsafe { MatchData::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
+    let borrow = data.borrow();
+    let match_against = &borrow.string[borrow.region.start..borrow.region.end];
+    let captures = borrow
+        .regexp
+        .regex
+        .captures(match_against)
+        .ok_or(Error::NoMatch)?;
+    Ok(Value::from_mrb(&interp, captures.at(0).unwrap_or_default()))
+}

--- a/mruby/src/extn/core/mod.rs
+++ b/mruby/src/extn/core/mod.rs
@@ -6,6 +6,7 @@ pub mod array;
 pub mod env;
 pub mod error;
 pub mod kernel;
+pub mod matchdata;
 pub mod module;
 pub mod regexp;
 pub mod string;
@@ -17,6 +18,7 @@ pub fn patch(interp: &Mrb) -> Result<(), MrbError> {
     env::patch(interp)?;
     error::patch(interp)?;
     kernel::patch(interp)?;
+    matchdata::init(interp)?;
     module::patch(interp)?;
     regexp::init(interp)?;
     string::patch(interp)?;

--- a/mruby/src/extn/core/regexp/mod.rs
+++ b/mruby/src/extn/core/regexp/mod.rs
@@ -18,7 +18,7 @@ use crate::MrbError;
 
 mod args;
 pub mod initialize;
-mod syntax;
+pub mod syntax;
 
 pub fn init(interp: &Mrb) -> Result<(), MrbError> {
     interp.eval(include_str!("regexp.rb"))?;
@@ -630,12 +630,7 @@ impl Regexp {
                 interp.borrow_mut().num_set_regexp_capture_globals = captures.len();
             }
 
-            let data = MatchData::new(
-                string.as_str(),
-                regexp.borrow().clone(),
-                0,
-                string.len(),
-            );
+            let data = MatchData::new(string.as_str(), regexp.borrow().clone(), 0, string.len());
             unwrap_value_or_raise!(interp, data.try_into_ruby(&interp, None))
         } else {
             interp.nil().inner()
@@ -807,12 +802,7 @@ impl Regexp {
                 interp.borrow_mut().num_set_regexp_capture_globals = captures.len();
             }
 
-            let data = MatchData::new(
-                string.as_str(),
-                regexp.borrow().clone(),
-                0,
-                string.len(),
-            );
+            let data = MatchData::new(string.as_str(), regexp.borrow().clone(), 0, string.len());
             unwrap_or_raise!(
                 interp,
                 data.try_into_ruby(&interp, None),

--- a/mruby/src/extn/core/regexp/mod.rs
+++ b/mruby/src/extn/core/regexp/mod.rs
@@ -8,9 +8,8 @@ use std::rc::Rc;
 use crate::convert::{FromMrb, RustBackedValue, TryFromMrb};
 use crate::def::{rust_data_free, ClassLike, Define};
 use crate::eval::MrbEval;
-use crate::extn::core::error::{
-    ArgumentError, RubyException, RuntimeError, SyntaxError, TypeError,
-};
+use crate::extn::core::error::{RubyException, RuntimeError, SyntaxError, TypeError};
+use crate::extn::core::matchdata::MatchData;
 use crate::interpreter::{Mrb, MrbApi};
 use crate::sys;
 use crate::value::types::Ruby;
@@ -18,7 +17,7 @@ use crate::value::{Value, ValueLike};
 use crate::MrbError;
 
 mod args;
-mod initialize;
+pub mod initialize;
 mod syntax;
 
 pub fn init(interp: &Mrb) -> Result<(), MrbError> {
@@ -87,54 +86,6 @@ pub fn init(interp: &Mrb) -> Result<(), MrbError> {
         Regexp::FIXEDENCODING,
         Regexp::NOENCODING,
     ))?;
-    let match_data = interp.borrow_mut().def_class::<MatchData>(
-        "MatchData",
-        None,
-        Some(rust_data_free::<MatchData>),
-    );
-    match_data.borrow_mut().mrb_value_is_rust_backed(true);
-    match_data
-        .borrow_mut()
-        .add_method("string", MatchData::string, sys::mrb_args_none());
-    match_data
-        .borrow_mut()
-        .add_method("regexp", MatchData::regexp, sys::mrb_args_none());
-    match_data
-        .borrow_mut()
-        .add_method("[]", MatchData::idx, sys::mrb_args_none());
-    match_data
-        .borrow_mut()
-        .add_method("begin", MatchData::begin, sys::mrb_args_req(1));
-    match_data
-        .borrow_mut()
-        .add_method("end", MatchData::end, sys::mrb_args_req(1));
-    match_data
-        .borrow_mut()
-        .add_method("length", MatchData::length, sys::mrb_args_none());
-    match_data
-        .borrow_mut()
-        .add_method("size", MatchData::length, sys::mrb_args_none());
-    match_data
-        .borrow_mut()
-        .add_method("captures", MatchData::captures, sys::mrb_args_none());
-    match_data.borrow_mut().add_method(
-        "named_captures",
-        MatchData::named_captures,
-        sys::mrb_args_none(),
-    );
-    match_data
-        .borrow_mut()
-        .add_method("pre_match", MatchData::pre_match, sys::mrb_args_none());
-    match_data
-        .borrow_mut()
-        .add_method("post_match", MatchData::post_match, sys::mrb_args_none());
-    match_data
-        .borrow_mut()
-        .add_method("to_a", MatchData::to_a, sys::mrb_args_none());
-    match_data
-        .borrow_mut()
-        .add_method("to_s", MatchData::to_s, sys::mrb_args_none());
-    match_data.borrow().define(&interp)?;
     Ok(())
 }
 
@@ -411,7 +362,7 @@ pub struct Regexp {
     literal_options: Options,
     options: Options,
     encoding: Encoding,
-    regex: Rc<Regex>,
+    pub regex: Rc<Regex>,
 }
 
 impl Default for Regexp {
@@ -679,11 +630,13 @@ impl Regexp {
                 interp.borrow_mut().num_set_regexp_capture_globals = captures.len();
             }
 
-            let data = MatchData {
-                string,
-                regexp: regexp.borrow().clone(),
-                start_pos: pos,
-            };
+            // TODO: this is gross
+            let data = MatchData::new(
+                string.as_str(),
+                regexp.borrow().clone(),
+                region.pos(0).map(|r| r.0).unwrap_or_default(),
+                region.pos(0).map(|r| r.1).unwrap_or_default(),
+            );
             unwrap_value_or_raise!(interp, data.try_into_ruby(&interp, None))
         } else {
             interp.nil().inner()
@@ -855,11 +808,12 @@ impl Regexp {
                 interp.borrow_mut().num_set_regexp_capture_globals = captures.len();
             }
 
-            let data = MatchData {
-                string,
-                regexp: regexp.borrow().clone(),
-                start_pos: pos,
-            };
+            let data = MatchData::new(
+                string.as_str(),
+                regexp.borrow().clone(),
+                region.pos(0).map(|r| r.0).unwrap_or_default(),
+                region.pos(0).map(|r| r.1).unwrap_or_default(),
+            );
             unwrap_or_raise!(
                 interp,
                 data.try_into_ruby(&interp, None),
@@ -966,399 +920,5 @@ impl Regexp {
             regexp.borrow().encoding.as_literal_string()
         );
         Value::from_mrb(&interp, s).inner()
-    }
-}
-
-#[derive(Debug)]
-pub struct MatchData {
-    string: String,
-    regexp: Regexp,
-    start_pos: usize,
-}
-
-impl RustBackedValue for MatchData {}
-
-impl MatchData {
-    fn string_to_capture(&self) -> &str {
-        &self.string[self.start_pos..]
-    }
-
-    unsafe extern "C" fn string(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-        let interp = interpreter_or_raise!(mrb);
-
-        let data = unwrap_or_raise!(
-            interp,
-            Self::try_from_ruby(&interp, &Value::new(&interp, slf)),
-            interp.nil().inner()
-        );
-        let borrow = data.borrow();
-        Value::from_mrb(&interp, borrow.string.as_str()).inner()
-    }
-
-    unsafe extern "C" fn regexp(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-        let interp = interpreter_or_raise!(mrb);
-
-        let data = unwrap_or_raise!(
-            interp,
-            Self::try_from_ruby(&interp, &Value::new(&interp, slf)),
-            interp.nil().inner()
-        );
-        let borrow = data.borrow();
-        unwrap_value_or_raise!(interp, borrow.regexp.clone().try_into_ruby(&interp, None))
-    }
-
-    unsafe extern "C" fn idx(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-        let interp = interpreter_or_raise!(mrb);
-        let data = unwrap_or_raise!(
-            interp,
-            Self::try_from_ruby(&interp, &Value::new(&interp, slf)),
-            interp.nil().inner()
-        );
-        let borrow = data.borrow();
-        let length = borrow
-            .regexp
-            .regex
-            .captures(borrow.string_to_capture())
-            .map(|captures| captures.len())
-            .unwrap_or_default();
-        let args = unwrap_or_raise!(
-            interp,
-            args::MatchIndex::extract(&interp, length),
-            interp.nil().inner()
-        );
-        match args {
-            args::MatchIndex::Index(index) => {
-                let index = if index < 0 {
-                    length
-                        .checked_sub(usize::try_from(-index).expect("positive i64 must be usize"))
-                        .unwrap_or_default()
-                } else {
-                    usize::try_from(index).expect("positive i64 must be usize")
-                };
-                let captures = borrow.regexp.regex.captures(borrow.string_to_capture());
-                match captures {
-                    Some(captures) => Value::from_mrb(&interp, captures.at(index)).inner(),
-                    None => interp.nil().inner(),
-                }
-            }
-            args::MatchIndex::Name(name) => {
-                let match_ = borrow
-                    .regexp
-                    .regex
-                    .capture_names()
-                    .find(|capture| capture.0 == name)
-                    .and_then(|capture| usize::try_from(capture.1[0]).ok())
-                    .and_then(|index| {
-                        borrow
-                            .regexp
-                            .regex
-                            .captures(borrow.string_to_capture())
-                            .and_then(|captures| captures.at(index))
-                    });
-                Value::from_mrb(&interp, match_).inner()
-            }
-            args::MatchIndex::StartLen(start, len) => {
-                let captures = borrow.regexp.regex.captures(borrow.string_to_capture());
-                match captures {
-                    Some(captures) => {
-                        let start = if start < 0 {
-                            captures.len().checked_sub(
-                                usize::try_from(-start).expect("positive i64 must be usize"),
-                            )
-                        } else {
-                            Some(usize::try_from(start).expect("positive i64 must be usize"))
-                        };
-                        match start {
-                            Some(start) => {
-                                let mut matches = vec![];
-                                for index in start..(start + len) {
-                                    matches.push(captures.at(index));
-                                }
-                                Value::from_mrb(&interp, matches).inner()
-                            }
-                            None => interp.nil().inner(),
-                        }
-                    }
-                    None => interp.nil().inner(),
-                }
-            }
-        }
-    }
-
-    unsafe extern "C" fn begin(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-        let interp = interpreter_or_raise!(mrb);
-
-        let data = unwrap_or_raise!(
-            interp,
-            Self::try_from_ruby(&interp, &Value::new(&interp, slf)),
-            interp.nil().inner()
-        );
-        let borrow = data.borrow();
-        let length = borrow
-            .regexp
-            .regex
-            .captures(borrow.string_to_capture())
-            .map(|captures| captures.len());
-        let args = unwrap_or_raise!(
-            interp,
-            args::MatchIndex::extract(&interp, length.unwrap_or_default()),
-            interp.nil().inner()
-        );
-        match args {
-            args::MatchIndex::Index(index) => {
-                let captures = borrow.regexp.regex.captures(borrow.string_to_capture());
-                match captures {
-                    Some(captures) => {
-                        let index = if index < 0 {
-                            captures.len().checked_sub(
-                                usize::try_from(-index).expect("positive i64 must be usize"),
-                            )
-                        } else {
-                            Some(usize::try_from(index).expect("positive i64 must be usize"))
-                        };
-                        let index = index
-                            .and_then(|index| captures.pos(index))
-                            .map(|pos| borrow.string_to_capture()[0..pos.0].chars().count())
-                            .and_then(|pos| i64::try_from(pos).ok());
-                        Value::from_mrb(&interp, index).inner()
-                    }
-                    None => interp.nil().inner(),
-                }
-            }
-            args::MatchIndex::Name(name) => {
-                let pos = borrow
-                    .regexp
-                    .regex
-                    .capture_names()
-                    .find(|capture| capture.0 == name)
-                    .and_then(|capture| usize::try_from(capture.1[0]).ok())
-                    .and_then(|index| {
-                        borrow
-                            .regexp
-                            .regex
-                            .captures(borrow.string_to_capture())
-                            .and_then(|captures| captures.pos(index))
-                            .map(|pos| borrow.string_to_capture()[0..pos.0].chars().count())
-                            .and_then(|pos| i64::try_from(pos).ok())
-                    });
-                Value::from_mrb(&interp, pos).inner()
-            }
-            args::MatchIndex::StartLen(_, _) => {
-                ArgumentError::raise(&interp, "must pass index or symbol")
-            }
-        }
-    }
-
-    unsafe extern "C" fn end(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-        let interp = interpreter_or_raise!(mrb);
-
-        let data = unwrap_or_raise!(
-            interp,
-            Self::try_from_ruby(&interp, &Value::new(&interp, slf)),
-            interp.nil().inner()
-        );
-        let borrow = data.borrow();
-        let length = borrow
-            .regexp
-            .regex
-            .captures(borrow.string_to_capture())
-            .map(|captures| captures.len());
-        let args = unwrap_or_raise!(
-            interp,
-            args::MatchIndex::extract(&interp, length.unwrap_or_default()),
-            interp.nil().inner()
-        );
-        match args {
-            args::MatchIndex::Index(index) => {
-                let captures = borrow.regexp.regex.captures(borrow.string_to_capture());
-                match captures {
-                    Some(captures) => {
-                        let index = if index < 0 {
-                            captures.len().checked_sub(
-                                usize::try_from(-index).expect("positive i64 must be usize"),
-                            )
-                        } else {
-                            Some(usize::try_from(index).expect("positive i64 must be usize"))
-                        };
-                        let index = index
-                            .and_then(|index| captures.pos(index))
-                            .map(|pos| borrow.string_to_capture()[0..pos.1].chars().count())
-                            .and_then(|pos| i64::try_from(pos).ok());
-                        Value::from_mrb(&interp, index).inner()
-                    }
-                    None => interp.nil().inner(),
-                }
-            }
-            args::MatchIndex::Name(name) => {
-                let pos = borrow
-                    .regexp
-                    .regex
-                    .capture_names()
-                    .find(|capture| capture.0 == name)
-                    .and_then(|capture| usize::try_from(capture.1[0]).ok())
-                    .and_then(|index| {
-                        borrow
-                            .regexp
-                            .regex
-                            .captures(borrow.string_to_capture())
-                            .and_then(|captures| captures.pos(index))
-                            .map(|pos| borrow.string_to_capture()[0..pos.1].chars().count())
-                            .and_then(|pos| i64::try_from(pos).ok())
-                    });
-                Value::from_mrb(&interp, pos).inner()
-            }
-            args::MatchIndex::StartLen(_, _) => {
-                ArgumentError::raise(&interp, "must pass index or symbol")
-            }
-        }
-    }
-
-    unsafe extern "C" fn length(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-        let interp = interpreter_or_raise!(mrb);
-
-        let data = unwrap_or_raise!(
-            interp,
-            Self::try_from_ruby(&interp, &Value::new(&interp, slf)),
-            interp.nil().inner()
-        );
-        let borrow = data.borrow();
-        let captures = borrow.regexp.regex.captures(borrow.string_to_capture());
-        if let Some(captures) = captures {
-            unwrap_value_or_raise!(
-                interp,
-                i64::try_from(captures.len()).map(|len| interp.fixnum(len))
-            )
-        } else {
-            interp.fixnum(0).inner()
-        }
-    }
-
-    unsafe extern "C" fn captures(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-        let interp = interpreter_or_raise!(mrb);
-
-        let data = unwrap_or_raise!(
-            interp,
-            Self::try_from_ruby(&interp, &Value::new(&interp, slf)),
-            interp.nil().inner()
-        );
-        let borrow = data.borrow();
-        let captures = borrow.regexp.regex.captures(borrow.string_to_capture());
-        if let Some(captures) = captures {
-            let mut vec = vec![];
-            for (group, subcapture) in captures.iter().enumerate() {
-                if group > 0 {
-                    vec.push(subcapture.map(String::from));
-                }
-            }
-            Value::from_mrb(&interp, vec).inner()
-        } else {
-            interp.nil().inner()
-        }
-    }
-
-    unsafe extern "C" fn named_captures(
-        mrb: *mut sys::mrb_state,
-        slf: sys::mrb_value,
-    ) -> sys::mrb_value {
-        let interp = interpreter_or_raise!(mrb);
-
-        let data = unwrap_or_raise!(
-            interp,
-            Self::try_from_ruby(&interp, &Value::new(&interp, slf)),
-            interp.nil().inner()
-        );
-        let borrow = data.borrow();
-        let captures = borrow.regexp.regex.captures(borrow.string_to_capture());
-        if let Some(captures) = captures {
-            let mut map = HashMap::default();
-            for (name, index) in borrow.regexp.regex.capture_names() {
-                if let Some(group) = captures.at(usize::try_from(index[0]).unwrap_or_default()) {
-                    map.insert(name.to_owned(), group.to_owned());
-                }
-            }
-            Value::from_mrb(&interp, map).inner()
-        } else {
-            interp.nil().inner()
-        }
-    }
-
-    unsafe extern "C" fn pre_match(
-        mrb: *mut sys::mrb_state,
-        slf: sys::mrb_value,
-    ) -> sys::mrb_value {
-        let interp = interpreter_or_raise!(mrb);
-
-        let data = unwrap_or_raise!(
-            interp,
-            Self::try_from_ruby(&interp, &Value::new(&interp, slf)),
-            interp.nil().inner()
-        );
-        let borrow = data.borrow();
-        let captures = borrow.regexp.regex.captures(borrow.string_to_capture());
-        if let Some((start, _)) = captures.and_then(|captures| captures.pos(0)) {
-            Value::from_mrb(&interp, borrow.string_to_capture()[..start].to_owned()).inner()
-        } else {
-            interp.nil().inner()
-        }
-    }
-
-    unsafe extern "C" fn post_match(
-        mrb: *mut sys::mrb_state,
-        slf: sys::mrb_value,
-    ) -> sys::mrb_value {
-        let interp = interpreter_or_raise!(mrb);
-
-        let data = unwrap_or_raise!(
-            interp,
-            Self::try_from_ruby(&interp, &Value::new(&interp, slf)),
-            interp.nil().inner()
-        );
-        let borrow = data.borrow();
-        let captures = borrow.regexp.regex.captures(borrow.string_to_capture());
-        if let Some((_, end)) = captures.and_then(|captures| captures.pos(0)) {
-            Value::from_mrb(&interp, borrow.string_to_capture()[end..].to_owned()).inner()
-        } else {
-            interp.nil().inner()
-        }
-    }
-
-    #[allow(clippy::wrong_self_convention)]
-    unsafe extern "C" fn to_a(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-        let interp = interpreter_or_raise!(mrb);
-
-        let data = unwrap_or_raise!(
-            interp,
-            Self::try_from_ruby(&interp, &Value::new(&interp, slf)),
-            interp.nil().inner()
-        );
-        let borrow = data.borrow();
-        let captures = borrow.regexp.regex.captures(borrow.string_to_capture());
-        if let Some(captures) = captures {
-            let mut vec = vec![];
-            for subcapture in captures.iter() {
-                vec.push(subcapture.map(String::from));
-            }
-            Value::from_mrb(&interp, vec).inner()
-        } else {
-            interp.nil().inner()
-        }
-    }
-
-    #[allow(clippy::wrong_self_convention)]
-    unsafe extern "C" fn to_s(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
-        let interp = interpreter_or_raise!(mrb);
-
-        let data = unwrap_or_raise!(
-            interp,
-            Self::try_from_ruby(&interp, &Value::new(&interp, slf)),
-            interp.nil().inner()
-        );
-        let borrow = data.borrow();
-        let captures = borrow.regexp.regex.captures(borrow.string_to_capture());
-        if let Some(captures) = captures {
-            Value::from_mrb(&interp, captures.at(0)).inner()
-        } else {
-            Value::from_mrb(&interp, "").inner()
-        }
     }
 }

--- a/mruby/src/extn/core/regexp/mod.rs
+++ b/mruby/src/extn/core/regexp/mod.rs
@@ -630,12 +630,11 @@ impl Regexp {
                 interp.borrow_mut().num_set_regexp_capture_globals = captures.len();
             }
 
-            // TODO: this is gross
             let data = MatchData::new(
                 string.as_str(),
                 regexp.borrow().clone(),
-                region.pos(0).map(|r| r.0).unwrap_or_default(),
-                region.pos(0).map(|r| r.1).unwrap_or_default(),
+                0,
+                string.len(),
             );
             unwrap_value_or_raise!(interp, data.try_into_ruby(&interp, None))
         } else {
@@ -811,8 +810,8 @@ impl Regexp {
             let data = MatchData::new(
                 string.as_str(),
                 regexp.borrow().clone(),
-                region.pos(0).map(|r| r.0).unwrap_or_default(),
-                region.pos(0).map(|r| r.1).unwrap_or_default(),
+                0,
+                string.len(),
             );
             unwrap_or_raise!(
                 interp,

--- a/mruby/src/extn/core/regexp/mod.rs
+++ b/mruby/src/extn/core/regexp/mod.rs
@@ -822,9 +822,7 @@ impl Regexp {
         let value = Value::new(&interp, slf);
         match names::method(&interp, &value) {
             Ok(result) => result.inner(),
-            Err(names::Error::Fatal) => {
-                RuntimeError::raise(&interp, "fatal MatchData#names error")
-            }
+            Err(names::Error::Fatal) => RuntimeError::raise(&interp, "fatal Regexp#names error"),
         }
     }
 

--- a/mruby/src/extn/core/regexp/names.rs
+++ b/mruby/src/extn/core/regexp/names.rs
@@ -1,0 +1,30 @@
+use std::cmp::Ordering;
+
+use crate::convert::{FromMrb, RustBackedValue};
+use crate::extn::core::regexp::Regexp;
+use crate::interpreter::Mrb;
+use crate::value::Value;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Error {
+    Fatal,
+}
+
+pub fn method(interp: &Mrb, value: &Value) -> Result<Value, Error> {
+    let data = unsafe { Regexp::try_from_ruby(interp, value) }.map_err(|_| Error::Fatal)?;
+    let borrow = data.borrow();
+    let mut names = vec![];
+    let mut capture_names = borrow.regex.capture_names().collect::<Vec<_>>();
+    capture_names.sort_by(|a, b| {
+        a.1.iter()
+            .fold(u32::max_value(), |a, &b| a.min(b))
+            .partial_cmp(b.1.iter().fold(&u32::max_value(), |a, b| a.min(b)))
+            .unwrap_or(Ordering::Equal)
+    });
+    for (name, _) in capture_names {
+        if !names.contains(&name) {
+            names.push(name);
+        }
+    }
+    Ok(Value::from_mrb(&interp, names))
+}

--- a/mruby/src/extn/core/string.rb
+++ b/mruby/src/extn/core/string.rb
@@ -478,29 +478,6 @@ class String
     self[0..-1] = replaced unless self == replaced
   end
 
-  def scan(pattern)
-    pattern = Regexp.compile(Regexp.escape(pattern)) if pattern.is_a?(String)
-    raise TypeError, "wrong argument type #{pattern.inspect} (expected Regexp)" if pattern.nil?
-    raise TypeError, "wrong argument type #{pattern.class.name} (expected Regexp)" unless pattern.is_a?(Regexp)
-
-    remainder = dup
-    match = pattern.match(remainder)
-    collect = []
-    until remainder.empty? || match.nil?
-      collect <<
-        if block_given?
-          yield match[0]
-        else
-          match[0]
-        end
-      remainder = remainder[match.end(0)..-1]
-      remainder = remainder[1..-1] if match.begin(0) == match.end(0)
-      match = nil
-      match = pattern.match(remainder) unless remainder.nil?
-    end
-    collect
-  end
-
   def scrub
     # TODO: This is a stub. Implement scrub correctly.
     self

--- a/mruby/src/extn/core/string/scan.rs
+++ b/mruby/src/extn/core/string/scan.rs
@@ -1,0 +1,122 @@
+use std::cmp;
+use std::mem;
+
+use crate::convert::{FromMrb, RustBackedValue};
+use crate::extn::core::matchdata::MatchData;
+use crate::extn::core::regexp::{syntax, Encoding, Options, Regexp};
+use crate::interpreter::{Mrb, MrbApi};
+use crate::sys;
+use crate::value::{Value, ValueLike};
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub enum Error {
+    Fatal,
+    WrongType,
+}
+
+#[derive(Debug)]
+pub struct Args {
+    pub regexp: Option<Regexp>,
+    pub block: Option<Value>,
+}
+
+impl Args {
+    const ARGSPEC: &'static [u8] = b"o&\0";
+
+    pub unsafe fn extract(interp: &Mrb) -> Result<Self, Error> {
+        let pattern = mem::uninitialized::<sys::mrb_value>();
+        let block = mem::uninitialized::<sys::mrb_value>();
+        sys::mrb_get_args(
+            interp.borrow().mrb,
+            Self::ARGSPEC.as_ptr() as *const i8,
+            &pattern,
+            &block,
+        );
+        let regexp = if let Ok(regexp) = Regexp::try_from_ruby(interp, &Value::new(interp, pattern))
+        {
+            Some(regexp.borrow().clone())
+        } else if let Some(ref pattern) = Value::new(interp, pattern)
+            .funcall::<Option<String>, _, _>("to_str", &[])
+            .map_err(|_| Error::WrongType)?
+        {
+            Regexp::new(
+                syntax::escape(pattern),
+                syntax::escape(pattern),
+                Options::default(),
+                Options::default(),
+                Encoding::default(),
+            )
+        } else {
+            None
+        };
+        let block = if sys::mrb_sys_value_is_nil(block) {
+            None
+        } else {
+            Some(Value::new(interp, block))
+        };
+        Ok(Self { regexp, block })
+    }
+}
+
+pub fn method(interp: &Mrb, args: Args, value: Value) -> Result<Value, Error> {
+    let mrb = interp.borrow().mrb;
+    let regexp = args.regexp.ok_or(Error::WrongType)?;
+    let s = value.to_s();
+    let mut collected = vec![];
+    for pos in regexp.regex.find_iter(s.as_str()) {
+        let scanned = &s[pos.0..pos.1];
+        if let Some(captures) = regexp.regex.captures(scanned) {
+            let num_regexp_globals_to_set = {
+                let num_previously_set_globals = interp.borrow().num_set_regexp_capture_globals;
+                cmp::max(num_previously_set_globals, captures.len())
+            };
+            for group in 1..=num_regexp_globals_to_set {
+                let value = Value::from_mrb(&interp, captures.at(group));
+                unsafe {
+                    sys::mrb_gv_set(
+                        mrb,
+                        interp.borrow_mut().sym_intern(&format!("${}", group)),
+                        value.inner(),
+                    );
+                }
+            }
+            interp.borrow_mut().num_set_regexp_capture_globals = captures.len();
+
+            let matched = if captures.len() > 1 {
+                let mut collected_groups = vec![];
+                for index in 1..captures.len() {
+                    collected_groups.push(Value::from_mrb(&interp, captures.at(index)));
+                }
+                Value::from_mrb(&interp, collected_groups)
+            } else {
+                Value::from_mrb(&interp, captures.at(0))
+            };
+            let data = MatchData::new(s.as_str(), regexp.clone(), pos.0, pos.1);
+            let data = unsafe { data.try_into_ruby(&interp, None) }.map_err(|_| Error::Fatal)?;
+            unsafe {
+                sys::mrb_gv_set(mrb, interp.borrow_mut().sym_intern("$~"), data.inner());
+            }
+            if let Some(ref block) = args.block {
+                unsafe {
+                    sys::mrb_yield(mrb, block.inner(), matched.inner());
+                    sys::mrb_gv_set(mrb, interp.borrow_mut().sym_intern("$~"), data.inner());
+                }
+            }
+            collected.push(matched);
+        }
+    }
+    if collected.is_empty() {
+        unsafe {
+            sys::mrb_gv_set(
+                mrb,
+                interp.borrow_mut().sym_intern("$~"),
+                interp.nil().inner(),
+            );
+        }
+    }
+    if args.block.is_some() {
+        Ok(value)
+    } else {
+        Ok(Value::from_mrb(&interp, collected))
+    }
+}

--- a/mruby/src/value/mod.rs
+++ b/mruby/src/value/mod.rs
@@ -361,6 +361,13 @@ impl Value {
     {
         self.funcall::<T, _, _>("itself", &[])
     }
+
+    /// Call `#freeze` on this [`Value`] and consume `self`.
+    pub fn freeze(self) -> Result<Self, MrbError> {
+        let frozen = self.funcall::<Value, _, _>("freeze", &[])?;
+        frozen.protect();
+        Ok(frozen)
+    }
 }
 
 impl ValueLike for Value {

--- a/mruby/src/value/mod.rs
+++ b/mruby/src/value/mod.rs
@@ -355,7 +355,7 @@ impl Value {
     /// `T`.
     ///
     /// If you want to consume this [`Value`], use [`Value::try_into`].
-    pub fn itself<T>(self) -> Result<T, MrbError>
+    pub fn itself<T>(&self) -> Result<T, MrbError>
     where
         T: TryFromMrb<Self, From = types::Ruby, To = types::Rust>,
     {

--- a/mruby/src/value/mod.rs
+++ b/mruby/src/value/mod.rs
@@ -364,7 +364,7 @@ impl Value {
 
     /// Call `#freeze` on this [`Value`] and consume `self`.
     pub fn freeze(self) -> Result<Self, MrbError> {
-        let frozen = self.funcall::<Value, _, _>("freeze", &[])?;
+        let frozen = self.funcall::<Self, _, _>("freeze", &[])?;
         frozen.protect();
         Ok(frozen)
     }

--- a/package.json
+++ b/package.json
@@ -82,6 +82,6 @@
   "scripts": {
     "eslint-check": "eslint --print-config . | eslint-config-prettier-check",
     "lint": "./scripts/lint.sh",
-    "loc": "loc --exclude vendor --exclude ffi\\.rs --exclude mruby/src/extn/test/mspec --exclude mruby/src/extn/test/ruby-spec"
+    "loc": "loc --exclude vendor --exclude ffi\\.rs --exclude mruby-bin/ruby/fixtures --exclude spec-runner/spec"
   }
 }

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -25,6 +25,8 @@ cargo doc --no-deps --all
 lint_ruby_sources mruby/src/extn
 ## spec-runner
 lint_ruby_sources spec-runner/src
+## mruby bins
+lint_ruby_sources mruby-bin/ruby
 ## nemesis
 lint_ruby_sources nemesis/ruby
 ## foolsgold

--- a/scripts/rruby-flamegraph.sh
+++ b/scripts/rruby-flamegraph.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+set -x
+
+scratch="$(mktemp -d)"
+pushd "$scratch"
+pid="$(pgrep "[r]ruby")"
+
+sudo dtrace -x ustackframes=100 -n "profile-99 /pid == $pid/ { @[ustack()] = count(); } tick-10s { exit(0); }" -o out.stacks
+
+inferno-collapse-dtrace <out.stacks >stacks.folded
+inferno-flamegraph <stacks.folded >flamegraph.svg
+
+open -a "Google Chrome.app" flamegraph.svg
+echo "$(pwd)/flamegraph.svg"

--- a/spec-runner/src/spec_runner.rb
+++ b/spec-runner/src/spec_runner.rb
@@ -55,6 +55,7 @@ class SpecCollector
       skipped = true if state.message =~ /'private_instance_methods'/
       skipped = true if state.message =~ /'taint'/
       skipped = true if state.message =~ /'tainted\?'/
+      skipped = true if state.message =~ /'untrust'/
     elsif state.exception.is_a?(SpecExpectationNotMetError)
       skipped = true if state.it =~ /encoding/
       skipped = true if state.it =~ /ASCII/


### PR DESCRIPTION
`String#scan` was implemented in Ruby and was slow and not spec compliant. This PR makes `String#scan` ruby/spec compliant and improves performance by a factor of 20. The implementation of `String#scan` in this crate is roughly comparable to CRuby for normal workloads (slower than CRuby by about 10-20%), but can be up to 50% faster for large Strings with sparse matches.

To do that, implement `String#scan` in Rust using an onig `Regex` directly. Before this PR, `String#scan` spends a lot of time in mruby `String#[]`.

<img width="1189" alt="Screen Shot 2019-06-27 at 5 12 40 PM" src="https://user-images.githubusercontent.com/860434/60561038-f8bcd400-9d06-11e9-90e0-d2d8b84c205b.png">

It now spends all of its time in onig.

<img width="1390" alt="Screen Shot 2019-07-02 at 8 20 12 PM" src="https://user-images.githubusercontent.com/860434/60561045-fe1a1e80-9d06-11e9-819e-aa1a13b7dd13.png">

This PR adds a benchmark to mruby-bin which is runnable like this:

```console
$ cargo run --release --bin string_scan_bench -- mruby-bin/ruby/benches/string_scan.rb
String#scan bench for mruby 2.0 [2.0.1-11]

Email: 92 matches
..................................................

    compile: 5.47ms elapsed in 50 iterations (avg. 0.1ms / iteration)
    scan: 16570.2ms elapsed in 50 iterations (avg. 331.4ms / iteration)
    scan with block: 16510.32ms elapsed in 50 iterations (avg. 330.2ms / iteration)

URI: 5301 matches
..................................................

    compile: 2.8ms elapsed in 50 iterations (avg. 0.05ms / iteration)
    scan: 15635.23ms elapsed in 50 iterations (avg. 312.7ms / iteration)
    scan with block: 15533.86ms elapsed in 50 iterations (avg. 310.67ms / iteration)

IP: 5 matches
..................................................

    compile: 2.33ms elapsed in 50 iterations (avg. 0.04ms / iteration)
    scan: 1386.49ms elapsed in 50 iterations (avg. 27.72ms / iteration)
    scan with block: 1367.78ms elapsed in 50 iterations (avg. 27.35ms / iteration)
```

and for CRuby like this:

```console
$ ruby mruby-bin/ruby/benches/string_scan.rb
String#scan bench for ruby 2.6.3p62 (2019-04-16 revision 67580) [x86_64-darwin18]

Email: 92 matches
..................................................

    compile: 1.84ms elapsed in 50 iterations (avg. 0.03ms / iteration)
    scan: 14724.34ms elapsed in 50 iterations (avg. 294.48ms / iteration)
    scan with block: 14669.76ms elapsed in 50 iterations (avg. 293.39ms / iteration)

URI: 5301 matches
..................................................

    compile: 1.93ms elapsed in 50 iterations (avg. 0.03ms / iteration)
    scan: 12823.31ms elapsed in 50 iterations (avg. 256.46ms / iteration)
    scan with block: 12786.91ms elapsed in 50 iterations (avg. 255.73ms / iteration)

IP: 5 matches
..................................................

    compile: 2.32ms elapsed in 50 iterations (avg. 0.04ms / iteration)
    scan: 2714.96ms elapsed in 50 iterations (avg. 54.29ms / iteration)
    scan with block: 2661.23ms elapsed in 50 iterations (avg. 53.22ms / iteration)
```

To pass ruby/spec for `String#scan`, `MatchData` needed to support windowed matches on a source `String`. I took the opportunity to refactor `MatchData`'s Rust representation to hold a match `Region`. I also implemented all of the missing methods   and fixed up some spec compliance issues in the existing implementation. Apart from the `` $` `` and `$'` special variables, `MatchData` is fully compliant with ruby/spec.

Fixes GH-135.