### PR TITLE
Fix segfault caused by improperly transmuting between Rc and c_void

### DIFF
--- a/mruby/src/def.rs
+++ b/mruby/src/def.rs
@@ -2,7 +2,6 @@ use std::cell::RefCell;
 use std::ffi::{c_void, CString};
 use std::fmt;
 use std::hash::{Hash, Hasher};
-use std::mem;
 use std::rc::Rc;
 
 use crate::class;
@@ -23,8 +22,8 @@ pub type Free = unsafe extern "C" fn(mrb: *mut sys::mrb_state, data: *mut c_void
 /// `Rc<RefCell<T>>`. If that assumption does not hold, this function has
 /// undefined behavior and may result in a segfault.
 pub unsafe extern "C" fn rust_data_free<T>(_mrb: *mut sys::mrb_state, data: *mut c_void) {
-    // Implicitly dropped by going out of scope
-    mem::transmute::<*mut c_void, Rc<RefCell<T>>>(data);
+    let data = Rc::from_raw(data as *const RefCell<T>);
+    drop(data);
 }
 
 /// Typedef for a method exposed in the mruby interpreter.

--- a/mruby/src/state.rs
+++ b/mruby/src/state.rs
@@ -2,7 +2,6 @@ use mruby_vfs::{FakeFileSystem, FileSystem};
 use std::any::{Any, TypeId};
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::ffi::c_void;
 use std::fmt;
 use std::mem;
 use std::rc::Rc;
@@ -242,7 +241,7 @@ impl Drop for State {
             // deallocated.
             let ptr = (*self.mrb).ud;
             if !ptr.is_null() {
-                let ud = mem::transmute::<*mut c_void, Mrb>(ptr);
+                let ud = Rc::from_raw(ptr as *const RefCell<Self>);
                 // cleanup pointers
                 (*self.mrb).ud = std::ptr::null_mut();
                 mem::drop(ud);

--- a/mruby/tests/segfault_rc_transmute.rs
+++ b/mruby/tests/segfault_rc_transmute.rs
@@ -1,0 +1,63 @@
+use mruby::gc::MrbGarbageCollection;
+use mruby::interpreter::{Interpreter, Mrb};
+use mruby::state::State;
+use mruby::sys;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+#[test]
+fn segfault_rc_transmute() {
+    println!("size of Rc<RefCell<State>>: {}", std::mem::size_of::<Mrb>());
+    println!(
+        "size of RefCell<State>: {}",
+        std::mem::size_of::<RefCell<State>>()
+    );
+    println!("size of State: {}", std::mem::size_of::<State>());
+    println!(
+        "size of mrb_value: {}",
+        std::mem::size_of::<sys::mrb_value>()
+    );
+
+    let interp = Interpreter::create().expect("mrb init");
+    // Increase the strong count on the Rc to 255.
+    let mut interps = vec![];
+    for _ in 0..254 {
+        interps.push(Rc::clone(&interp));
+    }
+    println!("strong count = {}", Rc::strong_count(&interp));
+
+    // create an object to collect on the mruby heap.
+    let bytes = std::iter::repeat(255_u8)
+        .take(1024 * 1024)
+        .collect::<Vec<_>>();
+    let _val = unsafe {
+        sys::mrb_str_new(
+            interp.borrow().mrb,
+            bytes.as_ptr() as *const i8,
+            bytes.len(),
+        )
+    };
+
+    println!("attempting full gc");
+    interp.full_gc();
+    println!("full gc succeeded");
+
+    // temporarily increase strong count to 256 and drop the reference
+    let temp = Rc::clone(&interp);
+    drop(temp);
+    println!("strong count = {}", Rc::strong_count(&interp));
+
+    println!("attempting full gc");
+    interp.full_gc();
+    // if we don't get here, we've segfaulted
+    println!("full gc succeeded");
+
+    // Increase the strong count to 256, which is beyond u8::MAX
+    interps.push(Rc::clone(&interp));
+    println!("strong count = {}", Rc::strong_count(&interp));
+
+    println!("attempting full gc");
+    interp.full_gc();
+    // if we don't get here, we've segfaulted
+    println!("full gc succeeded");
+}

--- a/mruby/tests/segfault_rc_transmute.rs
+++ b/mruby/tests/segfault_rc_transmute.rs
@@ -1,3 +1,19 @@
+#![deny(clippy::all, clippy::pedantic)]
+#![deny(warnings, intra_doc_link_resolution_failure)]
+
+//! This integration test checks for segfaults that stem from the improper
+//! handling of `Rc` when storing the `Mrb` interpreter in the `sys::mrb_state`
+//! userdata pointer as a `*mut c_void`.
+//!
+//! Checks for memory leaks stemming from improperly grabage collecting Ruby
+//! objects created in C functions, like the call to `sys::mrb_funcall_argv`.
+//!
+//! This test takes out `u8::MAX + 1` clones on the `Mrb` and attempts a full
+//! gc.
+//!
+//! If this test segfaults, we are improperly transmuting the `Rc` smart
+//! pointer.
+
 use mruby::gc::MrbGarbageCollection;
 use mruby::interpreter::{Interpreter, Mrb};
 use mruby::state::State;


### PR DESCRIPTION
Store and extract State from mrb->ud using Rc::into_raw and Rc::from_raw

Rc is not guaranteed to be the same size as a pointer, so transmuting to
and from c_void is undefined behavior. Instead call Rc::into_raw to get a
*const RefCell<State> and Rc::from_raw to get an Rc<RefCell<State>> from
that pointer on the ud.

I observed alignment issues which caused a segfault in `mrb_full_gc`.

See rust-lang/rust#62328.

Thank you @jonas-schievink and @rkruppe for spotting my error and showing me why the thing I did was wrong 💪 