### PR TITLE
Rust embed folder env interpolation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,7 +427,7 @@ dependencies = [
  "mruby 0.1.0",
  "mruby-gems 0.1.0",
  "nemesis 0.1.0",
- "rust-embed 4.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-embed 4.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -782,7 +782,7 @@ name = "mruby-gems"
 version = "0.1.0"
 dependencies = [
  "mruby 0.1.0",
- "rust-embed 4.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-embed 4.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -810,7 +810,7 @@ dependencies = [
  "mruby-gems 0.1.0",
  "ref_thread_local 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rust-embed 4.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-embed 4.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1257,19 +1257,20 @@ dependencies = [
 
 [[package]]
 name = "rust-embed"
-version = "4.4.0"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rust-embed-impl 4.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-embed-impl 4.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rust-embed-impl"
-version = "4.4.0"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shellexpand 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1370,6 +1371,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "shellexpand"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "shlex"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1389,7 +1395,7 @@ name = "spec-runner"
 version = "0.1.0"
 dependencies = [
  "mruby 0.1.0",
- "rust-embed 4.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-embed 4.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2052,8 +2058,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rocket 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "55b83fcf219c8b4980220231d5dd9eae167bdc63449fdab0a04b6c8b8cd361a8"
 "checksum rocket_codegen 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5549dc59a729fbd0e6f5d5de33ba136340228871633485e4946664d36289ffd7"
 "checksum rocket_http 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "abec045da00893bd4eef6084307a4bec0742278a7635a6a8b943da023202a5f7"
-"checksum rust-embed 4.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "73b42ffc98958788a47b1abde479901c0dfc12d6185965b3f289d05d5655c305"
-"checksum rust-embed-impl 4.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd0e740ca1e1969c2d3310bd2bda2024ed44ce473e527a2585aeaec1de9d81c3"
+"checksum rust-embed 4.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "87d03df18bbdfa087d46e74598715032a69b2a0811cdedc1b6cccadc5332f183"
+"checksum rust-embed-impl 4.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f02513e276f68b7520798f8d9a47ce4039103566ec7632559768a8d36ff1027e"
 "checksum rustc-demangle 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "ccc78bfd5acd7bf3e89cffcf899e5cb1a52d6fafa8dec2739ad70c9577a57288"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rustyline 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0f47ea1ceb347d2deae482d655dc8eef4bd82363d3329baffa3818bd76fea48b"
@@ -2067,6 +2073,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)" = "a72e9b96fa45ce22a4bc23da3858dfccfd60acd28a25bcd328a98fdd6bea43fd"
 "checksum serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)" = "46a3223d0c9ba936b61c0d2e3e559e3217dbfb8d65d06d26e8b3c25de38bae3e"
 "checksum serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)" = "5a23aa71d4a4d43fdbfaac00eff68ba8a06a51759a89ac3304323e800c4dd40d"
+"checksum shellexpand 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de7a5b5a9142fd278a10e0209b021a1b85849352e6951f4f914735c976737564"
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"

--- a/foolsgold/Cargo.toml
+++ b/foolsgold/Cargo.toml
@@ -8,15 +8,6 @@ edition = "2018"
 name = "nemesis_vs_thin"
 harness = false
 
-[[bin]]
-name = "foolsgold"
-# Disable doctests because doctests execute from the crate directory instead of
-# the workspace root. This causes the paths specified in RustEmbed derives to
-# not resolve, which panics.
-# TODO: Remove this workaround once this PR to interpolate env vars in paths is
-# merged: https://github.com/pyros2097/rust-embed/pull/59
-doctest = false
-
 [dependencies]
 env_logger = "0.6.1"
 log = "0.4.6"
@@ -31,8 +22,8 @@ path = "../mruby-gems"
 path = "../nemesis"
 
 [dependencies.rust-embed]
-version = "4.4.0"
-features = ["debug-embed"]
+version = "4.5.0"
+features = ["interpolate-folder-path"]
 
 [dependencies.uuid]
 version = "0.7"

--- a/foolsgold/src/assets.rs
+++ b/foolsgold/src/assets.rs
@@ -2,10 +2,8 @@ use nemesis::Error;
 use std::borrow::Cow;
 use std::collections::HashMap;
 
-// TODO: resolve path relative to CARGO_MANIFEST_DIR
-// https://github.com/pyros2097/rust-embed/pull/59
 #[derive(RustEmbed)]
-#[folder = "foolsgold/static/"]
+#[folder = "$CARGO_MANIFEST_DIR/static"]
 pub struct Assets;
 
 impl Assets {

--- a/foolsgold/src/foolsgold.rs
+++ b/foolsgold/src/foolsgold.rs
@@ -22,9 +22,7 @@ pub fn init(interp: &Mrb) -> Result<(), MrbError> {
 }
 
 #[derive(RustEmbed)]
-// TODO: resolve path relative to CARGO_MANIFEST_DIR
-// https://github.com/pyros2097/rust-embed/pull/59
-#[folder = "foolsgold/ruby/lib"]
+#[folder = "$CARGO_MANIFEST_DIR/ruby/lib"]
 struct FoolsGold;
 
 impl FoolsGold {

--- a/mruby-gems/Cargo.toml
+++ b/mruby-gems/Cargo.toml
@@ -4,17 +4,9 @@ version = "0.1.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 
-[lib]
-# Disable doctests because doctests execute from the crate directory instead of
-# the workspace root. This causes the paths specified in RustEmbed derives to
-# not resolve, which panics.
-# TODO: Remove this workaround once this PR to interpolate env vars in paths is
-# merged: https://github.com/pyros2097/rust-embed/pull/59
-doctest = false
-
 [dependencies.mruby]
 path = "../mruby"
 
 [dependencies.rust-embed]
-version = "4.4.0"
-features = ["debug-embed"]
+version = "4.5.0"
+features = ["interpolate-folder-path"]

--- a/mruby-gems/src/rubygems/mustermann.rs
+++ b/mruby-gems/src/rubygems/mustermann.rs
@@ -13,9 +13,7 @@ pub fn init(interp: &Mrb) -> Result<(), MrbError> {
 
 /// Gem
 #[derive(RustEmbed)]
-// TODO: resolve path relative to CARGO_MANIFEST_DIR
-// https://github.com/pyros2097/rust-embed/pull/59
-#[folder = "mruby-gems/vendor/ruby/2.6.0/gems/mustermann-1.0.3/lib"]
+#[folder = "$CARGO_MANIFEST_DIR/vendor/ruby/2.6.0/gems/mustermann-1.0.3/lib"]
 struct Mustermann;
 
 impl Mustermann {

--- a/mruby-gems/src/rubygems/rack.rs
+++ b/mruby-gems/src/rubygems/rack.rs
@@ -13,9 +13,7 @@ pub fn init(interp: &Mrb) -> Result<(), MrbError> {
 
 /// Gem
 #[derive(RustEmbed)]
-// TODO: resolve path relative to CARGO_MANIFEST_DIR
-// https://github.com/pyros2097/rust-embed/pull/59
-#[folder = "mruby-gems/vendor/ruby/2.6.0/gems/rack-2.0.7/lib"]
+#[folder = "$CARGO_MANIFEST_DIR/vendor/ruby/2.6.0/gems/rack-2.0.7/lib"]
 struct Rack;
 
 impl Rack {

--- a/mruby-gems/src/rubygems/rack_protection.rs
+++ b/mruby-gems/src/rubygems/rack_protection.rs
@@ -13,9 +13,7 @@ pub fn init(interp: &Mrb) -> Result<(), MrbError> {
 
 /// Gem
 #[derive(RustEmbed)]
-// TODO: resolve path relative to CARGO_MANIFEST_DIR
-// https://github.com/pyros2097/rust-embed/pull/59
-#[folder = "mruby-gems/vendor/ruby/2.6.0/gems/rack-protection-2.0.5/lib"]
+#[folder = "$CARGO_MANIFEST_DIR/vendor/ruby/2.6.0/gems/rack-protection-2.0.5/lib"]
 struct RackProtection;
 
 impl RackProtection {

--- a/mruby-gems/src/rubygems/sinatra.rs
+++ b/mruby-gems/src/rubygems/sinatra.rs
@@ -13,9 +13,7 @@ pub fn init(interp: &Mrb) -> Result<(), MrbError> {
 
 /// Gem
 #[derive(RustEmbed)]
-// TODO: resolve path relative to CARGO_MANIFEST_DIR
-// https://github.com/pyros2097/rust-embed/pull/59
-#[folder = "mruby-gems/vendor/ruby/2.6.0/gems/sinatra-2.0.5/lib"]
+#[folder = "$CARGO_MANIFEST_DIR/vendor/ruby/2.6.0/gems/sinatra-2.0.5/lib"]
 struct Sinatra;
 
 impl Sinatra {

--- a/mruby-gems/src/rubygems/tilt.rs
+++ b/mruby-gems/src/rubygems/tilt.rs
@@ -13,9 +13,7 @@ pub fn init(interp: &Mrb) -> Result<(), MrbError> {
 
 /// Gem
 #[derive(RustEmbed)]
-// TODO: resolve path relative to CARGO_MANIFEST_DIR
-// https://github.com/pyros2097/rust-embed/pull/59
-#[folder = "mruby-gems/vendor/ruby/2.6.0/gems/tilt-2.0.9/lib"]
+#[folder = "$CARGO_MANIFEST_DIR/vendor/ruby/2.6.0/gems/tilt-2.0.9/lib"]
 struct Tilt;
 
 impl Tilt {

--- a/mruby/Cargo.toml
+++ b/mruby/Cargo.toml
@@ -4,14 +4,6 @@ version = "0.1.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 
-[lib]
-# Disable doctests because doctests execute from the crate directory instead of
-# the workspace root. This causes the paths specified in RustEmbed derives to
-# not resolve, which panics.
-# TODO: Remove this workaround once this PR to interpolate env vars in paths is
-# merged: https://github.com/pyros2097/rust-embed/pull/59
-doctest = false
-
 [dependencies]
 byteorder = "1.3.2"
 log = "0.4.6"

--- a/mruby/src/def.rs
+++ b/mruby/src/def.rs
@@ -81,12 +81,11 @@ impl EnclosingRubyScope {
     ///
     /// ```rust
     /// use mruby::def::EnclosingRubyScope;
-    /// use mruby::interpreter::Interpreter;
     ///
     /// struct Fixnum;
     /// struct Inner;
     ///
-    /// let interp = crate::interpreter().expect("mrb init");
+    /// let interp = mruby::interpreter().expect("mrb init");
     /// let mut api = interp.borrow_mut();
     /// if let Some(scope) = api.class_spec::<Fixnum>().map(EnclosingRubyScope::class) {
     ///     api.def_class::<Inner>("Inner", Some(scope), None);
@@ -116,12 +115,11 @@ impl EnclosingRubyScope {
     ///
     /// ```rust
     /// use mruby::def::EnclosingRubyScope;
-    /// use mruby::interpreter::Interpreter;
     ///
     /// struct Kernel;
     /// struct Inner;
     ///
-    /// let interp = crate::interpreter().expect("mrb init");
+    /// let interp = mruby::interpreter().expect("mrb init");
     /// let mut api = interp.borrow_mut();
     /// if let Some(scope) = api.module_spec::<Kernel>().map(EnclosingRubyScope::module) {
     ///     api.def_class::<Inner>("Inner", Some(scope), None);

--- a/mruby/src/lib.rs
+++ b/mruby/src/lib.rs
@@ -20,9 +20,8 @@
 //!
 //! ```rust
 //! use mruby::eval::MrbEval;
-//! use mruby::interpreter::Interpreter;
 //!
-//! let interp = crate::interpreter().unwrap();
+//! let interp = mruby::interpreter().unwrap();
 //! let result = interp.eval("10 * 10").unwrap();
 //! let result = result.try_into::<i64>();
 //! assert_eq!(result, Ok(100));
@@ -54,10 +53,9 @@
 //!
 //! ```rust
 //! use mruby::eval::MrbEval;
-//! use mruby::interpreter::Interpreter;
 //! use mruby::load::MrbLoadSources;
 //!
-//! let mut interp = crate::interpreter().unwrap();
+//! let mut interp = mruby::interpreter().unwrap();
 //! let code = "
 //! def source_location
 //!   __FILE__
@@ -95,16 +93,17 @@
 //! provided by the [`onig`] crate.
 //!
 //! ```rust
-//! use mruby::convert::{RustBackedValue, TryFromMrb};
+//! #[macro_use]
+//! extern crate mruby;
+//!
+//! use mruby::convert::{FromMrb, RustBackedValue, TryFromMrb};
 //! use mruby::def::{rust_data_free, ClassLike, Define};
 //! use mruby::eval::MrbEval;
 //! use mruby::file::MrbFile;
-//! use mruby::interpreter::{Interpreter, Mrb, MrbApi};
 //! use mruby::load::MrbLoadSources;
 //! use mruby::sys;
 //! use mruby::value::Value;
-//! use mruby::{interpreter_or_raise, unwrap_or_raise, unwrap_value_or_raise};
-//! use mruby::MrbError;
+//! use mruby::{Mrb, MrbError};
 //! use std::io::Write;
 //! use std::mem;
 //!
@@ -127,10 +126,10 @@
 //!         let cont = unwrap_or_raise!(
 //!             interp,
 //!             Self::try_from_ruby(&interp, &Value::new(&interp, slf)),
-//!             interp.nil().inner()
+//!             Value::from_mrb(&interp, None::<Value>).inner()
 //!         );
 //!         let borrow = cont.borrow();
-//!         interp.fixnum(borrow.inner).inner()
+//!         Value::from_mrb(&interp, borrow.inner).inner()
 //!     }
 //! }
 //!
@@ -147,11 +146,13 @@
 //!     }
 //! }
 //!
-//! let mut interp = crate::interpreter().unwrap();
-//! interp.def_file_for_type::<_, Container>("container.rb").unwrap();
-//! interp.eval("require 'container'").unwrap();
-//! let result = interp.eval("Container.new(15).value * 24").unwrap();
-//! assert_eq!(result.try_into::<i64>(), Ok(360));
+//! fn main() {
+//!     let interp = mruby::interpreter().unwrap();
+//!     interp.def_file_for_type::<_, Container>("container.rb").unwrap();
+//!     interp.eval("require 'container'").unwrap();
+//!     let result = interp.eval("Container.new(15).value * 24").unwrap();
+//!     assert_eq!(result.try_into::<i64>(), Ok(360));
+//! }
 //! ```
 //!
 //! ## Converters Between Ruby and Rust Types

--- a/mruby/src/state.rs
+++ b/mruby/src/state.rs
@@ -67,27 +67,32 @@ impl State {
     /// The recommended pattern for using `def_class` looks like this:
     ///
     /// ```rust
+    /// #[macro_use]
+    /// extern crate mruby;
+    ///
+    /// use mruby::convert::FromMrb;
     /// use mruby::def::{ClassLike, Define};
-    /// use mruby::interpreter::{Interpreter, MrbApi};
-    /// use mruby::interpreter_or_raise;
     /// use mruby::sys;
+    /// use mruby::value::Value;
     ///
     /// extern "C" fn value(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value
     /// {
     ///     let interp = unsafe { interpreter_or_raise!(mrb) };
-    ///     interp.fixnum(29).inner()
+    ///     Value::from_mrb(&interp, 29).inner()
     /// }
     ///
-    /// let interp = crate::interpreter().expect("mrb init");
-    /// let spec = {
-    ///     let mut api = interp.borrow_mut();
-    ///     let spec = api.def_class::<()>("Container", None, None);
-    ///     spec.borrow_mut().add_method("value", value, sys::mrb_args_none());
-    ///     spec.borrow_mut().add_self_method("value", value, sys::mrb_args_none());
-    ///     spec.borrow_mut().mrb_value_is_rust_backed(true);
-    ///     spec
-    /// };
-    /// spec.borrow().define(&interp).expect("class install");
+    /// fn main() {
+    ///     let interp = mruby::interpreter().expect("mrb init");
+    ///     let spec = {
+    ///         let mut api = interp.borrow_mut();
+    ///         let spec = api.def_class::<()>("Container", None, None);
+    ///         spec.borrow_mut().add_method("value", value, sys::mrb_args_none());
+    ///         spec.borrow_mut().add_self_method("value", value, sys::mrb_args_none());
+    ///         spec.borrow_mut().mrb_value_is_rust_backed(true);
+    ///         spec
+    ///     };
+    ///     spec.borrow().define(&interp).expect("class install");
+    /// }
     /// ```
     pub fn def_class<T: Any>(
         &mut self,
@@ -131,26 +136,31 @@ impl State {
     /// The recommended pattern for using `def_module` looks like this:
     ///
     /// ```rust
+    /// #[macro_use]
+    /// extern crate mruby;
+    ///
+    /// use mruby::convert::FromMrb;
     /// use mruby::def::{ClassLike, Define};
-    /// use mruby::interpreter::{Interpreter, MrbApi};
-    /// use mruby::interpreter_or_raise;
     /// use mruby::sys;
+    /// use mruby::value::Value;
     ///
     /// extern "C" fn value(mrb: *mut sys::mrb_state, _slf: sys::mrb_value) -> sys::mrb_value
     /// {
     ///     let interp = unsafe { interpreter_or_raise!(mrb) };
-    ///     interp.fixnum(29).inner()
+    ///     Value::from_mrb(&interp, 29).inner()
     /// }
     ///
-    /// let interp = crate::interpreter().expect("mrb init");
-    /// let spec = {
-    ///     let mut api = interp.borrow_mut();
-    ///     let spec = api.def_module::<()>("Container", None);
-    ///     spec.borrow_mut().add_method("value", value, sys::mrb_args_none());
-    ///     spec.borrow_mut().add_self_method("value", value, sys::mrb_args_none());
-    ///     spec
-    /// };
-    /// spec.borrow().define(&interp).expect("class install");
+    /// fn main() {
+    ///     let interp = mruby::interpreter().expect("mrb init");
+    ///     let spec = {
+    ///         let mut api = interp.borrow_mut();
+    ///         let spec = api.def_module::<()>("Container", None);
+    ///         spec.borrow_mut().add_method("value", value, sys::mrb_args_none());
+    ///         spec.borrow_mut().add_self_method("value", value, sys::mrb_args_none());
+    ///         spec
+    ///     };
+    ///     spec.borrow().define(&interp).expect("class install");
+    /// }
     /// ```
     pub fn def_module<T: Any>(
         &mut self,

--- a/nemesis/Cargo.toml
+++ b/nemesis/Cargo.toml
@@ -4,14 +4,6 @@ version = "0.1.0"
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 edition = "2018"
 
-[lib]
-# Disable doctests because doctests execute from the crate directory instead of
-# the workspace root. This causes the paths specified in RustEmbed derives to
-# not resolve, which panics.
-# TODO: Remove this workaround once this PR to interpolate env vars in paths is
-# merged: https://github.com/pyros2097/rust-embed/pull/59
-doctest = false
-
 [dependencies]
 log = "0.4.6"
 ref_thread_local = "0.0.0"
@@ -24,5 +16,5 @@ path = "../mruby"
 path = "../mruby-gems"
 
 [dependencies.rust-embed]
-version = "4.4.0"
-features = ["debug-embed"]
+version = "4.5.0"
+features = ["interpolate-folder-path"]

--- a/nemesis/src/rubygems/nemesis.rs
+++ b/nemesis/src/rubygems/nemesis.rs
@@ -12,9 +12,7 @@ pub fn init(interp: &Mrb) -> Result<(), MrbError> {
 }
 
 #[derive(RustEmbed)]
-// TODO: resolve path relative to CARGO_MANIFEST_DIR
-// https://github.com/pyros2097/rust-embed/pull/59
-#[folder = "nemesis/ruby/lib"]
+#[folder = "$CARGO_MANIFEST_DIR/ruby/lib"]
 struct Nemesis;
 
 impl Nemesis {

--- a/spec-runner/Cargo.toml
+++ b/spec-runner/Cargo.toml
@@ -10,5 +10,5 @@ edition = "2018"
 path = "../mruby"
 
 [dependencies.rust-embed]
-version = "4.4.0"
-features = ["debug-embed"]
+version = "4.5.0"
+features = ["interpolate-folder-path"]

--- a/spec-runner/src/mspec.rs
+++ b/spec-runner/src/mspec.rs
@@ -18,7 +18,7 @@ pub fn init(interp: &Mrb) -> Result<(), MrbError> {
 }
 
 #[derive(RustEmbed)]
-#[folder = "spec-runner/spec/mspec/"]
+#[folder = "$CARGO_MANIFEST_DIR/spec/mspec"]
 struct Sources;
 
 #[derive(Debug)]


### PR DESCRIPTION
Fixes GH-136.

Also enables us to not require the debug-embed trait for faster dev compile times and easier iteration when modifying ruby.