### PR TITLE
URI spec compliance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,10 @@ jobs:
             cargo doc --no-deps --all
           environment:
             RUSTDOCFLAGS: "-Z unstable-options --enable-index-page"
+      - run:
+          name: ruby/spec Compliance Regression Test
+          command: |
+            ./scripts/spec-compliance.sh
       - persist_to_workspace:
           root: target
           paths:

--- a/mruby/src/extn/core/matchdata/element_reference.rs
+++ b/mruby/src/extn/core/matchdata/element_reference.rs
@@ -70,7 +70,7 @@ impl Args {
             first,
             &mut start,
             &mut len,
-            num_captures,
+            num_captures + 1,
             0_u8,
         );
         if check_range == sys::mrb_range_beg_len::MRB_RANGE_OK {

--- a/mruby/src/extn/stdlib/strscan.rb
+++ b/mruby/src/extn/stdlib/strscan.rb
@@ -146,7 +146,9 @@ class StringScanner
   def matched
     return nil if @last_match.nil?
 
-    @last_match[0]
+    ret = @last_match[0]
+    ret = String.new(ret) unless ret.class == String
+    ret
   end
 
   def matched?
@@ -190,7 +192,9 @@ class StringScanner
   def post_match
     return nil if @last_match.nil?
 
-    @string[@last_match_charpos..-1]
+    ret = @string[@last_match_charpos..-1]
+    ret = String.new(ret) unless ret.class == String
+    ret
   end
 
   def pre_match
@@ -202,7 +206,9 @@ class StringScanner
       else
         @last_match.length
       end
-    @string[0...@last_match_charpos - match_len]
+    ret = @string[0...@last_match_charpos - match_len]
+    ret = String.new(ret) unless ret.class == String
+    ret
   end
 
   def reset
@@ -213,7 +219,9 @@ class StringScanner
   end
 
   def rest
-    @string[@charpos..-1]
+    ret = @string[@charpos..-1]
+    ret = String.new(ret) unless ret.class == String
+    ret
   end
 
   def rest?
@@ -252,7 +260,9 @@ class StringScanner
     @last_match_charpos = @charpos
 
     if return_string_p
-      @string[previous_charpos, match.end(0)]
+      ret = @string[previous_charpos, match.end(0)]
+      ret = String.new(ret) unless ret.class == String
+      ret
     else
       match.end(0)
     end

--- a/scripts/spec-compliance.sh
+++ b/scripts/spec-compliance.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+set -x
+
+shopt -s globstar
+
+run_core_spec() {
+  pushd "spec-runner/spec/ruby/core" >/dev/null
+  cargo run --bin spec-runner "$1"/**/*.rb
+  popd >/dev/null
+}
+
+run_library_spec() {
+  pushd "spec-runner/spec/ruby/library" >/dev/null
+  cargo run --bin spec-runner "$1"/**/*.rb
+  popd >/dev/null
+}
+
+run_core_spec "matchdata"
+run_core_spec "regexp"
+
+run_library_spec "monitor"
+run_library_spec "stringscanner"
+run_library_spec "uri"


### PR DESCRIPTION
Fixup `String#scan`, `StringScanner`, and `MatchData#[]`.

Add a script to track ruby/spec compliance.