### PR TITLE
RustBackedValue::try_into_ruby should not hold a borrow while calling mrb_obj_new

### DIFF
--- a/mruby/src/convert/float.rs
+++ b/mruby/src/convert/float.rs
@@ -11,9 +11,8 @@ impl FromMrb<Float> for Value {
     type To = Ruby;
 
     fn from_mrb(interp: &Mrb, value: Float) -> Self {
-        Self::new(interp, unsafe {
-            sys::mrb_sys_float_value(interp.borrow().mrb, value)
-        })
+        let mrb = interp.borrow().mrb;
+        Self::new(interp, unsafe { sys::mrb_sys_float_value(mrb, value) })
     }
 }
 

--- a/mruby/src/convert/hash.rs
+++ b/mruby/src/convert/hash.rs
@@ -23,12 +23,8 @@ impl FromMrb<Vec<(Value, Value)>> for Value {
 
     fn from_mrb(interp: &Mrb, value: Vec<(Self, Self)>) -> Self {
         let mrb = interp.borrow().mrb;
-        // We can initalize a `Hash` with a known capacity using
-        // `sys::mrb_hash_new_capa`, but doing so requires converting from
-        // `usize` to `i64` which is fallible. To simplify the code and make
-        // `Vec<(Value, Value)>` easier to work with, use an infallible `Hash`
-        // constructor.
-        let hash = unsafe { sys::mrb_hash_new(mrb) };
+        let hash =
+            unsafe { sys::mrb_hash_new_capa(mrb, i64::try_from(value.len()).unwrap_or_default()) };
         for (key, val) in value {
             unsafe { sys::mrb_hash_set(mrb, hash, key.inner(), val.inner()) };
         }

--- a/mruby/src/convert/object.rs
+++ b/mruby/src/convert/object.rs
@@ -40,6 +40,7 @@ where
         interp: &Mrb,
         slf: Option<sys::mrb_value>,
     ) -> Result<Value, MrbError> {
+        let mrb = interp.borrow().mrb;
         let spec = interp
             .borrow()
             .class_spec::<Self>()
@@ -73,12 +74,7 @@ where
             // have fewer than `MRB_FUNCALL_ARGC_MAX` args, which is less than
             // i64 max value.
             let len = args.len().try_into().unwrap_or_default();
-            sys::mrb_obj_new(
-                interp.borrow().mrb,
-                rclass,
-                len,
-                args.as_ptr() as *const sys::mrb_value,
-            )
+            sys::mrb_obj_new(mrb, rclass, len, args.as_ptr() as *const sys::mrb_value)
         };
 
         let data = Rc::new(RefCell::new(self));

--- a/mruby/tests/obj_new_borrow_mut.rs
+++ b/mruby/tests/obj_new_borrow_mut.rs
@@ -1,0 +1,42 @@
+#![deny(clippy::all, clippy::pedantic)]
+#![deny(warnings, intra_doc_link_resolution_failure)]
+
+//! This integration test checks for segfaults that stem from the improperly
+//! holding a borrow on the interpreter in converters that prevent arbitrary
+//! Rust code from taking a mutable borrow.
+//!
+//! This test creates a Rust-backed object and takes a mutable borrow on the
+//! interpreter in its initialize method.
+//!
+//! If this test segfaults, we are improperly holding a borrow on the
+//! interpreter while calling `mrb_obj_new`.
+
+#[macro_use]
+extern crate mruby;
+
+use mruby::convert::RustBackedValue;
+use mruby::def::{ClassLike, Define};
+use mruby::sys;
+
+struct Obj;
+
+impl RustBackedValue for Obj {}
+
+unsafe extern "C" fn initialize(mrb: *mut sys::mrb_state, slf: sys::mrb_value) -> sys::mrb_value {
+    let interp = interpreter_or_raise!(mrb);
+    interp.borrow_mut();
+    slf
+}
+
+#[test]
+fn obj_new_borrow_mut() {
+    let interp = mruby::interpreter().expect("mrb init");
+    let class = interp.borrow_mut().def_class::<Obj>("Obj", None, None);
+    class
+        .borrow_mut()
+        .add_method("initialize", initialize, sys::mrb_args_none());
+    class.borrow().define(&interp).unwrap();
+    unsafe {
+        Obj.try_into_ruby(&interp, None).unwrap();
+    }
+}


### PR DESCRIPTION
Fixes GH-145.

Adds a test.