### PR TITLE
 Simplify the Drop implementation for CactusRef

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,7 @@ name = "cactusref"
 version = "0.1.0"
 dependencies = [
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/cactusref/Cargo.toml
+++ b/cactusref/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+itertools = "0.8.0"
 log = "0.4.6"
 
 [dev-dependencies]

--- a/cactusref/src/link.rs
+++ b/cactusref/src/link.rs
@@ -1,0 +1,36 @@
+use core::ptr::NonNull;
+use std::hash::{Hash, Hasher};
+
+use crate::{CactusBox, Reachable};
+
+pub(crate) struct CactusLinkRef<T: Reachable>(pub NonNull<CactusBox<T>>);
+
+impl<T: Reachable> CactusLinkRef<T> {
+    #[inline]
+    pub fn value(&self) -> &T {
+        unsafe { &self.0.as_ref().value }
+    }
+}
+
+impl<T: Reachable> Copy for CactusLinkRef<T> {}
+
+impl<T: Reachable> Clone for CactusLinkRef<T> {
+    fn clone(&self) -> Self {
+        Self(self.0)
+    }
+}
+
+impl<T: Reachable> Hash for CactusLinkRef<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let object_id = self.value().object_id();
+        object_id.hash(state);
+    }
+}
+
+impl<T: Reachable> PartialEq for CactusLinkRef<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.value().object_id() == other.value().object_id()
+    }
+}
+
+impl<T: Reachable> Eq for CactusLinkRef<T> {}


### PR DESCRIPTION
CactusRef is a cycle-aware Rc. Cycle detection and busting is a
zero-cost abstraction. If a consumer of the CactusRef crate never calls
the `adopt` API, they never pay the algorithmic costs of cycle detection
and the reachability checks. The only cost consumers pay is the memory
cost of an empty `RefCell<HashSet<NonNull>>`.

An orphaned cycle is a connected graph where all nodes are only
reachable via other nodes in the graph. To enable `CactusRef`s in an
orphaned cycle to be deallocated, use the `CactusRef::adopt` API.

`CactusRef::adopt` does explicit bookkeeping to store `links` to adoptee
`CactusRef`s. Each link increases the strong count on the adoptee but
does not allocate another `CactusRef`.

On drop, if a `CactusRef` has no links, it is dropped like a normal
`Rc`. If the `CactusRef` has links, it performs a breadth first search
using its wrapped value's `Reachable` implementation to determine the
all `CactusRef`s that it can reach.

After determining all reachable objects, `CactusRef` reduces the graph
to objects that form a cycle by performing pairwise reachability checks.
During this step, for each object in the cycle, `CactusRef` counts the
number of refs held by other objects in the cycle.

Using the cycle-held strong refs, `CactusRef` computes whether the
object graph is reachable by any non-cycle nodes by comparing strong
counts.

If the cycle is orphaned, `CactusRef` busts all the link `HashSet`s and
deallocates each object.