### PR TITLE
Cactusref reap fully connected object graphs of size n > 2

### DIFF
--- a/cactusref/src/cycle/mod.rs
+++ b/cactusref/src/cycle/mod.rs
@@ -63,10 +63,7 @@ pub(crate) fn cycle_refs<T: ?Sized>(this: Link<T>) -> HashMap<Link<T>, usize> {
     {
         let left_reaches_right = reachable_links(*left).contains(right);
         let right_reaches_left = reachable_links(*right).contains(left);
-        let is_new = !cycle_owned_refs
-            .keys()
-            .any(|item: &Link<T>| *item == *right);
-        if left_reaches_right && right_reaches_left && is_new {
+        if left_reaches_right && right_reaches_left {
             let count = *cycle_owned_refs.entry(*right).or_insert(0);
             cycle_owned_refs.insert(*right, count + 1);
         }

--- a/cactusref/tests/no_leak_mutually_adopted.rs
+++ b/cactusref/tests/no_leak_mutually_adopted.rs
@@ -14,7 +14,7 @@ fn cactusref_mutually_adopted_no_leak() {
 
     let s = "a".repeat(1024 * 1024);
 
-    // 500MB of `String`s will be allocated by the leak detector
+    // 100MB of `String`s will be allocated by the leak detector
     leak::Detector::new(
         "CactusRef mutually adopted pointers",
         ITERATIONS,

--- a/cactusref/tests/no_leak_n_equals_3_fully_connected.rs
+++ b/cactusref/tests/no_leak_n_equals_3_fully_connected.rs
@@ -1,0 +1,38 @@
+#![deny(clippy::all, clippy::pedantic)]
+#![deny(warnings, intra_doc_link_resolution_failure)]
+
+use cactusref::{Adoptable, CactusRef};
+
+mod leak;
+
+const ITERATIONS: usize = 50;
+const LEAK_TOLERANCE: i64 = 1024 * 1024 * 25;
+
+#[test]
+fn cactusref_n_equals_3_fully_connected_no_leak() {
+    env_logger::Builder::from_env("CACTUS_LOG").init();
+
+    let s = "a".repeat(1024 * 1024);
+
+    // 300MB of `String`s will be allocated by the leak detector
+    leak::Detector::new(
+        "CactusRef mutually adopted pointers",
+        ITERATIONS,
+        LEAK_TOLERANCE,
+    )
+    .check_leaks(|_| {
+        // each iteration creates 6MB of `String`s
+        let n1 = CactusRef::new(s.clone());
+        let n2 = CactusRef::new(s.clone());
+        let n3 = CactusRef::new(s.clone());
+        CactusRef::adopt(&n1, &n2);
+        CactusRef::adopt(&n1, &n3);
+        CactusRef::adopt(&n2, &n1);
+        CactusRef::adopt(&n2, &n3);
+        CactusRef::adopt(&n3, &n1);
+        CactusRef::adopt(&n3, &n2);
+        drop(n1);
+        drop(n2);
+        drop(n3);
+    });
+}


### PR DESCRIPTION
The code was erroneously only logging one strong ref held by the cycle for each node, which meant that cycles would not get reaped if a node in the cycle was linked with multiple other nodes.