### PR TITLE
Improve the runtime complexity and performance of CactusRef cycle detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,6 @@ name = "cactusref"
 version = "0.1.0"
 dependencies = [
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/cactusref/Cargo.toml
+++ b/cactusref/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-itertools = "0.8.0"
 log = "0.4.6"
 
 [dev-dependencies]

--- a/cactusref/src/adoptable.rs
+++ b/cactusref/src/adoptable.rs
@@ -36,5 +36,7 @@ unsafe impl<T: ?Sized> Adoptable for Rc<T> {
             other.inc_strong();
             links.insert(Link(other.ptr));
         }
+        let mut links = other.inner().back_links.borrow_mut();
+        links.insert(Link(this.ptr));
     }
 }

--- a/cactusref/src/cycle/drop.rs
+++ b/cactusref/src/cycle/drop.rs
@@ -114,6 +114,8 @@ unsafe impl<#[may_dangle] T: ?Sized> Drop for Rc<T> {
                 for item in cycle.keys() {
                     let mut links = item.0.as_ref().links.borrow_mut();
                     links.clear();
+                    let mut links = item.0.as_ref().back_links.borrow_mut();
+                    links.clear();
                 }
                 for (mut obj, _) in cycle {
                     trace!("cactusref dropping member of orphaned cycle");

--- a/cactusref/src/cycle/mod.rs
+++ b/cactusref/src/cycle/mod.rs
@@ -56,13 +56,17 @@ pub(crate) fn cycle_refs<T: ?Sized>(this: Link<T>) -> HashMap<Link<T>, usize> {
     // that can reach each other. These nodes form a cycle.
     let mut cycle_owned_refs = HashMap::default();
     let clique = reachable_links(this);
+    let reachable = clique
+        .iter()
+        .map(|link| (*link, reachable_links(*link)))
+        .collect::<HashMap<_, _>>();
     for (left, right) in clique
         .iter()
         .cartesian_product(clique.iter())
         .filter(|(left, right)| left != right)
     {
-        let left_reaches_right = reachable_links(*left).contains(right);
-        let right_reaches_left = reachable_links(*right).contains(left);
+        let left_reaches_right = reachable[left].contains(right);
+        let right_reaches_left = reachable[right].contains(left);
         if left_reaches_right && right_reaches_left {
             let count = *cycle_owned_refs.entry(*right).or_insert(0);
             cycle_owned_refs.insert(*right, count + 1);

--- a/cactusref/src/cycle/mod.rs
+++ b/cactusref/src/cycle/mod.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use std::collections::HashMap;
 
 use crate::link::{Link, Links};
@@ -51,26 +50,48 @@ pub(crate) fn reachable_links<T: ?Sized>(this: Link<T>) -> Links<T> {
     clique
 }
 
+pub(crate) fn graph_reachable_links<T: ?Sized>(this: Link<T>) -> Links<T> {
+    // Perform a breadth first search over all of the links to determine the
+    // clique of refs that self can reach.
+    let mut clique = Links::default();
+    clique.insert(this);
+    loop {
+        let size = clique.len();
+        for item in clique.clone().iter() {
+            let links = unsafe { item.0.as_ref() }.links.borrow();
+            for link in links.iter() {
+                clique.insert(*link);
+            }
+            let links = unsafe { item.0.as_ref() }.back_links.borrow();
+            for link in links.iter() {
+                clique.insert(*link);
+            }
+        }
+        // BFS has found no new refs in the clique.
+        if size == clique.len() {
+            break;
+        }
+    }
+    clique
+}
+
 pub(crate) fn cycle_refs<T: ?Sized>(this: Link<T>) -> HashMap<Link<T>, usize> {
     // Iterate over the items in the clique. For each pair of nodes, find nodes
     // that can reach each other. These nodes form a cycle.
     let mut cycle_owned_refs = HashMap::default();
-    let clique = reachable_links(this);
-    let reachable = clique
+    let clique = graph_reachable_links(this);
+    let reachable_by_node = clique
         .iter()
-        .map(|link| (*link, reachable_links(*link)))
+        .map(|link| (*link, reachable_links(*link).registry))
         .collect::<HashMap<_, _>>();
-    for (left, right) in clique
-        .iter()
-        .cartesian_product(clique.iter())
-        .filter(|(left, right)| left != right)
-    {
-        let left_reaches_right = reachable[left].contains(right);
-        let right_reaches_left = reachable[right].contains(left);
-        if left_reaches_right && right_reaches_left {
-            let count = *cycle_owned_refs.entry(*right).or_insert(0);
-            cycle_owned_refs.insert(*right, count + 1);
-        }
+    for link in clique.iter() {
+        cycle_owned_refs.insert(
+            *link,
+            reachable_by_node
+                .get(link)
+                .map(|links| links.len())
+                .unwrap_or_default(),
+        );
     }
     cycle_owned_refs
 }

--- a/cactusref/src/cycle/mod.rs
+++ b/cactusref/src/cycle/mod.rs
@@ -50,48 +50,27 @@ pub(crate) fn reachable_links<T: ?Sized>(this: Link<T>) -> Links<T> {
     clique
 }
 
-pub(crate) fn graph_reachable_links<T: ?Sized>(this: Link<T>) -> Links<T> {
-    // Perform a breadth first search over all of the links to determine the
-    // clique of refs that self can reach.
-    let mut clique = Links::default();
-    clique.insert(this);
+pub(crate) fn cycle_refs<T: ?Sized>(this: Link<T>) -> HashMap<Link<T>, usize> {
+    // Perform a breadth first search over all of the forward and backward links
+    // to determine the clique of nodes in a cycle and their strong counts.
+    let mut cycle_owned_refs = HashMap::default();
+    cycle_owned_refs.insert(this, 0);
     loop {
-        let size = clique.len();
-        for item in clique.clone().iter() {
+        let size = cycle_owned_refs.len();
+        for item in cycle_owned_refs.clone().keys() {
             let links = unsafe { item.0.as_ref() }.links.borrow();
             for link in links.iter() {
-                clique.insert(*link);
+                *cycle_owned_refs.entry(*link).or_insert(0) += 1;
             }
             let links = unsafe { item.0.as_ref() }.back_links.borrow();
             for link in links.iter() {
-                clique.insert(*link);
+                cycle_owned_refs.entry(*link).or_insert(0);
             }
         }
         // BFS has found no new refs in the clique.
-        if size == clique.len() {
+        if size == cycle_owned_refs.len() {
             break;
         }
-    }
-    clique
-}
-
-pub(crate) fn cycle_refs<T: ?Sized>(this: Link<T>) -> HashMap<Link<T>, usize> {
-    // Iterate over the items in the clique. For each pair of nodes, find nodes
-    // that can reach each other. These nodes form a cycle.
-    let mut cycle_owned_refs = HashMap::default();
-    let clique = graph_reachable_links(this);
-    let reachable_by_node = clique
-        .iter()
-        .map(|link| (*link, reachable_links(*link).registry))
-        .collect::<HashMap<_, _>>();
-    for link in clique.iter() {
-        cycle_owned_refs.insert(
-            *link,
-            reachable_by_node
-                .get(link)
-                .map(|links| links.len())
-                .unwrap_or_default(),
-        );
     }
     cycle_owned_refs
 }

--- a/cactusref/src/ptr.rs
+++ b/cactusref/src/ptr.rs
@@ -75,6 +75,7 @@ pub struct RcBox<T: ?Sized> {
     pub(crate) strong: Cell<usize>,
     pub(crate) weak: Cell<usize>,
     pub(crate) links: RefCell<Links<T>>,
+    pub(crate) back_links: RefCell<Links<T>>,
     pub(crate) value: T,
 }
 

--- a/cactusref/src/rc.rs
+++ b/cactusref/src/rc.rs
@@ -57,6 +57,7 @@ impl<T> Rc<T> {
                 strong: Cell::new(1),
                 weak: Cell::new(1),
                 links: RefCell::new(Links::default()),
+                back_links: RefCell::new(Links::default()),
                 value,
             })),
             phantom: PhantomData,
@@ -401,6 +402,7 @@ impl<T: ?Sized> Rc<T> {
         ptr::write(&mut (*inner).strong, Cell::new(1));
         ptr::write(&mut (*inner).weak, Cell::new(1));
         ptr::write(&mut (*inner).links, RefCell::new(Links::default()));
+        ptr::write(&mut (*inner).back_links, RefCell::new(Links::default()));
 
         inner
     }


### PR DESCRIPTION
Improve performance of cycle detection by a factor of 30 for a cycle size `N = 10`.

Improve runtime complexity of cycle detection from O(nodes^3 + links) to O(links).