### PR TITLE
Cactusref self referential adoption

### DIFF
--- a/cactusref/src/adoptable.rs
+++ b/cactusref/src/adoptable.rs
@@ -29,12 +29,48 @@ unsafe impl<T: ?Sized> Adoptable for Rc<T> {
     /// droppable `Rc` created. During cycle detection, this increased strong
     /// count is used to determine whether the cycle is reachable by any objects
     /// outside of the cycle.
+    ///
+    /// # Examples
+    ///
+    /// The following implements a self-referential array.
+    ///
+    /// ```rust
+    /// use cactusref::{Adoptable, Rc};
+    /// use std::cell::RefCell;
+    ///
+    /// #[derive(Default)]
+    /// struct Array {
+    ///     buffer: Vec<Rc<RefCell<Self>>>,
+    /// }
+    ///
+    /// let array = Rc::new(RefCell::new(Array::default()));
+    /// for _ in 0..10 {
+    ///     let item = Rc::clone(&array);
+    ///     Rc::adopt(&array, &item);
+    ///     array.borrow_mut().buffer.push(item);
+    /// }
+    /// let weak = Rc::downgrade(&array);
+    /// assert!(weak.upgrade().is_some());
+    /// assert_eq!(weak.upgrade().unwrap().borrow().buffer.len(), 10);
+    /// // 1 for the array binding, 10 for the `Rc`s in buffer, and 10
+    /// // for the self adoptions.
+    /// assert_eq!(Rc::strong_count(&array), 21);
+    /// drop(array);
+    /// assert!(weak.upgrade().is_none());
+    /// ```
     fn adopt(this: &Self, other: &Self) {
-        let mut links = this.inner().links.borrow_mut();
-        // Allow `this` to be self-referential and allow `this` to adopt `other`
-        // multiple times, for example if building a `Vec` wrapper.
+        // Adoption signals the intent to take an owned reference to `other`, so
+        // always increment the strong count of other. This allows `this` to be
+        // self-referential and allows `this` to own multiple references to
+        // `other`. These behaviors allow implementing self-referential
+        // collection types.
         other.inc_strong();
+        // Store a forward reference to `other` in `this`. This bookkeeping logs
+        // a strong reference and is used for discovering cycles.
+        let mut links = this.inner().links.borrow_mut();
         links.insert(Link(other.ptr));
+        // Store a backward reference to `this` in `other`. This bookkeeping is
+        // used for discovering cycles.
         let mut links = other.inner().back_links.borrow_mut();
         links.insert(Link(this.ptr));
     }

--- a/cactusref/src/adoptable.rs
+++ b/cactusref/src/adoptable.rs
@@ -54,7 +54,7 @@ unsafe impl<T: ?Sized> Adoptable for Rc<T> {
     /// assert_eq!(weak.upgrade().unwrap().borrow().buffer.len(), 10);
     /// // 1 for the array binding, 10 for the `Rc`s in buffer, and 10
     /// // for the self adoptions.
-    /// assert_eq!(Rc::strong_count(&array), 21);
+    /// assert_eq!(Rc::strong_count(&array), 11);
     /// drop(array);
     /// assert!(weak.upgrade().is_none());
     /// ```
@@ -65,6 +65,9 @@ unsafe impl<T: ?Sized> Adoptable for Rc<T> {
         // `other`. These behaviors allow implementing self-referential
         // collection types.
         other.inc_strong();
+        if Self::ptr_eq(this, other) {
+            this.inc_link();
+        }
         // Store a forward reference to `other` in `this`. This bookkeeping logs
         // a strong reference and is used for discovering cycles.
         let mut links = this.inner().links.borrow_mut();

--- a/cactusref/src/adoptable.rs
+++ b/cactusref/src/adoptable.rs
@@ -50,13 +50,11 @@ unsafe impl<T: ?Sized> Adoptable for Rc<T> {
     ///     array.borrow_mut().buffer.push(item);
     /// }
     /// let weak = Rc::downgrade(&array);
-    /// assert!(weak.upgrade().is_some());
-    /// assert_eq!(weak.upgrade().unwrap().borrow().buffer.len(), 10);
-    /// // 1 for the array binding, 10 for the `Rc`s in buffer, and 10
-    /// // for the self adoptions.
+    /// // 1 for the array binding, 10 for the `Rc`s in buffer
     /// assert_eq!(Rc::strong_count(&array), 11);
     /// drop(array);
     /// assert!(weak.upgrade().is_none());
+    /// assert_eq!(weak.weak_count(), Some(1));
     /// ```
     fn adopt(this: &Self, other: &Self) {
         // Adoption signals the intent to take an owned reference to `other`, so

--- a/cactusref/src/adoptable.rs
+++ b/cactusref/src/adoptable.rs
@@ -31,11 +31,10 @@ unsafe impl<T: ?Sized> Adoptable for Rc<T> {
     /// outside of the cycle.
     fn adopt(this: &Self, other: &Self) {
         let mut links = this.inner().links.borrow_mut();
-        // Do not adopt self, do not adopt other multiple times
-        if !Self::ptr_eq(this, other) && !links.contains(&Link(other.ptr)) {
-            other.inc_strong();
-            links.insert(Link(other.ptr));
-        }
+        // Allow `this` to be self-referential and allow `this` to adopt `other`
+        // multiple times, for example if building a `Vec` wrapper.
+        other.inc_strong();
+        links.insert(Link(other.ptr));
         let mut links = other.inner().back_links.borrow_mut();
         links.insert(Link(this.ptr));
     }

--- a/cactusref/src/cycle/drop.rs
+++ b/cactusref/src/cycle/drop.rs
@@ -112,9 +112,10 @@ unsafe impl<#[may_dangle] T: ?Sized> Drop for Rc<T> {
                     cycle.len()
                 );
                 for item in cycle.keys() {
-                    let mut links = item.0.as_ref().links.borrow_mut();
+                    let item = item.0.as_ref();
+                    let mut links = item.links.borrow_mut();
                     links.clear();
-                    let mut links = item.0.as_ref().back_links.borrow_mut();
+                    let mut links = item.back_links.borrow_mut();
                     links.clear();
                 }
                 for (mut obj, _) in cycle {

--- a/cactusref/src/cycle/mod.rs
+++ b/cactusref/src/cycle/mod.rs
@@ -56,8 +56,7 @@ pub(crate) fn cycle_refs<T: ?Sized>(this: Link<T>) -> HashMap<Link<T>, usize> {
     // Map of Link to number of strong references held by the cycle.
     let mut cycle_owned_refs = HashMap::default();
     // `this` may have strong references to itself.
-    let selfref = this.selfref();
-    cycle_owned_refs.insert(this, selfref);
+    cycle_owned_refs.insert(this, this.self_link());
     loop {
         let size = cycle_owned_refs.len();
         for item in cycle_owned_refs.clone().keys() {

--- a/cactusref/src/cycle/mod.rs
+++ b/cactusref/src/cycle/mod.rs
@@ -55,18 +55,9 @@ pub(crate) fn reachable_links<T: ?Sized>(this: Link<T>) -> Links<T> {
 pub(crate) fn cycle_refs<T: ?Sized>(this: Link<T>) -> HashMap<Link<T>, usize> {
     // Map of Link to number of strong references held by the cycle.
     let mut cycle_owned_refs = HashMap::default();
-    // `this` does not have a strong reference to itself.
-    let self_references = unsafe {
-        this.0
-            .as_ref()
-            .links
-            .borrow()
-            .registry
-            .get(&this)
-            .copied()
-            .unwrap_or_default()
-    };
-    cycle_owned_refs.insert(this, self_references);
+    // `this` may have strong references to itself.
+    let selfref = this.selfref();
+    cycle_owned_refs.insert(this, selfref);
     loop {
         let size = cycle_owned_refs.len();
         for item in cycle_owned_refs.clone().keys() {

--- a/cactusref/src/link.rs
+++ b/cactusref/src/link.rs
@@ -53,6 +53,19 @@ impl<T: ?Sized> Default for Links<T> {
 
 pub(crate) struct Link<T: ?Sized>(pub NonNull<RcBox<T>>);
 
+impl<T: ?Sized> Link<T> {
+    #[inline]
+    pub fn selfref(&self) -> usize {
+        let item = unsafe { self.0.as_ref() };
+        item.links
+            .borrow()
+            .registry
+            .get(&self)
+            .copied()
+            .unwrap_or_default()
+    }
+}
+
 impl<T: ?Sized> Copy for Link<T> {}
 
 impl<T: ?Sized> Clone for Link<T> {

--- a/cactusref/src/link.rs
+++ b/cactusref/src/link.rs
@@ -1,23 +1,21 @@
 use core::ptr::{self, NonNull};
-use std::collections::hash_set;
-use std::collections::HashSet;
+use std::collections::hash_map;
+use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 
 use crate::ptr::RcBox;
 
 pub(crate) struct Links<T: ?Sized> {
-    pub registry: HashSet<Link<T>>,
+    pub registry: HashMap<Link<T>, usize>,
 }
 
 impl<T: ?Sized> Links<T> {
     pub fn contains(&self, other: &Link<T>) -> bool {
-        self.registry.iter().any(|link| link.0 == other.0)
+        self.registry.contains_key(other)
     }
 
     pub fn insert(&mut self, other: Link<T>) {
-        if !(&*self).contains(&other) {
-            self.registry.insert(other);
-        }
+        *self.registry.entry(other).or_insert(0) += 1;
     }
 
     pub fn clear(&mut self) {
@@ -32,7 +30,7 @@ impl<T: ?Sized> Links<T> {
         self.registry.len()
     }
 
-    pub fn iter(&self) -> hash_set::Iter<Link<T>> {
+    pub fn iter(&self) -> hash_map::Iter<Link<T>, usize> {
         self.registry.iter()
     }
 }
@@ -48,7 +46,7 @@ impl<T: ?Sized> Clone for Links<T> {
 impl<T: ?Sized> Default for Links<T> {
     fn default() -> Self {
         Self {
-            registry: HashSet::default(),
+            registry: HashMap::default(),
         }
     }
 }

--- a/cactusref/src/link.rs
+++ b/cactusref/src/link.rs
@@ -55,7 +55,7 @@ pub(crate) struct Link<T: ?Sized>(pub NonNull<RcBox<T>>);
 
 impl<T: ?Sized> Link<T> {
     #[inline]
-    pub fn selfref(&self) -> usize {
+    pub fn self_link(&self) -> usize {
         let item = unsafe { self.0.as_ref() };
         item.links
             .borrow()

--- a/cactusref/src/rc.rs
+++ b/cactusref/src/rc.rs
@@ -56,6 +56,7 @@ impl<T> Rc<T> {
             ptr: Box::into_raw_non_null(Box::new(RcBox {
                 strong: Cell::new(1),
                 weak: Cell::new(1),
+                link: Cell::new(0),
                 links: RefCell::new(Links::default()),
                 back_links: RefCell::new(Links::default()),
                 value,
@@ -242,7 +243,7 @@ impl<T: ?Sized> Rc<T> {
     /// ```
     #[inline]
     pub fn strong_count(this: &Self) -> usize {
-        this.strong()
+        this.strong() - this.link()
     }
 
     /// Returns `true` if there are no other `Rc` or [`Weak`] pointers to this
@@ -401,6 +402,7 @@ impl<T: ?Sized> Rc<T> {
 
         ptr::write(&mut (*inner).strong, Cell::new(1));
         ptr::write(&mut (*inner).weak, Cell::new(1));
+        ptr::write(&mut (*inner).link, Cell::new(0));
         ptr::write(&mut (*inner).links, RefCell::new(Links::default()));
         ptr::write(&mut (*inner).back_links, RefCell::new(Links::default()));
 

--- a/cactusref/src/weak.rs
+++ b/cactusref/src/weak.rs
@@ -206,7 +206,7 @@ impl<T: ?Sized> Weak<T> {
     /// ```
     pub fn upgrade(&self) -> Option<Rc<T>> {
         let inner = self.inner()?;
-        if inner.strong() == 0 {
+        if inner.strong() <= inner.link() {
             None
         } else {
             inner.inc_strong();

--- a/cactusref/src/weak.rs
+++ b/cactusref/src/weak.rs
@@ -222,7 +222,7 @@ impl<T: ?Sized> Weak<T> {
     /// If `self` was created using [`Weak::new`], this will return 0.
     pub fn strong_count(&self) -> usize {
         if let Some(inner) = self.inner() {
-            inner.strong()
+            inner.strong() - inner.link()
         } else {
             0
         }
@@ -235,7 +235,7 @@ impl<T: ?Sized> Weak<T> {
     /// value.
     pub fn weak_count(&self) -> Option<usize> {
         self.inner().map(|inner| {
-            if inner.strong() > 0 {
+            if inner.strong() - inner.link() > 0 {
                 inner.weak() - 1 // subtract the implicit weak ptr
             } else {
                 inner.weak()

--- a/cactusref/tests/no_leak_cactusref_adopt_self.rs
+++ b/cactusref/tests/no_leak_cactusref_adopt_self.rs
@@ -1,12 +1,19 @@
 #![deny(clippy::all, clippy::pedantic)]
 #![deny(warnings, intra_doc_link_resolution_failure)]
 
+use std::cell::RefCell;
+
 use cactusref::{Adoptable, CactusRef};
 
 mod leak;
 
 const ITERATIONS: usize = 100;
 const LEAK_TOLERANCE: i64 = 1024 * 1024 * 25;
+
+struct RString {
+    inner: String,
+    link: Option<CactusRef<RefCell<Self>>>,
+}
 
 #[test]
 fn cactusref_adopt_self_no_leak() {
@@ -17,8 +24,10 @@ fn cactusref_adopt_self_no_leak() {
     // 500MB of `String`s will be allocated by the leak detector
     leak::Detector::new("CactusRef adopt self", ITERATIONS, LEAK_TOLERANCE).check_leaks(|_| {
         // each iteration creates 5MB of `String`s
-        let first = CactusRef::new(s.clone());
+        let first = CactusRef::new(RefCell::new(RString { inner: s.clone(), link: None }));
+        first.borrow_mut().link = Some(CactusRef::clone(&first));
         CactusRef::adopt(&first, &first);
+        assert_eq!(first.borrow().inner, s);
         drop(first);
     });
 }

--- a/cactusref/tests/no_leak_cactusref_adopt_self.rs
+++ b/cactusref/tests/no_leak_cactusref_adopt_self.rs
@@ -24,7 +24,10 @@ fn cactusref_adopt_self_no_leak() {
     // 500MB of `String`s will be allocated by the leak detector
     leak::Detector::new("CactusRef adopt self", ITERATIONS, LEAK_TOLERANCE).check_leaks(|_| {
         // each iteration creates 5MB of `String`s
-        let first = CactusRef::new(RefCell::new(RString { inner: s.clone(), link: None }));
+        let first = CactusRef::new(RefCell::new(RString {
+            inner: s.clone(),
+            link: None,
+        }));
         first.borrow_mut().link = Some(CactusRef::clone(&first));
         CactusRef::adopt(&first, &first);
         assert_eq!(first.borrow().inner, s);

--- a/cactusref/tests/no_leak_self_referential_collection_strong.rs
+++ b/cactusref/tests/no_leak_self_referential_collection_strong.rs
@@ -1,0 +1,42 @@
+#![deny(clippy::all, clippy::pedantic)]
+#![deny(warnings, intra_doc_link_resolution_failure)]
+
+use std::cell::RefCell;
+
+use cactusref::{Adoptable, CactusRef};
+
+mod leak;
+
+const ITERATIONS: usize = 50;
+const LEAK_TOLERANCE: i64 = 1024 * 1024 * 25;
+
+struct RArray {
+    inner: Vec<CactusRef<RefCell<Self>>>,
+    _alloc: String,
+}
+
+#[test]
+fn cactusref_self_referential_collection_no_leak() {
+    env_logger::Builder::from_env("CACTUS_LOG").init();
+
+    let s = "a".repeat(2 * 1024 * 1024);
+
+    // 100MB of empty buffers will be allocated by the leak detector
+    leak::Detector::new(
+        "CactusRef adopted self-referential with strong",
+        ITERATIONS,
+        LEAK_TOLERANCE,
+    )
+    .check_leaks(|_| {
+        // each iteration creates 2MB of empty buffers
+        let vec = CactusRef::new(RefCell::new(RArray {
+            inner: vec![],
+            _alloc: s.clone(),
+        }));
+        for _ in 1..10 {
+            vec.borrow_mut().inner.push(CactusRef::clone(&vec));
+            CactusRef::adopt(&vec, &vec);
+        }
+        drop(vec);
+    });
+}

--- a/cactusref/tests/no_leak_self_referential_collection_weak.rs
+++ b/cactusref/tests/no_leak_self_referential_collection_weak.rs
@@ -29,7 +29,10 @@ fn cactusref_self_referential_collection_no_leak() {
     )
     .check_leaks(|_| {
         // each iteration creates 2MB of empty buffers
-        let vec = CactusRef::new(RefCell::new(RArray { inner: vec![], _alloc: s.clone() }));
+        let vec = CactusRef::new(RefCell::new(RArray {
+            inner: vec![],
+            _alloc: s.clone(),
+        }));
         for _ in 1..10 {
             vec.borrow_mut().inner.push(CactusRef::downgrade(&vec));
             CactusRef::adopt(&vec, &vec);

--- a/cactusref/tests/no_leak_self_referential_collection_weak.rs
+++ b/cactusref/tests/no_leak_self_referential_collection_weak.rs
@@ -1,0 +1,39 @@
+#![deny(clippy::all, clippy::pedantic)]
+#![deny(warnings, intra_doc_link_resolution_failure)]
+
+use std::cell::RefCell;
+
+use cactusref::{Adoptable, CactusRef, CactusWeakRef};
+
+mod leak;
+
+const ITERATIONS: usize = 50;
+const LEAK_TOLERANCE: i64 = 1024 * 1024 * 25;
+
+struct RArray {
+    inner: Vec<CactusWeakRef<RefCell<Self>>>,
+    _alloc: String,
+}
+
+#[test]
+fn cactusref_self_referential_collection_no_leak() {
+    env_logger::Builder::from_env("CACTUS_LOG").init();
+
+    let s = "a".repeat(2 * 1024 * 1024);
+
+    // 100MB of empty buffers will be allocated by the leak detector
+    leak::Detector::new(
+        "CactusRef adopted self-referential with weak",
+        ITERATIONS,
+        LEAK_TOLERANCE,
+    )
+    .check_leaks(|_| {
+        // each iteration creates 2MB of empty buffers
+        let vec = CactusRef::new(RefCell::new(RArray { inner: vec![], _alloc: s.clone() }));
+        for _ in 1..10 {
+            vec.borrow_mut().inner.push(CactusRef::downgrade(&vec));
+            CactusRef::adopt(&vec, &vec);
+        }
+        drop(vec);
+    });
+}

--- a/cactusref/tests/weak.rs
+++ b/cactusref/tests/weak.rs
@@ -1,0 +1,36 @@
+#![deny(clippy::all, clippy::pedantic)]
+#![deny(warnings, intra_doc_link_resolution_failure)]
+
+use cactusref::{Adoptable, Rc};
+use std::cell::RefCell;
+
+#[derive(Default)]
+struct Array {
+    buffer: Vec<Rc<RefCell<Self>>>,
+}
+
+#[test]
+fn cactusref_weak() {
+    let array = Rc::new(RefCell::new(Array::default()));
+    for _ in 0..10 {
+        let item = Rc::clone(&array);
+        Rc::adopt(&array, &item);
+        array.borrow_mut().buffer.push(item);
+    }
+    assert_eq!(Rc::strong_count(&array), 11);
+
+    let weak = Rc::downgrade(&array);
+    assert!(weak.upgrade().is_some());
+    assert_eq!(weak.strong_count(), 11);
+    assert_eq!(weak.weak_count(), Some(1));
+    assert_eq!(weak.upgrade().unwrap().borrow().buffer.len(), 10);
+
+    // 1 for the array binding, 10 for the `Rc`s in buffer, and 10
+    // for the self adoptions.
+    assert_eq!(Rc::strong_count(&array), 11);
+
+    drop(array);
+
+    assert!(weak.upgrade().is_none());
+    assert_eq!(weak.weak_count(), Some(1));
+}

--- a/cactusref/tests/weak_upgrade_returns_none_when_cycle_is_deallocated.rs
+++ b/cactusref/tests/weak_upgrade_returns_none_when_cycle_is_deallocated.rs
@@ -40,6 +40,7 @@ fn weak_upgrade_returns_none_when_cycle_is_deallocated() {
         assert_eq!(CactusRef::strong_count(&vec), 11);
         let weak = CactusRef::downgrade(&vec);
         assert!(weak.upgrade().is_some());
+        assert_eq!(weak.weak_count(), Some(1));
         drop(vec);
         assert!(weak.upgrade().is_none());
     });

--- a/cactusref/tests/weak_upgrade_returns_none_when_cycle_is_deallocated.rs
+++ b/cactusref/tests/weak_upgrade_returns_none_when_cycle_is_deallocated.rs
@@ -1,0 +1,46 @@
+#![deny(clippy::all, clippy::pedantic)]
+#![deny(warnings, intra_doc_link_resolution_failure)]
+
+use std::cell::RefCell;
+
+use cactusref::{Adoptable, CactusRef};
+
+mod leak;
+
+const ITERATIONS: usize = 50;
+const LEAK_TOLERANCE: i64 = 1024 * 1024 * 25;
+
+struct RArray {
+    inner: Vec<CactusRef<RefCell<Self>>>,
+    _alloc: String,
+}
+
+#[test]
+fn weak_upgrade_returns_none_when_cycle_is_deallocated() {
+    env_logger::Builder::from_env("CACTUS_LOG").init();
+
+    let s = "a".repeat(2 * 1024 * 1024);
+
+    // 100MB of empty buffers will be allocated by the leak detector
+    leak::Detector::new(
+        "CactusRef Weak::upgrade on cycle drop",
+        ITERATIONS,
+        LEAK_TOLERANCE,
+    )
+    .check_leaks(|_| {
+        // each iteration creates 2MB of empty buffers
+        let vec = CactusRef::new(RefCell::new(RArray {
+            inner: vec![],
+            _alloc: s.clone(),
+        }));
+        for _ in 0..10 {
+            vec.borrow_mut().inner.push(CactusRef::clone(&vec));
+            CactusRef::adopt(&vec, &vec);
+        }
+        assert_eq!(CactusRef::strong_count(&vec), 11);
+        let weak = CactusRef::downgrade(&vec);
+        assert!(weak.upgrade().is_some());
+        drop(vec);
+        assert!(weak.upgrade().is_none());
+    });
+}


### PR DESCRIPTION
Allow a `CactusRef` to adopt others multiple times.

Allow a `CactusRef` to adopt itself, perhaps multiple times.

Add tests.

This enables building a structure like a Ruby array that can contain self. Paves the way for an unadoption API.