### PR TITLE
Remove unused self link tracking

### DIFF
--- a/cactusref/src/adoptable.rs
+++ b/cactusref/src/adoptable.rs
@@ -66,9 +66,7 @@ unsafe impl<T: ?Sized> Adoptable for Rc<T> {
         // self-referential and allows `this` to own multiple references to
         // `other`. These behaviors allow implementing self-referential
         // collection types.
-        if Self::ptr_eq(this, other) {
-            this.inc_link();
-        }
+
         // Store a forward reference to `other` in `this`. This bookkeeping logs
         // a strong reference and is used for discovering cycles.
         let mut links = this.inner().links.borrow_mut();
@@ -121,9 +119,6 @@ unsafe impl<T: ?Sized> Adoptable for Rc<T> {
     /// assert_eq!(weak.weak_count(), Some(1));
     /// ```
     fn unadopt(this: &Self, other: &Self) {
-        if Self::ptr_eq(this, other) {
-            this.dec_link();
-        }
         // Remove a forward reference to `other` in `this`. This bookkeeping
         // logs a strong reference and is used for discovering cycles.
         let mut links = this.inner().links.borrow_mut();

--- a/cactusref/src/ptr.rs
+++ b/cactusref/src/ptr.rs
@@ -59,27 +59,6 @@ pub trait RcBoxPtr<T: ?Sized> {
     }
 
     #[inline]
-    fn link(&self) -> usize {
-        self.inner().link.get()
-    }
-
-    #[inline]
-    fn inc_link(&self) {
-        // We want to abort on overflow instead of dropping the value.
-        if self.link() == usize::max_value() {
-            unsafe {
-                abort();
-            }
-        }
-        self.inner().link.set(self.link() + 1);
-    }
-
-    #[inline]
-    fn dec_link(&self) {
-        self.inner().link.set(self.link() - 1);
-    }
-
-    #[inline]
     fn kill(&self) {
         self.inner().tombstone.set(usize::max_value());
     }
@@ -106,7 +85,6 @@ pub struct RcBox<T: ?Sized> {
     pub strong: Cell<usize>,
     pub weak: Cell<usize>,
     pub tombstone: Cell<usize>,
-    pub link: Cell<usize>,
     pub links: RefCell<Links<T>>,
     pub back_links: RefCell<Links<T>>,
     pub value: T,

--- a/cactusref/src/rc.rs
+++ b/cactusref/src/rc.rs
@@ -57,7 +57,6 @@ impl<T> Rc<T> {
                 strong: Cell::new(1),
                 weak: Cell::new(1),
                 tombstone: Cell::new(0),
-                link: Cell::new(0),
                 links: RefCell::new(Links::default()),
                 back_links: RefCell::new(Links::default()),
                 value,
@@ -404,7 +403,6 @@ impl<T: ?Sized> Rc<T> {
         ptr::write(&mut (*inner).strong, Cell::new(1));
         ptr::write(&mut (*inner).weak, Cell::new(1));
         ptr::write(&mut (*inner).tombstone, Cell::new(0));
-        ptr::write(&mut (*inner).link, Cell::new(0));
         ptr::write(&mut (*inner).links, RefCell::new(Links::default()));
         ptr::write(&mut (*inner).back_links, RefCell::new(Links::default()));
 


### PR DESCRIPTION
This is a holdover from when Adoptable::adopt was increasing the
strong count.

Code cleanup.