### PR TITLE
RcBox does not store a HashMap<T>

### DIFF
--- a/cactusref/README.md
+++ b/cactusref/README.md
@@ -56,7 +56,7 @@ Cycle detection is a zero-cost abstraction. If you never
 strong references). The only costs you pay are the memory costs of one
 [`Cell<usize>`](https://doc.rust-lang.org/nightly/core/cell/struct.Cell.html)
 for preventing double frees, two empty
-[`RefCell`](https://doc.rust-lang.org/nightly/core/cell/struct.RefCell.html)`<`[`HashMap`](https://doc.rust-lang.org/nightly/std/collections/struct.HashMap.html)`<T>>`
+[`RefCell`](https://doc.rust-lang.org/nightly/core/cell/struct.RefCell.html)`<`[`HashMap`](https://doc.rust-lang.org/nightly/std/collections/struct.HashMap.html)`<NonNull<T>, usize>>`
 for tracking adoptions, and an if statement to check if these structures are
 empty on `drop`.
 

--- a/cactusref/src/lib.rs
+++ b/cactusref/src/lib.rs
@@ -59,7 +59,7 @@
 //! `std::rc::Rc` (and leaks in the same way as `std::rc::Rc` if you form a
 //! cycle of strong references). The only costs you pay are the memory costs of
 //! one [`Cell<usize>`](std::cell::Cell) for preventing double frees, two empty
-//! [`RefCell`](std::cell::RefCell)`<`[`HashMap`](std::collections::HashMap)`<T>>`
+//! [`RefCell`](std::cell::RefCell)`<`[`HashMap`](std::collections::HashMap)`<NonNull<T>, usize>>`
 //! for tracking adoptions, and an if statement to check if these structures are
 //! empty on `drop`.
 //!


### PR DESCRIPTION
RcBox stores a HashMap<Links<T>, usize>. Links<T> wraps a NonNull<T>.