### PR TITLE
Remove unnecessary tombstone field from RcBox

### DIFF
--- a/cactusref/README.md
+++ b/cactusref/README.md
@@ -53,11 +53,9 @@ to all nodes in the cycle come from other nodes in the cycle.
 Cycle detection is a zero-cost abstraction. If you never
 `use cactusref::Adoptable;`, `Drop` uses the same implementation as
 `std::rc::Rc` (and leaks in the same way as `std::rc::Rc` if you form a cycle of
-strong references). The only costs you pay are the memory costs of one
-[`Cell<usize>`](https://doc.rust-lang.org/nightly/core/cell/struct.Cell.html)
-for preventing double frees, two empty
+strong references). The only costs you pay are the memory costs two empty
 [`RefCell`](https://doc.rust-lang.org/nightly/core/cell/struct.RefCell.html)`<`[`HashMap`](https://doc.rust-lang.org/nightly/std/collections/struct.HashMap.html)`<NonNull<T>, usize>>`
-for tracking adoptions, and an if statement to check if these structures are
+for tracking adoptions and an if statement to check if these structures are
 empty on `drop`.
 
 Cycle detection uses breadth-first search for traversing the object graph. The

--- a/cactusref/README.md
+++ b/cactusref/README.md
@@ -53,7 +53,7 @@ to all nodes in the cycle come from other nodes in the cycle.
 Cycle detection is a zero-cost abstraction. If you never
 `use cactusref::Adoptable;`, `Drop` uses the same implementation as
 `std::rc::Rc` (and leaks in the same way as `std::rc::Rc` if you form a cycle of
-strong references). The only costs you pay are the memory costs two empty
+strong references). The only costs you pay are the memory costs of two empty
 [`RefCell`](https://doc.rust-lang.org/nightly/core/cell/struct.RefCell.html)`<`[`HashMap`](https://doc.rust-lang.org/nightly/std/collections/struct.HashMap.html)`<NonNull<T>, usize>>`
 for tracking adoptions and an if statement to check if these structures are
 empty on `drop`.

--- a/cactusref/src/lib.rs
+++ b/cactusref/src/lib.rs
@@ -58,9 +58,9 @@
 //! `use cactusref::Adoptable;`, `Drop` uses the same implementation as
 //! `std::rc::Rc` (and leaks in the same way as `std::rc::Rc` if you form a
 //! cycle of strong references). The only costs you pay are the memory costs of
-//! one [`Cell<usize>`](std::cell::Cell) for preventing double frees, two empty
+//! two empty
 //! [`RefCell`](std::cell::RefCell)`<`[`HashMap`](std::collections::HashMap)`<NonNull<T>, usize>>`
-//! for tracking adoptions, and an if statement to check if these structures are
+//! for tracking adoptions and an if statement to check if these structures are
 //! empty on `drop`.
 //!
 //! Cycle detection uses breadth-first search for traversing the object graph.

--- a/cactusref/src/ptr.rs
+++ b/cactusref/src/ptr.rs
@@ -60,12 +60,12 @@ pub trait RcBoxPtr<T: ?Sized> {
 
     #[inline]
     fn kill(&self) {
-        self.inner().tombstone.set(usize::max_value());
+        self.inner().strong.set(0);
     }
 
     #[inline]
     fn is_dead(&self) -> bool {
-        self.inner().tombstone.get() > 0
+        self.strong() == 0
     }
 }
 
@@ -84,7 +84,6 @@ impl<T: ?Sized> RcBoxPtr<T> for RcBox<T> {
 pub struct RcBox<T: ?Sized> {
     pub strong: Cell<usize>,
     pub weak: Cell<usize>,
-    pub tombstone: Cell<usize>,
     pub links: RefCell<Links<T>>,
     pub back_links: RefCell<Links<T>>,
     pub value: T,

--- a/cactusref/src/rc.rs
+++ b/cactusref/src/rc.rs
@@ -56,7 +56,6 @@ impl<T> Rc<T> {
             ptr: Box::into_raw_non_null(Box::new(RcBox {
                 strong: Cell::new(1),
                 weak: Cell::new(1),
-                tombstone: Cell::new(0),
                 links: RefCell::new(Links::default()),
                 back_links: RefCell::new(Links::default()),
                 value,
@@ -402,7 +401,6 @@ impl<T: ?Sized> Rc<T> {
 
         ptr::write(&mut (*inner).strong, Cell::new(1));
         ptr::write(&mut (*inner).weak, Cell::new(1));
-        ptr::write(&mut (*inner).tombstone, Cell::new(0));
         ptr::write(&mut (*inner).links, RefCell::new(Links::default()));
         ptr::write(&mut (*inner).back_links, RefCell::new(Links::default()));
 


### PR DESCRIPTION
RcBox includes a Cell<usize> to mark that an Rc is currently being
deallocated to prevent double frees. This structure is unnecessary.
By reordering a bit in Drop, we can implement the tombstone by setting
RcBox.strong to zero on kill. This saves a few bytes per RcBox.