### PR TITLE
Cactusref optimize cycle detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,6 +141,7 @@ dependencies = [
 name = "cactusref"
 version = "0.1.0"
 dependencies = [
+ "criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,7 @@ version = "0.1.0"
 dependencies = [
  "criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashbrown 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -509,6 +510,11 @@ dependencies = [
  "string 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "http"
@@ -1999,6 +2005,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum h2 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)" = "1e42e3daed5a7e17b12a0c23b5b2fbff23a925a570938ebee4baca1a9a1a2240"
+"checksum hashbrown 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1de41fb8dba9714efd92241565cdff73f78508c95697dd56787d3cba27e2353"
 "checksum http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "eed324f0f0daf6ec10c474f150505af2c143f251722bf9dbd1261bd1f2ee2c1a"
 "checksum http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
 "checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"

--- a/cactusref/Cargo.toml
+++ b/cactusref/Cargo.toml
@@ -11,6 +11,7 @@ name = "drop"
 harness = false
 
 [dependencies]
+hashbrown = "0.5"
 log = "0.4.6"
 
 [dev-dependencies]

--- a/cactusref/Cargo.toml
+++ b/cactusref/Cargo.toml
@@ -6,9 +6,14 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[[bench]]
+name = "drop"
+harness = false
+
 [dependencies]
 log = "0.4.6"
 
 [dev-dependencies]
+criterion = "0.2.11"
 env_logger = "0.6.1"
 libc = "0.2"

--- a/cactusref/README.md
+++ b/cactusref/README.md
@@ -54,7 +54,7 @@ Cycle detection is a zero-cost abstraction. If you never
 `use cactusref::Adoptable;`, `Drop` uses the same implementation as
 `std::rc::Rc` (and leaks in the same way as `std::rc::Rc` if you form a cycle of
 strong references). The only costs you pay are the memory costs of two empty
-[`RefCell`](https://doc.rust-lang.org/nightly/core/cell/struct.RefCell.html)`<`[`HashMap`](https://doc.rust-lang.org/nightly/std/collections/struct.HashMap.html)`<NonNull<T>, usize>>`
+[`RefCell`](https://doc.rust-lang.org/nightly/core/cell/struct.RefCell.html)`<`[`HashMap`](https://docs.rs/hashbrown/0.5.0/hashbrown/struct.HashMap.html)`<NonNull<T>, usize>>`
 for tracking adoptions and an if statement to check if these structures are
 empty on `drop`.
 

--- a/cactusref/benches/drop.rs
+++ b/cactusref/benches/drop.rs
@@ -1,0 +1,75 @@
+#[macro_use]
+extern crate criterion;
+
+use cactusref::{Adoptable, Rc};
+use criterion::black_box;
+use criterion::Criterion;
+use std::cell::RefCell;
+
+struct Node<T> {
+    _data: T,
+    links: Vec<Rc<RefCell<Self>>>,
+}
+
+fn circular_graph(count: usize) -> Vec<Rc<RefCell<Node<usize>>>> {
+    let mut nodes = vec![];
+    for i in 0..count {
+        nodes.push(Rc::new(RefCell::new(Node {
+            _data: i,
+            links: vec![],
+        })));
+    }
+    for i in 0..count - 1 {
+        let link = Rc::clone(&nodes[i + 1]);
+        Rc::adopt(&nodes[i], &link);
+        nodes[i].borrow_mut().links.push(link);
+    }
+    let link = Rc::clone(&nodes[0]);
+    Rc::adopt(&nodes[count - 1], &link);
+    nodes[count - 1].borrow_mut().links.push(link);
+    nodes
+}
+
+fn fully_connected_graph(count: usize) -> Vec<Rc<RefCell<Node<usize>>>> {
+    let mut nodes = vec![];
+    for i in 0..count {
+        nodes.push(Rc::new(RefCell::new(Node {
+            _data: i,
+            links: vec![],
+        })));
+    }
+    for left in &nodes {
+        for right in &nodes {
+            let link = Rc::clone(right);
+            Rc::adopt(left, &link);
+            left.borrow_mut().links.push(link);
+        }
+    }
+    nodes
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function_over_inputs(
+        "drop a circular graph",
+        |b, &&size| {
+            b.iter(|| {
+                let graph = circular_graph(black_box(size));
+                drop(graph);
+            })
+        },
+        &[10, 50, 100],
+    );
+    c.bench_function_over_inputs(
+        "drop a fully connected graph",
+        |b, &&size| {
+            b.iter(|| {
+                let graph = fully_connected_graph(black_box(size));
+                drop(graph);
+            })
+        },
+        &[10, 50, 100],
+    );
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/cactusref/src/cycle/drop.rs
+++ b/cactusref/src/cycle/drop.rs
@@ -1,6 +1,6 @@
 use core::ptr;
+use hashbrown::HashMap;
 use std::alloc::{Alloc, Global, Layout};
-use std::collections::HashMap;
 
 use crate::cycle::DetectCycles;
 use crate::link::Link;

--- a/cactusref/src/cycle/drop.rs
+++ b/cactusref/src/cycle/drop.rs
@@ -91,8 +91,9 @@ unsafe impl<#[may_dangle] T: ?Sized> Drop for Rc<T> {
     /// ## Performance
     ///
     /// Cycle detection uses breadth first search to trace the object graph.
-    /// The runtime complexity of detecting a cycle is `O(links)` where links is
-    /// the number of adoptions that are alive.
+    /// The runtime complexity of detecting a cycle is `O(links + nodes)` where
+    /// links is the number of adoptions that are alive and nodes is the number
+    /// of objects in the cycle.
     ///
     /// Determining whether the cycle is orphaned builds on cycle detection and
     /// iterates over all nodes in the graph to see if their strong count is

--- a/cactusref/src/cycle/mod.rs
+++ b/cactusref/src/cycle/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use hashbrown::{HashMap, HashSet};
 
 use crate::link::{Link, Links};
 use crate::ptr::RcBoxPtr;

--- a/cactusref/src/cycle/mod.rs
+++ b/cactusref/src/cycle/mod.rs
@@ -57,34 +57,30 @@ fn reachable_links<T: ?Sized>(this: Link<T>) -> Links<T> {
 // Perform a breadth first search over all of the forward and backward links to
 // determine the clique of nodes in a cycle and their strong counts.
 fn cycle_refs<T: ?Sized>(this: Link<T>) -> HashMap<Link<T>, usize> {
-    // Map of Link to number of strong references held by the cycle.
+    // These collections track compute the layout of the object graph in linear
+    // time in the size of the graph.
     let mut cycle_owned_refs = HashMap::default();
-    // `this` may have strong references to itself.
-    cycle_owned_refs.insert(this, this.self_link());
-    let mut seen = HashSet::new();
-    seen.insert((this, this));
-    loop {
-        let size = seen.len();
-        for item in cycle_owned_refs.clone().keys() {
-            let links = unsafe { item.0.as_ref() }.links.borrow();
-            for (link, strong) in links.iter() {
-                // Forward references contribute to strong ownership counts.
-                if !seen.contains(&(*item, *link)) {
-                    *cycle_owned_refs.entry(*link).or_insert(0) += strong;
-                    seen.insert((*item, *link));
-                }
-            }
-            let links = unsafe { item.0.as_ref() }.back_links.borrow();
-            for (link, _) in links.iter() {
-                // Back references do not contribute to strong ownership counts,
-                // but they are added to the set of cycle owned refs so BFS can
-                // include them in the reachability analysis.
-                cycle_owned_refs.entry(*link).or_insert(0);
-            }
+    let mut discovered = vec![this];
+    let mut visited = HashSet::new();
+
+    // crawl the graph
+    while let Some(node) = discovered.pop() {
+        if visited.contains(&node) {
+            continue;
         }
-        // BFS has found no new refs in the clique.
-        if size == seen.len() {
-            break;
+        visited.insert(node);
+        let links = unsafe { node.0.as_ref() }.links.borrow();
+        for (link, strong) in links.iter() {
+            // Forward references contribute to strong ownership counts.
+            *cycle_owned_refs.entry(*link).or_insert(0) += strong;
+            discovered.push(*link);
+        }
+        let links = unsafe { node.0.as_ref() }.back_links.borrow();
+        for (link, _) in links.iter() {
+            // Back references do not contribute to strong ownership counts,
+            // but they are added to the set of cycle owned refs so BFS can
+            // include them in the reachability analysis.
+            cycle_owned_refs.entry(*link).or_insert(0);
         }
     }
     trace!(

--- a/cactusref/src/lib.rs
+++ b/cactusref/src/lib.rs
@@ -59,7 +59,7 @@
 //! `std::rc::Rc` (and leaks in the same way as `std::rc::Rc` if you form a
 //! cycle of strong references). The only costs you pay are the memory costs of
 //! two empty
-//! [`RefCell`](std::cell::RefCell)`<`[`HashMap`](std::collections::HashMap)`<NonNull<T>, usize>>`
+//! [`RefCell`](std::cell::RefCell)`<`[`HashMap`](hashbrown::HashMap)`<NonNull<T>, usize>>`
 //! for tracking adoptions and an if statement to check if these structures are
 //! empty on `drop`.
 //!

--- a/cactusref/src/link.rs
+++ b/cactusref/src/link.rs
@@ -1,6 +1,5 @@
 use core::ptr::{self, NonNull};
-use std::collections::hash_map;
-use std::collections::HashMap;
+use hashbrown::{hash_map, HashMap};
 use std::hash::{Hash, Hasher};
 
 use crate::ptr::RcBox;

--- a/cactusref/src/link.rs
+++ b/cactusref/src/link.rs
@@ -59,19 +59,6 @@ impl<T: ?Sized> Default for Links<T> {
 
 pub struct Link<T: ?Sized>(pub NonNull<RcBox<T>>);
 
-impl<T: ?Sized> Link<T> {
-    #[inline]
-    pub fn self_link(&self) -> usize {
-        let item = unsafe { self.0.as_ref() };
-        item.links
-            .borrow()
-            .registry
-            .get(&self)
-            .copied()
-            .unwrap_or_default()
-    }
-}
-
 impl<T: ?Sized> Copy for Link<T> {}
 
 impl<T: ?Sized> Clone for Link<T> {

--- a/cactusref/src/ptr.rs
+++ b/cactusref/src/ptr.rs
@@ -136,3 +136,13 @@ pub fn data_offset_sized<T>() -> isize {
     let layout = Layout::new::<RcBox<()>>();
     (layout.size() + layout.padding_needed_for(align)) as isize
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sizeof_rcbox() {
+        assert_eq!(mem::size_of::<RcBox<()>>(), 144);
+    }
+}

--- a/cactusref/src/ptr.rs
+++ b/cactusref/src/ptr.rs
@@ -143,6 +143,6 @@ mod tests {
 
     #[test]
     fn sizeof_rcbox() {
-        assert_eq!(mem::size_of::<RcBox<()>>(), 144);
+        assert_eq!(mem::size_of::<RcBox<()>>(), 112);
     }
 }


### PR DESCRIPTION
Use a faster hasher by using the hashbrown crate. We're only hashing pointers. We do not care about being cryptographically secure. Switching to the hashbrown simpler `Hasher` saves 32 bytes on the size of the `RcBox`.

Properly implement BFS in when detecting cycles to be linear time with the number of nodes. The runtime complexity is O(nodes + links). We need to crawl all the links because we need to compute the cycle-internal strong counts.

This script adds a benchmark. Compared to master, performance is improved about 90% for singly linked and complete graphs of 50 nodes.

```console
$ cargo bench -p cactusref
drop a circular graph/10
                        time:   [19.512 us 19.560 us 19.616 us]
                        change: [-69.879% -69.682% -69.470%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  6 (6.00%) high mild
  8 (8.00%) high severe
drop a circular graph/50
                        time:   [223.07 us 223.65 us 224.29 us]
                        change: [-91.266% -91.197% -91.133%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  3 (3.00%) high severe

drop a fully connected graph/10
                        time:   [61.076 us 61.369 us 61.694 us]
                        change: [-72.808% -72.624% -72.430%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  6 (6.00%) high mild
  3 (3.00%) high severe
drop a fully connected graph/50
                        time:   [2.7680 ms 2.7989 ms 2.8381 ms]
                        change: [-87.763% -87.604% -87.423%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe
```