### PR TITLE
Only compute strong and cycle counts for logging in debug builds

### DIFF
--- a/cactusref/src/cycle/mod.rs
+++ b/cactusref/src/cycle/mod.rs
@@ -83,15 +83,23 @@ fn cycle_refs<T: ?Sized>(this: Link<T>) -> HashMap<Link<T>, usize> {
             cycle_owned_refs.entry(*link).or_insert(0);
         }
     }
+    #[cfg(debug_assertions)]
+    debug_cycle(&cycle_owned_refs);
+    cycle_owned_refs
+}
+
+#[inline]
+#[cfg(debug_assertions)]
+fn debug_cycle<T: ?Sized>(cycle: &HashMap<Link<T>, usize>) {
+    let counts = cycle
+        .iter()
+        .map(|(item, cycle_count)| {
+            let strong = unsafe { item.0.as_ref() }.strong();
+            (strong, cycle_count)
+        })
+        .collect::<Vec<_>>();
     trace!(
         "cactusref reachability test found (strong, cycle) counts: {:?}",
-        cycle_owned_refs
-            .iter()
-            .map(|(item, cycle_count)| {
-                let strong = unsafe { item.0.as_ref() }.strong();
-                (strong, cycle_count)
-            })
-            .collect::<Vec<_>>()
+        counts
     );
-    cycle_owned_refs
 }


### PR DESCRIPTION
This improves performance modestly for larger graphs

```console
$ cargo bench -p cactusref
drop a circular graph/10
                        time:   [17.129 us 17.253 us 17.391 us]
                        change: [-2.3398% -1.3859% -0.3611%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
drop a circular graph/20
                        time:   [49.596 us 49.769 us 49.951 us]
                        change: [-2.7092% -0.5416% +2.0192%] (p = 0.68 > 0.05)
                        No change in performance detected.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
drop a circular graph/30
                        time:   [104.86 us 105.15 us 105.45 us]
                        change: [-3.3911% -2.2695% -1.1257%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  5 (5.00%) high mild
  6 (6.00%) high severe
drop a circular graph/40
                        time:   [154.11 us 154.50 us 154.90 us]
                        change: [-4.3932% -3.4576% -2.4844%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  4 (4.00%) high mild
  7 (7.00%) high severe
drop a circular graph/50
                        time:   [213.29 us 214.29 us 215.32 us]
                        change: [-2.8471% -1.2010% +0.2541%] (p = 0.14 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe
drop a circular graph/100
                        time:   [705.98 us 708.56 us 711.13 us]
                        change: [-2.8588% -1.7151% -0.4284%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  6 (6.00%) high severe

drop a fully connected graph/10
                        time:   [46.314 us 46.612 us 46.891 us]
                        change: [-1.4172% +0.7133% +2.7943%] (p = 0.54 > 0.05)
                        No change in performance detected.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
drop a fully connected graph/20
                        time:   [230.56 us 231.83 us 233.24 us]
                        change: [-1.8806% +0.0715% +1.7323%] (p = 0.94 > 0.05)
                        No change in performance detected.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
drop a fully connected graph/30
                        time:   [693.73 us 697.22 us 700.75 us]
                        change: [+0.3046% +1.4265% +2.4789%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
drop a fully connected graph/40
                        time:   [1.4545 ms 1.4632 ms 1.4728 ms]
                        change: [-0.5784% +0.4962% +1.5844%] (p = 0.37 > 0.05)
                        No change in performance detected.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
drop a fully connected graph/50
                        time:   [2.7442 ms 2.7611 ms 2.7804 ms]
                        change: [+0.1649% +1.3231% +2.4391%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
drop a fully connected graph/100
                        time:   [22.220 ms 22.371 ms 22.532 ms]
                        change: [-3.3068% -2.1622% -1.1538%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  1 (1.00%) low severe
  10 (10.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe