### PR TITLE
Cactusref optimize

### DIFF
--- a/cactusref/README.md
+++ b/cactusref/README.md
@@ -53,7 +53,7 @@ to all nodes in the cycle come from other nodes in the cycle.
 Cycle detection is a zero-cost abstraction. If you never
 `use cactusref::Adoptable;`, `Drop` uses the same implementation as
 `std::rc::Rc` (and leaks in the same way as `std::rc::Rc` if you form a cycle of
-strong references). The only costs you pay are the memory costs of two empty
+strong references). The only costs you pay are the memory costs of one empty
 [`RefCell`](https://doc.rust-lang.org/nightly/core/cell/struct.RefCell.html)`<`[`HashMap`](https://docs.rs/hashbrown/0.5.0/hashbrown/struct.HashMap.html)`<NonNull<T>, usize>>`
 for tracking adoptions and an if statement to check if these structures are
 empty on `drop`.

--- a/cactusref/src/adoptable.rs
+++ b/cactusref/src/adoptable.rs
@@ -126,7 +126,7 @@ unsafe impl<T: ?Sized> Adoptable for Rc<T> {
         // Remove a forward reference to `other` in `this`. This bookkeeping
         // logs a strong reference and is used for discovering cycles.
         let mut links = this.inner().links.borrow_mut();
-        links.remove(Link::forward(other.ptr));
+        links.remove(Link::forward(other.ptr), 1);
         // `this` and `other` may be the same `Rc`. Drop the borrow on `links`
         // before accessing `other` to avoid a already borrowed error from the
         // `RefCell`.
@@ -134,6 +134,6 @@ unsafe impl<T: ?Sized> Adoptable for Rc<T> {
         // Remove a backward reference to `this` in `other`. This bookkeeping is
         // used for discovering cycles.
         let mut links = other.inner().links.borrow_mut();
-        links.remove(Link::backward(this.ptr));
+        links.remove(Link::backward(this.ptr), 1);
     }
 }

--- a/cactusref/src/cycle/mod.rs
+++ b/cactusref/src/cycle/mod.rs
@@ -1,57 +1,30 @@
 use hashbrown::{HashMap, HashSet};
 
-use crate::link::{Link, Links};
+use crate::link::{Kind, Link};
 use crate::ptr::RcBoxPtr;
 use crate::Rc;
 
 mod drop;
 
 trait DetectCycles<T: ?Sized> {
-    fn can_reach(this: &Self, other: &Self) -> bool;
-
     fn orphaned_cycle(this: &Self) -> Option<HashMap<Link<T>, usize>>;
 }
 
 impl<T: ?Sized> DetectCycles<T> for Rc<T> {
-    fn can_reach(this: &Self, other: &Self) -> bool {
-        reachable_links(Link(this.ptr)).contains(&Link(other.ptr))
-    }
-
     fn orphaned_cycle(this: &Self) -> Option<HashMap<Link<T>, usize>> {
-        let cycle = cycle_refs(Link(this.ptr));
+        let cycle = cycle_refs(Link::forward(this.ptr));
         if cycle.is_empty() {
             return None;
         }
-        let has_external_owners = cycle.iter().any(|(item, cycle_owned_refs)| {
-            unsafe { item.0.as_ref() }.strong() > *cycle_owned_refs
-        });
+        let has_external_owners = cycle
+            .iter()
+            .any(|(item, cycle_owned_refs)| item.strong() > *cycle_owned_refs);
         if has_external_owners {
             None
         } else {
             Some(cycle)
         }
     }
-}
-
-// Perform a breadth first search over all of the links to determine the clique
-// of refs that self can reach.
-fn reachable_links<T: ?Sized>(this: Link<T>) -> Links<T> {
-    let mut clique = Links::default();
-    clique.insert(this);
-    loop {
-        let size = clique.len();
-        for (item, _) in clique.clone().iter() {
-            let links = unsafe { item.0.as_ref() }.links.borrow();
-            for (link, _) in links.iter() {
-                clique.insert(*link);
-            }
-        }
-        // BFS has found no new refs in the clique.
-        if size == clique.len() {
-            break;
-        }
-    }
-    clique
 }
 
 // Perform a breadth first search over all of the forward and backward links to
@@ -69,18 +42,13 @@ fn cycle_refs<T: ?Sized>(this: Link<T>) -> HashMap<Link<T>, usize> {
             continue;
         }
         visited.insert(node);
-        let links = unsafe { node.0.as_ref() }.links.borrow();
+        let links = node.inner().links.borrow();
         for (link, strong) in links.iter() {
-            // Forward references contribute to strong ownership counts.
-            *cycle_owned_refs.entry(*link).or_insert(0) += strong;
-            discovered.push(*link);
-        }
-        let links = unsafe { node.0.as_ref() }.back_links.borrow();
-        for (link, _) in links.iter() {
-            // Back references do not contribute to strong ownership counts,
-            // but they are added to the set of cycle owned refs so BFS can
-            // include them in the reachability analysis.
-            cycle_owned_refs.entry(*link).or_insert(0);
+            let entry = cycle_owned_refs.entry(link.as_forward()).or_insert(0);
+            if let Kind::Forward = link.link_kind() {
+                *entry += strong;
+                discovered.push(*link);
+            }
         }
     }
     #[cfg(debug_assertions)]
@@ -93,10 +61,7 @@ fn cycle_refs<T: ?Sized>(this: Link<T>) -> HashMap<Link<T>, usize> {
 fn debug_cycle<T: ?Sized>(cycle: &HashMap<Link<T>, usize>) {
     let counts = cycle
         .iter()
-        .map(|(item, cycle_count)| {
-            let strong = unsafe { item.0.as_ref() }.strong();
-            (strong, cycle_count)
-        })
+        .map(|(item, cycle_count)| (item.strong(), cycle_count))
         .collect::<Vec<_>>();
     trace!(
         "cactusref reachability test found (strong, cycle) counts: {:?}",

--- a/cactusref/src/cycle/mod.rs
+++ b/cactusref/src/cycle/mod.rs
@@ -44,10 +44,14 @@ fn cycle_refs<T: ?Sized>(this: Link<T>) -> HashMap<Link<T>, usize> {
         visited.insert(node);
         let links = node.inner().links.borrow();
         for (link, strong) in links.iter() {
-            let entry = cycle_owned_refs.entry(link.as_forward()).or_insert(0);
             if let Kind::Forward = link.link_kind() {
-                *entry += strong;
+                cycle_owned_refs
+                    .entry(*link)
+                    .and_modify(|count| *count += strong)
+                    .or_insert(*strong);
                 discovered.push(*link);
+            } else {
+                cycle_owned_refs.entry(link.as_forward()).or_default();
             }
         }
     }

--- a/cactusref/src/lib.rs
+++ b/cactusref/src/lib.rs
@@ -58,7 +58,7 @@
 //! `use cactusref::Adoptable;`, `Drop` uses the same implementation as
 //! `std::rc::Rc` (and leaks in the same way as `std::rc::Rc` if you form a
 //! cycle of strong references). The only costs you pay are the memory costs of
-//! two empty
+//! one empty
 //! [`RefCell`](std::cell::RefCell)`<`[`HashMap`](hashbrown::HashMap)`<NonNull<T>, usize>>`
 //! for tracking adoptions and an if statement to check if these structures are
 //! empty on `drop`.

--- a/cactusref/src/link.rs
+++ b/cactusref/src/link.rs
@@ -15,18 +15,14 @@ pub struct Links<T: ?Sized> {
 }
 
 impl<T: ?Sized> Links<T> {
-    pub fn contains(&self, other: &Link<T>) -> bool {
-        self.registry.contains_key(other)
-    }
-
     pub fn insert(&mut self, other: Link<T>) {
         *self.registry.entry(other).or_insert(0) += 1;
     }
 
-    pub fn remove(&mut self, other: Link<T>) {
+    pub fn remove(&mut self, other: Link<T>, strong: usize) {
         match self.registry.get(&other).copied().unwrap_or_default() {
-            count if count <= 1 => self.registry.remove(&other),
-            count => self.registry.insert(other, count - 1),
+            count if count <= strong => self.registry.remove(&other),
+            count => self.registry.insert(other, count - strong),
         };
     }
 

--- a/cactusref/src/link.rs
+++ b/cactusref/src/link.rs
@@ -2,7 +2,13 @@ use core::ptr::{self, NonNull};
 use hashbrown::{hash_map, HashMap};
 use std::hash::{Hash, Hasher};
 
-use crate::ptr::RcBox;
+use crate::ptr::{RcBox, RcBoxPtr};
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Kind {
+    Forward,
+    Backward,
+}
 
 pub struct Links<T: ?Sized> {
     pub registry: HashMap<Link<T>, usize>,
@@ -19,7 +25,7 @@ impl<T: ?Sized> Links<T> {
 
     pub fn remove(&mut self, other: Link<T>) {
         match self.registry.get(&other).copied().unwrap_or_default() {
-            0 | 1 => self.registry.remove(&other),
+            count if count <= 1 => self.registry.remove(&other),
             count => self.registry.insert(other, count - 1),
         };
     }
@@ -30,10 +36,6 @@ impl<T: ?Sized> Links<T> {
 
     pub fn is_empty(&self) -> bool {
         self.registry.is_empty()
-    }
-
-    pub fn len(&self) -> usize {
-        self.registry.len()
     }
 
     pub fn iter(&self) -> hash_map::Iter<Link<T>, usize> {
@@ -57,19 +59,59 @@ impl<T: ?Sized> Default for Links<T> {
     }
 }
 
-pub struct Link<T: ?Sized>(pub NonNull<RcBox<T>>);
+// Using a a tuple struct is about 10% faster than using named fields.
+pub struct Link<T: ?Sized>(NonNull<RcBox<T>>, Kind);
+
+impl<T: ?Sized> Link<T> {
+    #[inline]
+    pub fn forward(ptr: NonNull<RcBox<T>>) -> Self {
+        Self(ptr, Kind::Forward)
+    }
+
+    #[inline]
+    pub fn backward(ptr: NonNull<RcBox<T>>) -> Self {
+        Self(ptr, Kind::Backward)
+    }
+
+    #[inline]
+    pub fn link_kind(&self) -> Kind {
+        self.1
+    }
+
+    #[inline]
+    pub fn as_forward(&self) -> Self {
+        Self::forward(self.0)
+    }
+
+    #[inline]
+    pub fn as_ptr(&self) -> *const RcBox<T> {
+        self.0.as_ptr()
+    }
+
+    #[inline]
+    pub fn into_raw_non_null(self) -> NonNull<RcBox<T>> {
+        self.0
+    }
+}
+
+impl<T: ?Sized> RcBoxPtr<T> for Link<T> {
+    #[inline]
+    fn inner(&self) -> &RcBox<T> {
+        unsafe { self.0.as_ref() }
+    }
+}
 
 impl<T: ?Sized> Copy for Link<T> {}
 
 impl<T: ?Sized> Clone for Link<T> {
     fn clone(&self) -> Self {
-        Self(self.0)
+        Self(self.0, self.1)
     }
 }
 
 impl<T: ?Sized> PartialEq for Link<T> {
     fn eq(&self, other: &Self) -> bool {
-        ptr::eq(self.0.as_ptr(), other.0.as_ptr())
+        ptr::eq(self.0.as_ptr(), other.0.as_ptr()) && self.1 == other.1
     }
 }
 
@@ -78,5 +120,6 @@ impl<T: ?Sized> Eq for Link<T> {}
 impl<T: ?Sized> Hash for Link<T> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.0.hash(state);
+        self.1.hash(state);
     }
 }

--- a/cactusref/src/ptr.rs
+++ b/cactusref/src/ptr.rs
@@ -85,7 +85,6 @@ pub struct RcBox<T: ?Sized> {
     pub strong: Cell<usize>,
     pub weak: Cell<usize>,
     pub links: RefCell<Links<T>>,
-    pub back_links: RefCell<Links<T>>,
     pub value: T,
 }
 
@@ -143,6 +142,6 @@ mod tests {
 
     #[test]
     fn sizeof_rcbox() {
-        assert_eq!(mem::size_of::<RcBox<()>>(), 112);
+        assert_eq!(mem::size_of::<RcBox<()>>(), 64);
     }
 }

--- a/cactusref/src/rc.rs
+++ b/cactusref/src/rc.rs
@@ -57,7 +57,6 @@ impl<T> Rc<T> {
                 strong: Cell::new(1),
                 weak: Cell::new(1),
                 links: RefCell::new(Links::default()),
-                back_links: RefCell::new(Links::default()),
                 value,
             })),
             phantom: PhantomData,
@@ -402,7 +401,6 @@ impl<T: ?Sized> Rc<T> {
         ptr::write(&mut (*inner).strong, Cell::new(1));
         ptr::write(&mut (*inner).weak, Cell::new(1));
         ptr::write(&mut (*inner).links, RefCell::new(Links::default()));
-        ptr::write(&mut (*inner).back_links, RefCell::new(Links::default()));
 
         inner
     }

--- a/cactusref/tests/no_leak_cactusref_adopt_self.rs
+++ b/cactusref/tests/no_leak_cactusref_adopt_self.rs
@@ -30,6 +30,13 @@ fn cactusref_adopt_self_no_leak() {
         }));
         first.borrow_mut().link = Some(CactusRef::clone(&first));
         CactusRef::adopt(&first, &first);
+        CactusRef::adopt(&first, &first);
+        CactusRef::adopt(&first, &first);
+        CactusRef::adopt(&first, &first);
+        CactusRef::adopt(&first, &first);
+        CactusRef::adopt(&first, &first);
+        CactusRef::adopt(&first, &first);
+        CactusRef::adopt(&first, &first);
         assert_eq!(first.borrow().inner, s);
         drop(first);
     });

--- a/cactusref/tests/no_leak_doubly_linked_list.rs
+++ b/cactusref/tests/no_leak_doubly_linked_list.rs
@@ -84,18 +84,20 @@ fn cactusref_doubly_linked_list_no_leak() {
     env_logger::Builder::from_env("CACTUS_LOG").init();
 
     // 500MB of `String`s will be allocated by the leak detector
-    leak::Detector::new("CactusRef adopt self", ITERATIONS, LEAK_TOLERANCE).check_leaks(|_| {
-        let list = iter::repeat(())
-            .map(|_| "a".repeat(1024 * 1024))
-            .take(10)
-            .collect::<Vec<_>>();
-        let mut list = List::from(list);
-        let head = list.pop().unwrap();
-        assert_eq!(Rc::strong_count(&head), 1);
-        assert_eq!(list.head.as_ref().map(Rc::strong_count), Some(3));
-        let weak = Rc::downgrade(&head);
-        drop(head);
-        assert!(weak.upgrade().is_none());
-        drop(list);
-    });
+    leak::Detector::new("CactusRef doubly linked list", ITERATIONS, LEAK_TOLERANCE).check_leaks(
+        |_| {
+            let list = iter::repeat(())
+                .map(|_| "a".repeat(1024 * 1024))
+                .take(10)
+                .collect::<Vec<_>>();
+            let mut list = List::from(list);
+            let head = list.pop().unwrap();
+            assert_eq!(Rc::strong_count(&head), 1);
+            assert_eq!(list.head.as_ref().map(Rc::strong_count), Some(3));
+            let weak = Rc::downgrade(&head);
+            drop(head);
+            assert!(weak.upgrade().is_none());
+            drop(list);
+        },
+    );
 }

--- a/cactusref/tests/no_leak_fully_connected_graph.rs
+++ b/cactusref/tests/no_leak_fully_connected_graph.rs
@@ -45,6 +45,8 @@ fn cactusref_fully_connected_graph_no_leak() {
     )
     .check_leaks(|_| {
         let list = fully_connected_graph(10);
+        drop(Rc::clone(&list[0]));
+        assert_eq!(Rc::strong_count(&list[0]), 11);
         drop(list);
     });
 }

--- a/cactusref/tests/no_leak_fully_connected_graph.rs
+++ b/cactusref/tests/no_leak_fully_connected_graph.rs
@@ -1,0 +1,50 @@
+#![deny(clippy::all, clippy::pedantic)]
+#![deny(warnings, intra_doc_link_resolution_failure)]
+#![allow(clippy::shadow_unrelated)]
+
+use cactusref::{Adoptable, Rc};
+use std::cell::RefCell;
+
+mod leak;
+
+const ITERATIONS: usize = 50;
+const LEAK_TOLERANCE: i64 = 1024 * 1024 * 25;
+
+struct Node<T> {
+    _data: T,
+    links: Vec<Rc<RefCell<Self>>>,
+}
+
+fn fully_connected_graph(count: usize) -> Vec<Rc<RefCell<Node<String>>>> {
+    let mut nodes = vec![];
+    for _ in 0..count {
+        nodes.push(Rc::new(RefCell::new(Node {
+            _data: "a".repeat(1024 * 1024),
+            links: vec![],
+        })));
+    }
+    for left in &nodes {
+        for right in &nodes {
+            let link = Rc::clone(right);
+            Rc::adopt(left, &link);
+            left.borrow_mut().links.push(link);
+        }
+    }
+    nodes
+}
+
+#[test]
+fn cactusref_fully_connected_graph_no_leak() {
+    env_logger::Builder::from_env("CACTUS_LOG").init();
+
+    // 500MB of `String`s will be allocated by the leak detector
+    leak::Detector::new(
+        "CactusRef fully connected graph",
+        ITERATIONS,
+        LEAK_TOLERANCE,
+    )
+    .check_leaks(|_| {
+        let list = fully_connected_graph(10);
+        drop(list);
+    });
+}


### PR DESCRIPTION
Performance is all about trade-offs. This patch is not universally better.

Pros:
- Cycle detection algorithm is significantly simpler to understand
- Link traversal in drop cases is simpler to understand
- Adoption bookkeeping is more explicit and simpler to understand
- `RcBox` size has decreased from 112 bytes to 64 bytes

Cons:
- Cycle detection is slower.
- The performance degradation is worse for sparsely connected graphs. About 15% slower for a singly linked ring.

5% slower in the worst case complexity + simpler implementation + half memory usage for the no-adoption case is a trade-off I am willing to make.

Bench run:

```console
$ cargo bench -p cactusref
drop a circular graph/10
                        time:   [21.325 us 21.643 us 21.992 us]
                        change: [+14.904% +17.185% +19.838%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) low mild
  4 (4.00%) high mild
  1 (1.00%) high severe
drop a circular graph/20
                        time:   [59.318 us 59.983 us 60.670 us]
                        change: [+13.297% +14.917% +16.485%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe
drop a circular graph/30
                        time:   [126.09 us 127.25 us 128.41 us]
                        change: [+13.567% +15.032% +16.431%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
drop a circular graph/40
                        time:   [180.68 us 181.89 us 183.12 us]
                        change: [+12.199% +14.038% +16.072%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) high mild
  6 (6.00%) high severe
drop a circular graph/50
                        time:   [247.86 us 249.77 us 251.66 us]
                        change: [+11.269% +12.802% +14.489%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild
drop a circular graph/100
                        time:   [802.12 us 806.81 us 811.70 us]
                        change: [+10.868% +12.924% +14.989%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  8 (8.00%) high severe

drop a fully connected graph/10
                        time:   [49.171 us 49.746 us 50.443 us]
                        change: [+6.6333% +8.2439% +9.8562%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
drop a fully connected graph/20
                        time:   [238.42 us 240.57 us 242.95 us]
                        change: [+5.7385% +7.0547% +8.2935%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe
drop a fully connected graph/30
                        time:   [687.28 us 692.42 us 698.23 us]
                        change: [+1.6952% +2.8716% +4.1074%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) low mild
  4 (4.00%) high mild
  5 (5.00%) high severe
drop a fully connected graph/40
                        time:   [1.4594 ms 1.4698 ms 1.4809 ms]
                        change: [-0.0632% +1.3767% +3.1430%] (p = 0.10 > 0.05)
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
drop a fully connected graph/50
                        time:   [2.8164 ms 2.8408 ms 2.8654 ms]
                        change: [+4.0132% +4.9724% +5.9184%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
drop a fully connected graph/100
                        time:   [21.931 ms 22.026 ms 22.134 ms]
                        change: [-1.0727% +0.2455% +1.4751%] (p = 0.71 > 0.05)
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
```