### PR TITLE
Cactusref links opt

### DIFF
--- a/cactusref/src/link.rs
+++ b/cactusref/src/link.rs
@@ -11,7 +11,7 @@ pub enum Kind {
 }
 
 pub struct Links<T: ?Sized> {
-    pub registry: HashMap<Link<T>, usize>,
+    registry: HashMap<Link<T>, usize>,
 }
 
 impl<T: ?Sized> Links<T> {

--- a/cactusref/src/link.rs
+++ b/cactusref/src/link.rs
@@ -1,4 +1,4 @@
-use core::ptr::{self, NonNull};
+use core::ptr::NonNull;
 use hashbrown::{hash_map, HashMap};
 use std::hash::{Hash, Hasher};
 
@@ -107,7 +107,7 @@ impl<T: ?Sized> Clone for Link<T> {
 
 impl<T: ?Sized> PartialEq for Link<T> {
     fn eq(&self, other: &Self) -> bool {
-        ptr::eq(self.0.as_ptr(), other.0.as_ptr()) && self.1 == other.1
+        self.0.as_ptr() == other.0.as_ptr() && self.1 == other.1
     }
 }
 

--- a/cactusref/src/link.rs
+++ b/cactusref/src/link.rs
@@ -15,10 +15,12 @@ pub struct Links<T: ?Sized> {
 }
 
 impl<T: ?Sized> Links<T> {
+    #[inline]
     pub fn insert(&mut self, other: Link<T>) {
         *self.registry.entry(other).or_insert(0) += 1;
     }
 
+    #[inline]
     pub fn remove(&mut self, other: Link<T>, strong: usize) {
         match self.registry.get(&other).copied().unwrap_or_default() {
             count if count <= strong => self.registry.remove(&other),
@@ -26,14 +28,17 @@ impl<T: ?Sized> Links<T> {
         };
     }
 
+    #[inline]
     pub fn clear(&mut self) {
         self.registry.clear()
     }
 
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.registry.is_empty()
     }
 
+    #[inline]
     pub fn iter(&self) -> hash_map::Iter<Link<T>, usize> {
         self.registry.iter()
     }
@@ -91,7 +96,6 @@ impl<T: ?Sized> Link<T> {
 }
 
 impl<T: ?Sized> RcBoxPtr<T> for Link<T> {
-    #[inline]
     fn inner(&self) -> &RcBox<T> {
         unsafe { self.0.as_ref() }
     }


### PR DESCRIPTION
Avoid unneeded function call overhead to `core::ptr::eq` when we can just compare the pointers directly.